### PR TITLE
feat: add paid advertising todo to event checklist

### DIFF
--- a/src/lib/event-checklist.ts
+++ b/src/lib/event-checklist.ts
@@ -37,7 +37,8 @@ export const EVENT_CHECKLIST_DEFINITIONS: EventChecklistDefinition[] = [
   { key: 'add_google_business_post', label: 'Add Google Business Profile Event post', offsetDays: -28, channel: 'Google', required: true, order: 6 },
   { key: 'schedule_social_content', label: 'Create & schedule social content', offsetDays: -28, channel: 'FB/IG', required: true, order: 7 },
   { key: 'schedule_stories', label: 'Schedule Stories (day-before & day-of)', offsetDays: -28, channel: 'FB/IG', required: true, order: 8 },
-  { key: 'send_whatsapp_reminder', label: 'WhatsApp reminder to local group', offsetDays: 0, channel: 'WhatsApp', required: true, order: 9 }
+  { key: 'setup_paid_advertising', label: 'Set up paid advertising', offsetDays: -28, channel: 'Paid Ads', required: true, order: 9 },
+  { key: 'send_whatsapp_reminder', label: 'WhatsApp reminder to local group', offsetDays: 0, channel: 'WhatsApp', required: true, order: 10 }
 ]
 
 export const EVENT_CHECKLIST_TOTAL_TASKS = EVENT_CHECKLIST_DEFINITIONS.length


### PR DESCRIPTION
## What changed
Added a "Set up paid advertising" checklist task to the event todo system, due 28 days before the event date — the same cadence as the social media setup tasks (Facebook Event, Google Business, social content, Stories).

## Why
Paid advertising setup was being missed because there was no reminder in the event checklist workflow. This ensures it gets the same visibility as social media prep.

## Testing done
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [x] All event-related tests pass (no hardcoded total count — computed from array length)
- [x] Verified `EVENT_CHECKLIST_TOTAL_TASKS` auto-adjusts to 11
- [x] WhatsApp reminder order bumped from 9 → 10 (no functional impact)

## Complexity score
XS (1) — single file, single array entry addition

## Breaking changes
None — existing checklist statuses are keyed by `task_key`, so existing events simply won't have a record for `setup_paid_advertising` yet (defaults to incomplete).

## Migration risk
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)