### PR TITLE
feat(table-bookings): structured dietary/allergies/preorder persistence on public API

### DIFF
--- a/src/app/api/table-bookings/route.ts
+++ b/src/app/api/table-bookings/route.ts
@@ -24,6 +24,7 @@ import {
   sendTableBookingCreatedSmsIfAllowed,
   type TableBookingRpcResult
 } from '@/lib/table-bookings/bookings'
+import { saveSundayPreorderByBookingId } from '@/lib/table-bookings/sunday-preorder'
 import { logAuditEvent } from '@/app/actions/audit'
 import { logger } from '@/lib/logger'
 import { verifyTurnstileToken, getClientIp } from '@/lib/turnstile'
@@ -36,6 +37,14 @@ const tableBookingIpLimiter = createRateLimiter({
 })
 
 type SmsSafetyMeta = Awaited<ReturnType<typeof sendTableBookingCreatedSmsIfAllowed>>['sms']
+
+const SundayPreorderItemSchema = z.object({
+  menu_dish_id: z.string().uuid(),
+  quantity: z.preprocess(
+    (value) => (typeof value === 'string' ? Number.parseInt(value, 10) : value),
+    z.number().int().min(1).max(25)
+  )
+})
 
 const CreateTableBookingSchema = z.object({
   phone: z.string().trim().min(7).max(32),
@@ -51,6 +60,9 @@ const CreateTableBookingSchema = z.object({
   purpose: z.enum(['food', 'drinks']),
   notes: z.string().trim().max(500).optional(),
   sunday_lunch: z.boolean().optional(),
+  dietary_requirements: z.array(z.string().trim().min(1).max(100)).max(20).optional(),
+  allergies: z.array(z.string().trim().min(1).max(100)).max(20).optional(),
+  sunday_preorder_items: z.array(SundayPreorderItemSchema).max(40).optional(),
   default_country_code: z.string().regex(/^\d{1,4}$/).optional(),
   skip_customer_sms: z.boolean().optional()
 })
@@ -179,7 +191,10 @@ export async function POST(request: NextRequest) {
       party_size: payload.party_size,
       purpose: payload.purpose,
       notes: payload.notes || null,
-      sunday_lunch: payload.sunday_lunch === true
+      sunday_lunch: payload.sunday_lunch === true,
+      dietary_requirements: payload.dietary_requirements ?? null,
+      allergies: payload.allergies ?? null,
+      sunday_preorder_items: payload.sunday_preorder_items ?? null
     })
 
     const supabase = createAdminClient()
@@ -258,6 +273,62 @@ export async function POST(request: NextRequest) {
         bookingResult = (rpcResultRaw ?? {}) as TableBookingRpcResult
       }
       mutationCommitted = Boolean(bookingResult.table_booking_id)
+
+      // Persist structured dietary/allergy arrays directly on the booking row.
+      // The RPC doesn't accept these so we write them post-insert. Best-effort:
+      // failures are logged, not surfaced to the caller — the booking itself is
+      // still valid without them.
+      if (
+        bookingResult.table_booking_id &&
+        ((payload.dietary_requirements?.length ?? 0) > 0 ||
+          (payload.allergies?.length ?? 0) > 0)
+      ) {
+        const { error: arraysError } = await supabase
+          .from('table_bookings')
+          .update({
+            dietary_requirements: payload.dietary_requirements ?? null,
+            allergies: payload.allergies ?? null,
+          })
+          .eq('id', bookingResult.table_booking_id)
+        if (arraysError) {
+          logger.warn('Failed to persist dietary/allergy arrays on table booking', {
+            metadata: {
+              tableBookingId: bookingResult.table_booking_id,
+              error: arraysError.message,
+            },
+          })
+        }
+      }
+
+      // Persist Sunday lunch pre-order line items in the dedicated table so the
+      // admin pre-order tab, kitchen prep sheet, and analytics see structured
+      // data instead of parsing a free-text notes blob. Best-effort: items still
+      // survive in the notes field if this fails, so the kitchen isn't blind.
+      if (
+        bookingResult.table_booking_id &&
+        payload.sunday_lunch === true &&
+        (payload.sunday_preorder_items?.length ?? 0) > 0
+      ) {
+        try {
+          await saveSundayPreorderByBookingId(supabase, {
+            bookingId: bookingResult.table_booking_id,
+            items: payload.sunday_preorder_items!,
+            staffOverride: true,
+          })
+        } catch (preorderError) {
+          logger.warn('Failed to persist Sunday preorder items for website booking', {
+            metadata: {
+              tableBookingId: bookingResult.table_booking_id,
+              itemCount: payload.sunday_preorder_items?.length ?? 0,
+              error:
+                preorderError instanceof Error
+                  ? preorderError.message
+                  : String(preorderError),
+            },
+          })
+        }
+      }
+
       const appBaseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin
 
       let nextStepUrl: string | null = null

--- a/tests/api/tableBookingStructuredPersistence.test.ts
+++ b/tests/api/tableBookingStructuredPersistence.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * A2 regression test — the public POST /api/table-bookings endpoint must
+ * persist dietary/allergy arrays onto the booking row and hand structured
+ * Sunday lunch pre-order items to saveSundayPreorderByBookingId, rather than
+ * losing them into a free-text notes blob.
+ */
+
+const {
+  saveSundayPreorderByBookingId,
+  ensureCustomerForPhone,
+  logAuditEvent,
+  warn,
+  error,
+  createTablePaymentToken,
+  sendTableBookingCreatedSmsIfAllowed,
+  sendManagerTableBookingCreatedEmailIfAllowed,
+  alignTablePaymentHoldToScheduledSend,
+  mapTableBookingBlockedReason,
+  recordAnalyticsEvent,
+  verifyTurnstileToken,
+} = vi.hoisted(() => ({
+  saveSundayPreorderByBookingId: vi.fn().mockResolvedValue({ state: 'saved', item_count: 2, booking_id: 'bk1' }),
+  ensureCustomerForPhone: vi.fn(),
+  logAuditEvent: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  createTablePaymentToken: vi.fn().mockResolvedValue({ url: 'https://example.com/pay' }),
+  sendTableBookingCreatedSmsIfAllowed: vi.fn().mockResolvedValue({ sms: null }),
+  sendManagerTableBookingCreatedEmailIfAllowed: vi.fn().mockResolvedValue({ sent: true }),
+  alignTablePaymentHoldToScheduledSend: vi.fn(async () => undefined),
+  mapTableBookingBlockedReason: vi.fn((reason?: string) => (reason as any) ?? null),
+  recordAnalyticsEvent: vi.fn(),
+  verifyTurnstileToken: vi.fn().mockResolvedValue({ success: true }),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  createRateLimiter: vi.fn(() => vi.fn().mockResolvedValue(null)),
+}))
+
+vi.mock('@/lib/api/auth', () => ({
+  withApiAuth: vi.fn(
+    async (handler: (request: Request) => Promise<Response>, _permissions: string[], request: Request) =>
+      handler(request),
+  ),
+  createApiResponse: (payload: unknown, status = 200) =>
+    new Response(JSON.stringify(payload), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  createErrorResponse: (message: string, _code: string, status: number) =>
+    new Response(JSON.stringify({ error: message }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+}))
+
+vi.mock('@/lib/api/idempotency', () => ({
+  claimIdempotencyKey: vi.fn().mockResolvedValue({ state: 'claimed' }),
+  computeIdempotencyRequestHash: vi.fn(() => 'hash'),
+  getIdempotencyKey: vi.fn(() => 'idem-1'),
+  persistIdempotencyResponse: vi.fn(),
+  releaseIdempotencyClaim: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/sms/customers', () => ({
+  ensureCustomerForPhone,
+}))
+
+vi.mock('@/lib/utils', () => ({
+  formatPhoneForStorage: vi.fn((value: string) => value),
+}))
+
+vi.mock('@/lib/turnstile', () => ({
+  verifyTurnstileToken,
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}))
+
+vi.mock('@/lib/analytics/events', () => ({
+  recordAnalyticsEvent,
+}))
+
+vi.mock('@/app/actions/audit', () => ({
+  logAuditEvent,
+}))
+
+vi.mock('@/lib/table-bookings/bookings', () => ({
+  alignTablePaymentHoldToScheduledSend,
+  createTablePaymentToken,
+  mapTableBookingBlockedReason,
+  sendManagerTableBookingCreatedEmailIfAllowed,
+  sendTableBookingCreatedSmsIfAllowed,
+}))
+
+vi.mock('@/lib/table-bookings/sunday-preorder', () => ({
+  saveSundayPreorderByBookingId,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn, error, info: vi.fn() },
+}))
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { POST } from '@/app/api/table-bookings/route'
+
+const BOOKING_ID = '11111111-1111-4111-8111-111111111111'
+const DISH_ID = '22222222-2222-4222-8222-222222222222'
+const DISH_ID_2 = '33333333-3333-4333-8333-333333333333'
+
+function buildSupabase() {
+  const tableBookingsUpdateEq = vi.fn().mockResolvedValue({ error: null })
+  const tableBookingsUpdate = vi.fn(() => ({ eq: tableBookingsUpdateEq }))
+
+  const rpc = vi.fn(async () => ({
+    data: {
+      state: 'pending_payment',
+      table_booking_id: BOOKING_ID,
+      booking_reference: 'TB-TEST',
+      hold_expires_at: new Date(Date.now() + 60_000).toISOString(),
+      deposit_amount: 20,
+      table_name: 'T1',
+    },
+    error: null,
+  }))
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'table_bookings') {
+        return { update: tableBookingsUpdate }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+    rpc,
+    _tableBookingsUpdate: tableBookingsUpdate,
+    _tableBookingsUpdateEq: tableBookingsUpdateEq,
+  }
+}
+
+function buildRequest(body: unknown): Request {
+  return new Request('http://localhost/api/table-bookings', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': 'test-key',
+      'idempotency-key': 'idem-1',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/table-bookings — structured persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ensureCustomerForPhone.mockResolvedValue({ customerId: 'cust-1' })
+    saveSundayPreorderByBookingId.mockResolvedValue({ state: 'saved', item_count: 2, booking_id: BOOKING_ID })
+  })
+
+  it('persists dietary_requirements and allergies arrays on the booking row', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+
+    const body = {
+      phone: '+447000000000',
+      first_name: 'Alice',
+      last_name: 'Smith',
+      email: 'alice@example.com',
+      date: '2026-04-26',
+      time: '12:00',
+      party_size: 2,
+      purpose: 'food',
+      sunday_lunch: true,
+      dietary_requirements: ['vegetarian'],
+      allergies: ['nuts', 'shellfish'],
+    }
+
+    const response = await POST(buildRequest(body) as any)
+    expect(response.status).toBeLessThan(500)
+
+    expect(supabase._tableBookingsUpdate).toHaveBeenCalledWith({
+      dietary_requirements: ['vegetarian'],
+      allergies: ['nuts', 'shellfish'],
+    })
+    expect(supabase._tableBookingsUpdateEq).toHaveBeenCalledWith('id', BOOKING_ID)
+  })
+
+  it('saves structured Sunday lunch pre-order items via saveSundayPreorderByBookingId', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+
+    const body = {
+      phone: '+447000000000',
+      date: '2026-04-26',
+      time: '12:00',
+      party_size: 2,
+      purpose: 'food',
+      sunday_lunch: true,
+      sunday_preorder_items: [
+        { menu_dish_id: DISH_ID, quantity: 1 },
+        { menu_dish_id: DISH_ID_2, quantity: 1 },
+      ],
+    }
+
+    await POST(buildRequest(body) as any)
+
+    expect(saveSundayPreorderByBookingId).toHaveBeenCalledWith(
+      supabase,
+      expect.objectContaining({
+        bookingId: BOOKING_ID,
+        items: [
+          { menu_dish_id: DISH_ID, quantity: 1 },
+          { menu_dish_id: DISH_ID_2, quantity: 1 },
+        ],
+        staffOverride: true,
+      }),
+    )
+  })
+
+  it('does not call saveSundayPreorderByBookingId when booking is not sunday_lunch', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+
+    const body = {
+      phone: '+447000000000',
+      date: '2026-04-24',
+      time: '19:00',
+      party_size: 2,
+      purpose: 'food',
+      sunday_lunch: false,
+      sunday_preorder_items: [{ menu_dish_id: DISH_ID, quantity: 1 }],
+    }
+
+    await POST(buildRequest(body) as any)
+
+    expect(saveSundayPreorderByBookingId).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning but does not fail the booking if pre-order persistence throws', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+    saveSundayPreorderByBookingId.mockRejectedValueOnce(new Error('menu lookup failed'))
+
+    const body = {
+      phone: '+447000000000',
+      date: '2026-04-26',
+      time: '12:00',
+      party_size: 2,
+      purpose: 'food',
+      sunday_lunch: true,
+      sunday_preorder_items: [{ menu_dish_id: DISH_ID, quantity: 1 }],
+    }
+
+    const response = await POST(buildRequest(body) as any)
+
+    expect(response.status).toBeLessThan(500)
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to persist Sunday preorder items for website booking',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ tableBookingId: BOOKING_ID, itemCount: 1 }),
+      }),
+    )
+  })
+
+  it('rejects a payload with sunday_preorder_items containing non-UUID menu_dish_id', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+
+    const body = {
+      phone: '+447000000000',
+      date: '2026-04-26',
+      time: '12:00',
+      party_size: 2,
+      purpose: 'food',
+      sunday_lunch: true,
+      sunday_preorder_items: [{ menu_dish_id: 'not-a-uuid', quantity: 1 }],
+    }
+
+    const response = await POST(buildRequest(body) as any)
+
+    expect(response.status).toBe(400)
+    expect(saveSundayPreorderByBookingId).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What changed
Extends the public `POST /api/table-bookings` schema to accept `dietary_requirements` (string[]), `allergies` (string[]), and `sunday_preorder_items` ({ menu_dish_id, quantity }[]). After the booking RPC returns, the route now:

- UPDATEs the booking row with the dietary/allergy arrays.
- Calls `saveSundayPreorderByBookingId()` so pre-order line items land in `table_booking_items` (the same helper the FOH staff route already uses).

Both are best-effort: a failure is logged, the booking still completes.

## Why
Every website Sunday lunch booking has been stuffing the customer's dishes, allergies, dietary needs, name, and email into one `notes` blob. The structured columns and `table_booking_items` stayed empty, so the admin pre-order tab and kitchen prep PDF were useless for website-sourced bookings. Root cause is documented in [docs/superpowers/specs/2026-04-18-sunday-lunch-booking-pipeline-fix-design.md](docs/superpowers/specs/2026-04-18-sunday-lunch-booking-pipeline-fix-design.md) Problem A.

This is the backend half (PR A2 in the spec). The website-side change that forwards the structured fields is a separate PR on the anchor.pub repo.

## Testing done
- [x] Vitest: 5 new regression tests pass, covers dietary persistence, preorder persist, non-Sunday short-circuit, error swallowing, UUID validation.
- [x] Typecheck clean.
- [x] Lint clean.
- [x] Full API test sweep — no new failures (4 pre-existing failures in `eventWaitlistOffersRouteErrors` and `idempotencyPersistFailClosedAdditionalRoutes` unchanged).
- [x] Production build clean.

## Complexity score
S — single file change plus a test file. One logical concern.

## Breaking changes
None. All new fields are optional; existing clients continue to work. The website starts sending them in the companion PR.

## Migration risk
None — no schema changes. Uses existing columns (`dietary_requirements`, `allergies`) and the existing `saveSundayPreorderByBookingId` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)