### PR TITLE
fix: surface errors to staff when timeclock clock-in/out fails

### DIFF
--- a/src/app/(timeclock)/timeclock/TimeclockKiosk.tsx
+++ b/src/app/(timeclock)/timeclock/TimeclockKiosk.tsx
@@ -50,12 +50,16 @@ export default function TimeclockKiosk({ employees, openSessions: initialSession
     if (!UUID_RE.test(selectedId)) { toast.error('Invalid employee selection'); return; }
     if (isAlreadyClockedIn) { toast.error('You are already clocked in'); return; }
     startTransition(async () => {
-      const result = await clockIn(selectedId);
-      if (!result.success) { toast.error(result.error); return; }
-      toast.success(`Welcome in, ${empName(selectedEmp!)} 👋`);
-      setSessions(prev => [...prev, { ...result.data, employee_name: empName(selectedEmp!) }]);
-      setSelectedId('');
-      router.refresh();
+      try {
+        const result = await clockIn(selectedId);
+        if (!result.success) { toast.error(result.error); return; }
+        toast.success(`Welcome in, ${empName(selectedEmp!)} 👋`);
+        setSessions(prev => [...prev, { ...result.data, employee_name: empName(selectedEmp!) }]);
+        setSelectedId('');
+        router.refresh();
+      } catch {
+        toast.error('Something went wrong. Please try again.');
+      }
     });
   };
 
@@ -64,12 +68,16 @@ export default function TimeclockKiosk({ employees, openSessions: initialSession
     if (!UUID_RE.test(selectedId)) { toast.error('Invalid employee selection'); return; }
     if (!isAlreadyClockedIn) { toast.error('You are not currently clocked in'); return; }
     startTransition(async () => {
-      const result = await clockOut(selectedId);
-      if (!result.success) { toast.error(result.error); return; }
-      toast.success(`See you later, ${empName(selectedEmp!)}! ✅`);
-      setSessions(prev => prev.filter(s => s.employee_id !== selectedId));
-      setSelectedId('');
-      router.refresh();
+      try {
+        const result = await clockOut(selectedId);
+        if (!result.success) { toast.error(result.error); return; }
+        toast.success(`See you later, ${empName(selectedEmp!)}! ✅`);
+        setSessions(prev => prev.filter(s => s.employee_id !== selectedId));
+        setSelectedId('');
+        router.refresh();
+      } catch {
+        toast.error('Something went wrong. Please try again.');
+      }
     });
   };
 


### PR DESCRIPTION
## What changed
Added try/catch around clockIn and clockOut server action calls in TimeclockKiosk.tsx so thrown exceptions now show a toast rather than silently disappearing.

## Why
Staff were reporting clock-in failures. Investigation found the root cause is transient 503s on Vercel cold-start: the first request after the function is cold fails, but startTransition silently swallows the exception — staff see the spinner stop with zero feedback and assume it failed permanently. A retry would succeed.

With this fix: "Something went wrong. Please try again." is shown on any thrown error.

## Testing done
- Manual live test on production kiosk — clock-in POST confirmed 200, session created and immediately closed
- TypeScript and ESLint pass (zero warnings)

## Complexity score
XS

## Breaking changes / Migration risk
None