### PR TITLE
fix: Critical - Fix fetch interception breaking Next.js navigation

### DIFF
--- a/src/lib/bug-reporter/network-logger.ts
+++ b/src/lib/bug-reporter/network-logger.ts
@@ -17,7 +17,7 @@ export class NetworkLogger {
   private originalXHRSend: typeof XMLHttpRequest.prototype.send;
   
   constructor() {
-    this.originalFetch = window.fetch;
+    this.originalFetch = window.fetch.bind(window);
     this.originalXHROpen = XMLHttpRequest.prototype.open;
     this.originalXHRSend = XMLHttpRequest.prototype.send;
     this.interceptFetch();
@@ -84,7 +84,7 @@ export class NetworkLogger {
         return originalSetRequestHeader.apply(this, [name, value]);
       };
       
-      return self.originalXHROpen.apply(this, [method, url, async ?? true, username, password]);
+      return self.originalXHROpen.call(this, method, url, async ?? true, username, password);
     };
     
     XMLHttpRequest.prototype.send = function(body?: Document | XMLHttpRequestBodyInit | null) {
@@ -102,7 +102,7 @@ export class NetworkLogger {
         });
       });
       
-      return self.originalXHRSend.apply(this, [body]);
+      return self.originalXHRSend.call(this, body);
     };
   }
   


### PR DESCRIPTION
## Critical Bug Fix

This fixes a critical issue introduced in PR #34 where the bug reporter's network logger was breaking all Next.js navigation.

## The Problem

The network logger was intercepting `window.fetch` without preserving the proper context binding. This caused:
- "Illegal invocation" errors on every fetch request
- All Next.js RSC (React Server Components) navigation to fail
- Navigation links to fall back to full page reloads

## The Solution

1. **Bind fetch to window context**: `window.fetch.bind(window)`
2. **Fix XMLHttpRequest calls**: Use `.call()` instead of `.apply()` with spread arguments

## Testing

- [x] Build passes successfully
- [x] Navigation works without errors
- [x] Bug reporter still captures network requests correctly
- [x] No console errors when navigating between pages

This is a critical fix that should be merged immediately to restore application functionality.