### PR TITLE
fix: allow deposit payment on confirmed private bookings

### DIFF
--- a/src/app/(authenticated)/private-bookings/[id]/PrivateBookingDetailClient.tsx
+++ b/src/app/(authenticated)/private-bookings/[id]/PrivateBookingDetailClient.tsx
@@ -2339,7 +2339,7 @@ export default function PrivateBookingDetailClient({
                       {formatMoney(booking.deposit_amount ?? 250)}
                     </p>
                     {!booking.deposit_paid_date &&
-                      booking.status === "draft" &&
+                      (booking.status === "draft" || booking.status === "confirmed") &&
                       canManageDeposits && (
                         <div className="mt-1 flex flex-col gap-1 items-end">
                           <button

--- a/src/app/actions/privateBookingActions.ts
+++ b/src/app/actions/privateBookingActions.ts
@@ -1343,8 +1343,8 @@ export async function createDepositPaymentOrder(
     return { error: 'Booking not found' }
   }
 
-  if (booking.status !== 'draft') {
-    return { error: 'Deposits can only be recorded against draft bookings' }
+  if (booking.status === 'cancelled' || booking.status === 'completed') {
+    return { error: 'Deposits can only be recorded against draft or confirmed bookings' }
   }
 
   if (booking.deposit_paid_date) {
@@ -1636,7 +1636,7 @@ export async function sendDepositPaymentLink(
 
   if (fetchError) return { error: 'Failed to load booking' }
   if (!booking) return { error: 'Booking not found' }
-  if (booking.status !== 'draft') return { error: 'Deposit payments can only be sent for draft bookings' }
+  if (booking.status === 'cancelled' || booking.status === 'completed') return { error: 'Deposit payment links can only be sent for draft or confirmed bookings' }
   if (booking.deposit_paid_date) return { error: 'Deposit has already been paid' }
 
   const depositAmount = typeof booking.deposit_amount === 'number' ? booking.deposit_amount : 0


### PR DESCRIPTION
## What changed
Deposit payment buttons and PayPal/manual payment actions were hidden and blocked when a private booking's status was `confirmed`. The UI and two server actions all required `status === 'draft'` before allowing a deposit to be recorded.

## Why
When staff manually confirm a booking before a deposit is collected (e.g. verbal confirmation, then chasing payment), they were locked out of the deposit UI entirely. The underlying service layer (`PrivateBookingService.recordDeposit`) already handled confirmed bookings correctly — it only blocks `cancelled`. This fix aligns the UI and server actions with that existing logic.

## Changes
- `PrivateBookingDetailClient.tsx` — show "Record Payment" and "Pay via PayPal" buttons when `status === 'draft' || status === 'confirmed'`
- `privateBookingActions.ts` — `createDepositPaymentOrder`: block only `cancelled`/`completed`, allow `draft` and `confirmed`
- `privateBookingActions.ts` — `sendDepositPaymentLink`: same fix

## Testing done
- [x] Build passes clean (`npm run build`)
- [x] Confirmed deposit buttons appear on confirmed bookings with no deposit paid
- [x] Confirmed deposit buttons remain hidden once `deposit_paid_date` is set
- [x] Confirmed buttons remain hidden on `cancelled` and `completed` bookings

## Complexity score
XS — 2 files, 4 lines changed, no schema changes

## Breaking changes
None

## Migration risk
None