### PR TITLE
feat: outstanding-todos rail on /events + calendar today fix

### DIFF
--- a/docs/superpowers/plans/2026-05-21-events-outstanding-todos-rail.md
+++ b/docs/superpowers/plans/2026-05-21-events-outstanding-todos-rail.md
@@ -1,0 +1,613 @@
+# Events — Outstanding Todos Right Rail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "Outstanding Todos" rail to the right-hand side of `/events` showing one flat, chronologically-sorted list of every checklist todo that is overdue or due today, with urgency made visually obvious and tickable in place.
+
+**Architecture:** Reuse the existing `getChecklistTodos()` server action (it already returns exactly overdue + due-today items, sorted by due date). Add a new client component `EventTodosWidget` rendered in a two-column wrapper in `events/page.tsx` so `EventsClient` is untouched. Pure display helpers are extracted for unit testing.
+
+**Tech Stack:** Next.js 15 App Router (RSC), React 19, TypeScript, Tailwind v4 (`@theme` tokens), Vitest + @testing-library/react, design-system components from `@/ds`.
+
+**Spec:** `docs/superpowers/specs/2026-05-21-events-outstanding-todos-rail-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/app/(authenticated)/events/_components/eventTodosWidget.helpers.ts` — pure, unit-testable display helpers (relative-due text, status counts, summary line).
+- **Create** `src/app/(authenticated)/events/_components/eventTodosWidget.helpers.test.ts` — helper unit tests.
+- **Create** `src/app/(authenticated)/events/_components/EventTodosWidget.tsx` — client component rendering the rail list with optimistic completion.
+- **Create** `src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx` — component tests.
+- **Modify** `src/app/(authenticated)/events/page.tsx` — fetch todos + `canManage`, wrap content in a two-column row, render the widget in the right rail.
+- **Modify (separate concern)** `src/app/(authenticated)/error.tsx` — fix the same dead `text-primary-foreground` token already fixed in the calendar.
+
+### Key facts the implementer must know
+
+- `getChecklistTodos()` (`src/app/actions/event-checklist.ts`) returns `{ success: boolean; error?: string; items?: ChecklistTodoItem[] }`. On success `items` is already filtered to `status === 'overdue' | 'due_today'` and sorted by `dueDate` ascending then `order`. **Do not re-sort or re-filter** in the widget — render in the order received.
+- It includes **draft** events (it does not filter by `event_status`). This is intentional; do not add a status filter. A test fixture must include a draft-event item to prove this.
+- `toggleEventChecklistTask(eventId, taskKey, completed)` → `Promise<{ success: boolean; error?: string }>`. It enforces `events:manage`, writes an audit log, and revalidates `/events`.
+- `ChecklistTodoItem` (from `@/lib/event-checklist`) fields used: `key`, `label`, `channel`, `eventId`, `eventName`, `dueDate`, `status` (`'overdue' | 'due_today'` here).
+- Semantic colour tokens exist in `@theme` (`src/app/globals.css`): `--color-danger`, `--color-warning` → utilities `border-danger`, `border-warning`, and Badge tones `danger`/`warning`. No hardcoded hex.
+- DS `Checkbox` renders `<button role="checkbox">`; with no `label`/children it uses `aria-label` as its accessible name. Its click calls `onChange(!checked)` and does **not** stop propagation — so the checkbox must be a **sibling** of (never nested inside) the row's `<Link>`.
+- Vitest is configured with `jsdom`, `globals: true`, and `@testing-library/jest-dom` (via `vitest.setup.ts`). `next/navigation` is globally mocked.
+
+---
+
+## Task 1: Isolate the dead-token fix as its own commit (separate concern)
+
+The calendar today-marker fix (`ScheduleCalendarMonth.tsx`, `text-primary-foreground` → `text-primary-fg`) is **already applied** in the working tree. `error.tsx:61` has the identical bug. Fix it and commit both together as one isolated fix, separate from the widget feature.
+
+**Files:**
+- Modify: `src/app/(authenticated)/error.tsx:61`
+- (Already modified, include in this commit) `src/components/schedule-calendar/ScheduleCalendarMonth.tsx:169`
+
+- [ ] **Step 1: Fix `error.tsx`**
+
+In `src/app/(authenticated)/error.tsx`, change the button class on line 61 from:
+
+```tsx
+        className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+```
+
+to:
+
+```tsx
+        className="px-4 py-2 bg-primary text-primary-fg rounded-md hover:bg-primary/90"
+```
+
+- [ ] **Step 2: Verify no other dead-token usages remain**
+
+Run: `grep -rn "text-primary-foreground\|bg-primary-foreground" src --include="*.tsx"`
+Expected: no matches. (`DragConfirmationModal.tsx` uses `text-[hsl(var(--primary-foreground))]`, which is a different, working form — leave it.)
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 4: Commit (separate concern)**
+
+```bash
+git add src/components/schedule-calendar/ScheduleCalendarMonth.tsx src/app/(authenticated)/error.tsx
+git commit -m "fix: use real primary-fg token for white text on green (calendar today marker, error retry button)"
+```
+
+---
+
+## Task 2: Pure display helpers (TDD)
+
+**Files:**
+- Create: `src/app/(authenticated)/events/_components/eventTodosWidget.helpers.ts`
+- Test: `src/app/(authenticated)/events/_components/eventTodosWidget.helpers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `eventTodosWidget.helpers.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import {
+  daysBetweenIso,
+  formatRelativeDue,
+  summariseTodos,
+  formatSummaryLine,
+} from './eventTodosWidget.helpers'
+
+describe('daysBetweenIso', () => {
+  it('counts whole days between ISO dates regardless of local timezone', () => {
+    expect(daysBetweenIso('2026-05-18', '2026-05-21')).toBe(3)
+    expect(daysBetweenIso('2026-05-21', '2026-05-21')).toBe(0)
+  })
+})
+
+describe('formatRelativeDue', () => {
+  it('labels overdue items by day count', () => {
+    expect(formatRelativeDue('2026-05-18', '2026-05-21')).toBe('Overdue by 3d')
+  })
+  it('labels due-today items', () => {
+    expect(formatRelativeDue('2026-05-21', '2026-05-21')).toBe('Due today')
+  })
+  it('labels future items', () => {
+    expect(formatRelativeDue('2026-05-26', '2026-05-21')).toBe('Due in 5d')
+  })
+})
+
+describe('summariseTodos', () => {
+  it('counts by status', () => {
+    expect(
+      summariseTodos([{ status: 'overdue' }, { status: 'overdue' }, { status: 'due_today' }]),
+    ).toEqual({ overdue: 2, dueToday: 1 })
+  })
+  it('handles empty input', () => {
+    expect(summariseTodos([])).toEqual({ overdue: 0, dueToday: 0 })
+  })
+})
+
+describe('formatSummaryLine', () => {
+  it('joins non-zero parts', () => {
+    expect(formatSummaryLine({ overdue: 3, dueToday: 2 })).toBe('3 overdue · 2 due today')
+  })
+  it('omits zero parts', () => {
+    expect(formatSummaryLine({ overdue: 0, dueToday: 2 })).toBe('2 due today')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/app/\(authenticated\)/events/_components/eventTodosWidget.helpers.test.ts`
+Expected: FAIL — cannot resolve `./eventTodosWidget.helpers`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `eventTodosWidget.helpers.ts`:
+
+```ts
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+
+const MS_PER_DAY = 86_400_000
+
+/** Whole-day difference (toIso - fromIso) using UTC-anchored ISO dates — deterministic and timezone-safe. */
+export function daysBetweenIso(fromIso: string, toIso: string): number {
+  const from = Date.parse(`${fromIso}T00:00:00Z`)
+  const to = Date.parse(`${toIso}T00:00:00Z`)
+  return Math.round((to - from) / MS_PER_DAY)
+}
+
+/** Human relative-due label for a todo's due date relative to today. */
+export function formatRelativeDue(dueDate: string, todayIso: string): string {
+  const overdueBy = daysBetweenIso(dueDate, todayIso) // positive => overdue
+  if (overdueBy > 0) return `Overdue by ${overdueBy}d`
+  if (overdueBy === 0) return 'Due today'
+  return `Due in ${-overdueBy}d`
+}
+
+export interface TodoCounts {
+  overdue: number
+  dueToday: number
+}
+
+export function summariseTodos(items: Pick<ChecklistTodoItem, 'status'>[]): TodoCounts {
+  let overdue = 0
+  let dueToday = 0
+  for (const item of items) {
+    if (item.status === 'overdue') overdue += 1
+    else if (item.status === 'due_today') dueToday += 1
+  }
+  return { overdue, dueToday }
+}
+
+export function formatSummaryLine(counts: TodoCounts): string {
+  const parts: string[] = []
+  if (counts.overdue > 0) parts.push(`${counts.overdue} overdue`)
+  if (counts.dueToday > 0) parts.push(`${counts.dueToday} due today`)
+  return parts.join(' · ')
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/app/\(authenticated\)/events/_components/eventTodosWidget.helpers.test.ts`
+Expected: PASS (10 assertions across 4 describe blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/\(authenticated\)/events/_components/eventTodosWidget.helpers.ts src/app/\(authenticated\)/events/_components/eventTodosWidget.helpers.test.ts
+git commit -m "feat: add display helpers for events outstanding-todos rail"
+```
+
+---
+
+## Task 3: EventTodosWidget component (TDD)
+
+**Files:**
+- Create: `src/app/(authenticated)/events/_components/EventTodosWidget.tsx`
+- Test: `src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `EventTodosWidget.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+
+vi.mock('@/app/actions/event-checklist', () => ({
+  toggleEventChecklistTask: vi.fn(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={typeof href === 'string' ? href : '#'} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Full, lightweight mock of the design-system barrel so the test does not load the heavy shell.
+vi.mock('@/ds', async () => {
+  const React = await import('react')
+  return {
+    Card: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+    CardHeader: ({ title, subtitle }: { title?: string; subtitle?: string }) =>
+      React.createElement('div', null, title, subtitle ? React.createElement('p', null, subtitle) : null),
+    CardBody: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+    Badge: ({ tone, children }: { tone?: string; children: React.ReactNode }) =>
+      React.createElement('span', { 'data-tone': tone }, children),
+    Checkbox: ({
+      onChange,
+      checked,
+      ...rest
+    }: {
+      onChange?: (v: boolean) => void
+      checked?: boolean
+      'aria-label'?: string
+    }) =>
+      React.createElement('button', {
+        type: 'button',
+        role: 'checkbox',
+        'aria-checked': Boolean(checked),
+        'aria-label': rest['aria-label'],
+        onClick: () => onChange?.(!checked),
+      }),
+    toast: { error: vi.fn(), success: vi.fn() },
+  }
+})
+
+import EventTodosWidget from './EventTodosWidget'
+import { toggleEventChecklistTask } from '@/app/actions/event-checklist'
+import { toast } from '@/ds'
+
+const mockToggle = vi.mocked(toggleEventChecklistTask)
+const TODAY = '2026-05-21'
+
+function makeItem(overrides: Partial<ChecklistTodoItem> = {}): ChecklistTodoItem {
+  return {
+    key: 'write_event_brief',
+    label: 'Write event brief',
+    offsetDays: -28,
+    channel: 'Admin',
+    required: true,
+    order: 1,
+    eventId: 'evt-1',
+    dueDate: '2026-05-18',
+    dueDateFormatted: '18 May 2026',
+    completed: false,
+    completedAt: null,
+    status: 'overdue',
+    eventName: 'Draft Quiz Night',
+    eventDate: '2026-06-15',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EventTodosWidget', () => {
+  it('renders todos in the order received with correct urgency tone, including draft-event items', () => {
+    const items = [
+      makeItem({ key: 'a', label: 'Alpha task', status: 'overdue', dueDate: '2026-05-18', eventName: 'Draft Quiz Night' }),
+      makeItem({ key: 'b', label: 'Beta task', status: 'due_today', dueDate: '2026-05-21', eventName: 'Scheduled Gig' }),
+    ]
+    render(<EventTodosWidget initialTodos={items} canManage todayIso={TODAY} />)
+
+    const labels = screen.getAllByText(/ task$/).map((el) => el.textContent)
+    expect(labels).toEqual(['Alpha task', 'Beta task'])
+
+    expect(screen.getByText('Overdue by 3d')).toHaveAttribute('data-tone', 'danger')
+    expect(screen.getByText('Due today')).toHaveAttribute('data-tone', 'warning')
+    // Draft-event item is shown (widget must not filter by event_status).
+    expect(screen.getByText('Draft Quiz Night')).toBeInTheDocument()
+  })
+
+  it('shows the caught-up empty state when there are no todos and no error', () => {
+    render(<EventTodosWidget initialTodos={[]} canManage todayIso={TODAY} />)
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument()
+  })
+
+  it('shows a load-error state instead of the caught-up state when loadError is set', () => {
+    render(<EventTodosWidget initialTodos={[]} canManage todayIso={TODAY} loadError="boom" />)
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument()
+    expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument()
+  })
+
+  it('hides checkboxes when the user cannot manage', () => {
+    render(<EventTodosWidget initialTodos={[makeItem()]} canManage={false} todayIso={TODAY} />)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('gives each checkbox an accessible name', () => {
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    expect(
+      screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }),
+    ).toBeInTheDocument()
+  })
+
+  it('optimistically removes a todo on successful completion', async () => {
+    mockToggle.mockResolvedValue({ success: true })
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+
+    await waitFor(() => expect(screen.queryByText('Write event brief')).not.toBeInTheDocument())
+    expect(mockToggle).toHaveBeenCalledWith('evt-1', 'write_event_brief', true)
+  })
+
+  it('restores the todo and shows a toast when completion fails', async () => {
+    mockToggle.mockResolvedValue({ success: false, error: 'nope' })
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('nope'))
+    expect(screen.getByText('Write event brief')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/app/\(authenticated\)/events/_components/EventTodosWidget.test.tsx`
+Expected: FAIL — cannot resolve `./EventTodosWidget`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `EventTodosWidget.tsx`:
+
+```tsx
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { Card, CardHeader, CardBody, Checkbox, Badge, toast } from '@/ds'
+import { cn } from '@/lib/utils'
+import { toggleEventChecklistTask } from '@/app/actions/event-checklist'
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+import { formatRelativeDue, summariseTodos, formatSummaryLine } from './eventTodosWidget.helpers'
+
+interface EventTodosWidgetProps {
+  initialTodos: ChecklistTodoItem[]
+  canManage: boolean
+  todayIso: string
+  loadError?: string | null
+}
+
+export default function EventTodosWidget({
+  initialTodos,
+  canManage,
+  todayIso,
+  loadError = null,
+}: EventTodosWidgetProps) {
+  const [todos, setTodos] = useState<ChecklistTodoItem[]>(initialTodos)
+  const [isPending, startTransition] = useTransition()
+
+  function handleComplete(item: ChecklistTodoItem) {
+    const snapshot = todos
+    setTodos((prev) => prev.filter((t) => !(t.eventId === item.eventId && t.key === item.key)))
+    startTransition(async () => {
+      const result = await toggleEventChecklistTask(item.eventId, item.key, true)
+      if (!result.success) {
+        setTodos(snapshot)
+        toast.error(result.error ?? 'Could not update todo')
+      }
+    })
+  }
+
+  const summary = formatSummaryLine(summariseTodos(todos))
+
+  return (
+    <div className="xl:sticky xl:top-6">
+      <Card>
+        <CardHeader
+          title="Outstanding Todos"
+          subtitle={!loadError && todos.length > 0 ? summary : undefined}
+        />
+        <CardBody className="max-h-96 xl:max-h-[calc(100vh-7rem)] overflow-y-auto">
+          {loadError ? (
+            <p className="py-6 text-center text-sm text-text-muted">
+              Outstanding todos could not be loaded.
+            </p>
+          ) : todos.length === 0 ? (
+            <p className="py-6 text-center text-sm text-text-muted">
+              You&apos;re all caught up — no outstanding todos.
+            </p>
+          ) : (
+            <ul className={cn('flex flex-col gap-1', isPending && 'opacity-60')}>
+              {todos.map((item) => (
+                <li
+                  key={`${item.eventId}:${item.key}`}
+                  className={cn(
+                    'flex items-start gap-2 border-l-4 pl-3 py-2',
+                    item.status === 'overdue' ? 'border-danger' : 'border-warning',
+                  )}
+                >
+                  {canManage && (
+                    <Checkbox
+                      aria-label={`Mark "${item.label}" complete`}
+                      checked={false}
+                      onChange={() => handleComplete(item)}
+                    />
+                  )}
+                  <Link href={`/events/${item.eventId}`} className="group block min-w-0 flex-1">
+                    <span className="block truncate text-sm text-text group-hover:underline">
+                      {item.label}
+                    </span>
+                    <span className="mt-1 flex flex-wrap items-center gap-2">
+                      <span className="max-w-[10rem] truncate text-xs text-text-muted">
+                        {item.eventName}
+                      </span>
+                      <Badge tone={item.status === 'overdue' ? 'danger' : 'warning'}>
+                        {formatRelativeDue(item.dueDate, todayIso)}
+                      </Badge>
+                      <span className="text-xs text-text-subtle">{item.channel}</span>
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/app/\(authenticated\)/events/_components/EventTodosWidget.test.tsx`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Lint**
+
+Run: `npm run lint`
+Expected: zero warnings/errors (note: `--max-warnings=0` is enforced).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/\(authenticated\)/events/_components/EventTodosWidget.tsx src/app/\(authenticated\)/events/_components/EventTodosWidget.test.tsx
+git commit -m "feat: add EventTodosWidget for outstanding-todos rail"
+```
+
+---
+
+## Task 4: Wire the widget into the `/events` page + verify end to end
+
+**Files:**
+- Modify: `src/app/(authenticated)/events/page.tsx`
+
+- [ ] **Step 1: Update `page.tsx`**
+
+Replace the full contents of `src/app/(authenticated)/events/page.tsx` with:
+
+```tsx
+import { redirect } from 'next/navigation'
+import { checkUserPermission } from '@/app/actions/rbac'
+import { getEvents } from '@/app/actions/events'
+import { getActiveEventCategories } from '@/app/actions/event-categories'
+import { fetchPrivateBookingsForCalendar } from '@/app/actions/private-bookings-dashboard'
+import { listCalendarNotes } from '@/app/actions/calendar-notes'
+import { listParkingBookings } from '@/app/actions/parking'
+import { getChecklistTodos } from '@/app/actions/event-checklist'
+import { getTodayIsoDate } from '@/lib/dateUtils'
+import type { VenueCalendarBooking, VenueCalendarParking } from '@/components/schedule-calendar'
+import EventsClient from './_components/EventsClient'
+import EventTodosWidget from './_components/EventTodosWidget'
+
+export const metadata = {
+  title: 'Events',
+}
+
+export default async function EventsPage() {
+  const canViewEvents = await checkUserPermission('events', 'view')
+
+  if (!canViewEvents) {
+    redirect('/unauthorized')
+  }
+
+  const [
+    eventsResult,
+    categoriesResult,
+    calEventsResult,
+    bookingsResult,
+    notesResult,
+    parkingResult,
+    todosResult,
+    canManageEvents,
+  ] = await Promise.all([
+    getEvents({ status: 'all', dateFrom: getTodayIsoDate(), page: 1, pageSize: 25 }),
+    getActiveEventCategories(),
+    getEvents({ status: 'all', page: 1, pageSize: 500 }),
+    fetchPrivateBookingsForCalendar(),
+    listCalendarNotes(),
+    listParkingBookings({ limit: 500 }),
+    getChecklistTodos(),
+    checkUserPermission('events', 'manage'),
+  ])
+
+  return (
+    <div className="p-6">
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <div className="min-w-0 flex-1">
+          <EventsClient
+            initialEvents={eventsResult.data ?? []}
+            initialPagination={eventsResult.pagination}
+            categories={categoriesResult.data ?? []}
+            initialCalendarEvents={calEventsResult.data ?? []}
+            initialCalendarBookings={'data' in bookingsResult && bookingsResult.data ? bookingsResult.data as VenueCalendarBooking[] : []}
+            initialCalendarNotes={notesResult.data ?? []}
+            initialCalendarParking={'data' in parkingResult && parkingResult.data ? parkingResult.data as VenueCalendarParking[] : []}
+          />
+        </div>
+        <aside className="xl:w-80 xl:shrink-0">
+          <EventTodosWidget
+            initialTodos={todosResult.items ?? []}
+            canManage={canManageEvents}
+            todayIso={getTodayIsoDate()}
+            loadError={todosResult.success ? null : todosResult.error ?? 'Unable to load outstanding todos'}
+          />
+        </aside>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: zero warnings/errors.
+
+- [ ] **Step 4: Full test run**
+
+Run: `npm test`
+Expected: all tests pass (including the two new files).
+
+- [ ] **Step 5: Production build**
+
+Run: `npm run build`
+Expected: build succeeds with no type/compile errors.
+
+- [ ] **Step 6: In-browser verification**
+
+Start the preview (`preview_start`) and open `/events`.
+
+- **Auth note:** `/events` is behind auth. If the preview cannot reach an authenticated session, **do not claim visual success** — report that visual verification was blocked by auth and ask the user to confirm, or provide a logged-in session. Build + unit tests still gate correctness.
+
+If reachable, confirm:
+- The "Outstanding Todos" rail appears on the right (`xl`+), sticky while the main content scrolls; on a narrow viewport (`preview_resize`) it stacks below the main content.
+- Overdue rows show a red left border + `danger` badge ("Overdue by Nd"); due-today rows show an amber left border + `warning` badge ("Due today").
+- Ticking a row removes it; the summary count updates.
+- The calendar "today" date number is now **white** on the green background (the Task 1 fix).
+
+Capture a `preview_screenshot` as proof.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/\(authenticated\)/events/page.tsx
+git commit -m "feat: show outstanding-todos rail on the events page"
+```
+
+---
+
+## Notes for the executor
+
+- **Stale checklist keys:** The widget only ever consumes `getChecklistTodos()`, which derives visible tasks via `buildEventChecklist()` from `EVENT_CHECKLIST_DEFINITIONS`. Never read or count raw `event_checklist_statuses` rows in the widget — historical/stale task keys exist there.
+- **Do not modify** `EventsClient`, `getChecklistTodos`, the `/events/todo` page, or `TodoClient`.
+- **`todayIso` prop:** added beyond the spec's prop list so relative-due text uses the same "today" as the server-computed status (deterministic). It is passed from `page.tsx` via `getTodayIsoDate()`.
+- Keep commit messages conventional; append the standard `Co-Authored-By` trailer per workspace git settings.
+```

--- a/docs/superpowers/specs/2026-05-21-events-outstanding-todos-rail-design.md
+++ b/docs/superpowers/specs/2026-05-21-events-outstanding-todos-rail-design.md
@@ -1,0 +1,160 @@
+# Events — Outstanding Todos Right Rail
+
+**Date:** 2026-05-21
+**Status:** Reviewed against codebase/database actuals; ready for implementation with explicit draft-event inclusion
+**Complexity:** S (2) — 1 new component + 1 page wrapper, no schema/data-layer changes
+
+## Problem
+
+The cross-event checklist todos already exist, but the only place to see them is `/events/todo`, which groups them into a separate card per event. Staff want an at-a-glance, single consolidated list of the todos that need action *now*, visible while they work on the main `/events` page, with urgency made visually obvious.
+
+## Goal
+
+Add an "Outstanding Todos" rail down the right-hand side of the `/events` landing page showing **one flat list, sorted chronologically by due date**, of every checklist todo that is **overdue or due today**. Each row makes urgency visually obvious and can be ticked off in place.
+
+## Non-goals / out of scope
+
+- **No change to `/events/todo`** — the existing grouped-by-event view stays exactly as-is.
+- **No future ("upcoming") todos** — only items due today or before are shown.
+- **No new data layer for this iteration** — reuse the existing `getChecklistTodos()` action and make its current event-status behaviour explicit.
+- The `text-primary-foreground` dead-token bug fix (calendar today-marker + `error.tsx` "Try again" button) is a **separate concern** tracked independently, not part of this feature.
+
+## Codebase/database actuals reviewed
+
+- Checklist todos are **derived**, not stored as todo rows. The source of truth is:
+  - `src/lib/event-checklist.ts` → `EVENT_CHECKLIST_DEFINITIONS`, `buildEventChecklist()`, `getOutstandingTodos()`.
+  - `event_checklist_statuses` → sparse completion records keyed by `(event_id, task_key)`.
+- `EventChecklistService.getChecklistTodos()` currently:
+  - loads events where `date >= today`;
+  - does **not** filter by `event_status`;
+  - builds checklist items from definitions;
+  - removes completed items;
+  - returns only `overdue` and `due_today`;
+  - sorts by `dueDate` ascending, then `order`.
+- Live database sample on **2026-05-21**:
+  - 88 current/future events matched `date >= today`.
+  - 85 were `draft`, 3 were `scheduled`.
+  - 40 outstanding due/overdue todos were produced.
+  - 35 of those todos were on draft events, 5 on scheduled events.
+- Persisted `event_checklist_statuses` contains historical/stale task keys that no longer exist in `EVENT_CHECKLIST_DEFINITIONS` (for example `publish_event_page`, `create_short_link`, `print_materials`). Do **not** count raw status rows as checklist totals; always derive visible tasks through `buildEventChecklist()` / `getOutstandingTodos()`.
+- `supabase/migrations/20260228000004_auto_close_past_event_tasks.sql` also has a stale task-key list and omits the current `setup_paid_advertising` definition. This does not block the rail, but it confirms that UI logic must rely on the current TypeScript checklist definitions, not migration hardcoded key lists.
+
+## Scope decision
+
+- **Show:** todos with status `overdue` or `due_today`.
+- **Hide:** todos with status `upcoming` (not yet due) and `completed`.
+- **Event-status scope:** include the exact existing dataset returned by `getChecklistTodos()`, including draft events. This intentionally preserves `/events/todo` semantics and keeps the change additive.
+- If the product decision changes to "scheduled/public events only", this spec must be revised before implementation because that is a data-layer/filter change, not just a rail component change.
+
+## Data flow
+
+1. `events/page.tsx` (server component) already runs a `Promise.all` of server actions. Add two calls:
+   - `getChecklistTodos()` → `{ success, error?, items?: ChecklistTodoItem[] }` (flat, already sorted chronologically on success).
+   - `checkUserPermission('events', 'manage')` → `canManage: boolean` (gates the tick action).
+2. Pass `initialTodos={result.items ?? []}`, `loadError={result.success ? null : result.error ?? 'Unable to load outstanding todos'}`, and `canManage` into a new `EventTodosWidget`.
+3. `EventTodosWidget` (client) renders the list and owns local state for optimistic removal on completion.
+
+`ChecklistTodoItem` (from `src/lib/event-checklist.ts`) already carries everything the row needs: `key`, `label`, `channel`, `eventId`, `eventName`, `eventDate`, `dueDate`, `dueDateFormatted`, `status` (`'overdue' | 'due_today'` for this widget's input).
+
+## Layout
+
+`events/page.tsx` wraps the existing content in a two-column row so **`EventsClient` is not modified**:
+
+```tsx
+<div className="p-6">
+  <div className="flex flex-col xl:flex-row gap-6">
+    <div className="flex-1 min-w-0">
+      <EventsClient ... />
+    </div>
+    <aside className="xl:w-80 xl:shrink-0">
+      <EventTodosWidget initialTodos={...} canManage={...} loadError={...} />
+    </aside>
+  </div>
+</div>
+```
+
+- **Desktop (`xl`+):** rail sits on the right at a fixed `w-80` (~320px). The widget card is `xl:sticky xl:top-6` so it stays in view while the main content scrolls. The list body is `overflow-y-auto` with a `max-h` so a long list never stretches the page.
+- **Below `xl`:** columns collapse to a single column; the rail drops **below** the main content as a full-width card (DOM order is main → aside, so no ordering hacks needed).
+- The rail top-aligns with the existing Events `PageHeader`.
+
+## Component: `EventTodosWidget`
+
+Location: `src/app/(authenticated)/events/_components/EventTodosWidget.tsx` (client component).
+
+**Props:** `{ initialTodos: ChecklistTodoItem[]; canManage: boolean; loadError?: string | null }`
+
+**Structure** (design-system components from `@/ds`): a `Card` with:
+- `CardHeader` — title "Outstanding Todos" + a summary line, e.g. *"3 overdue · 2 due today"* (or just the relevant non-zero parts).
+- `CardBody` — the scrollable flat list. One row per todo, in the order received (chronological).
+
+**Row anatomy** (compact, stacks vertically to fit the narrow rail):
+- A coloured **left border** indicating urgency.
+- Optional `Checkbox` (see interactivity) on the left.
+- Line 1: task `label`.
+- Line 2: `eventName` (muted/truncated) + a relative-due `Badge` and the `channel` tag.
+- The row (excluding the checkbox) is a link to `/events/{eventId}` so staff can jump to the event to action it.
+
+**Urgency visuals** (two states only):
+| Status | Left border / Badge tone | Relative-due text |
+|---|---|---|
+| `overdue` | red (`danger`) | "Overdue by Nd" |
+| `due_today` | amber (`warning`) | "Due today" |
+
+Because the list is sorted by `dueDate` ascending, the most-overdue items naturally sort to the top.
+
+## Interactivity (confirmed: interactive)
+
+- If `canManage` is true, each row shows a `Checkbox`. Ticking it:
+  1. Optimistically **removes** the row from local state (it is no longer "outstanding").
+  2. Calls `toggleEventChecklistTask(eventId, key, true)`.
+  3. On failure, restores the row and shows an error toast.
+- `toggleEventChecklistTask` already enforces `events:manage`, writes an audit log, and `revalidatePath('/events')` — so the server-side count refreshes on the next load.
+- If `canManage` is false, rows render **without** checkboxes (read-only). The list is still fully visible.
+- The checkbox click target must stop propagation so ticking a row does not navigate to the event detail page.
+
+## Derived-display helpers (unit-testable, pure)
+
+Extract pure functions (co-located, e.g. `eventTodosWidget.helpers.ts`) so logic is testable without rendering:
+- `formatRelativeDue(dueDate: string, todayIso: string): string` → "Overdue by 3d" / "Due today". Use deterministic ISO-date arithmetic; never raw browser-local date parsing for user-visible display.
+- `summariseTodos(items): { overdue: number; dueToday: number }` → for the header summary line.
+
+## States
+
+- **Loading:** none needed for first paint (server-rendered with data). Toggle uses `useTransition`; dim the row while pending.
+- **Empty:** friendly message — *"You're all caught up — no outstanding todos."*
+- **Load error:** show a compact warning in the card body, e.g. *"Outstanding todos could not be loaded."* Do **not** show the caught-up empty state when `loadError` is present.
+- **Error (toggle):** restore optimistic change + toast.
+
+## Permissions
+
+- Page already gates on `events:view` (redirects otherwise). The widget inherits that.
+- Ticking requires `events:manage`, enforced both in the UI (`canManage`) and server-side in `toggleEventChecklistTask` (never rely on UI hiding alone).
+
+## Accessibility
+
+- Checkboxes use the DS `Checkbox` with an explicit accessible name, e.g. `aria-label={`Mark ${item.label} complete`}`.
+- Urgency is conveyed by **badge text + relative-due text**, not colour alone.
+- Row links are keyboard-focusable with visible focus styles.
+- The scroll container is keyboard-scrollable; the rail card uses a proper heading.
+
+## Testing
+
+Per project testing conventions (Vitest, mock external/server actions):
+- `formatRelativeDue` — overdue (N days), due-today, boundary cases.
+- `summariseTodos` — counts by status, empty input.
+- `EventTodosWidget` — renders rows in the order received; correct badge tone per status; empty state only when no `loadError`; load-error state; checkbox hidden when `!canManage`; checkbox has an accessible name; optimistic removal on toggle success; rollback + toast on toggle failure (mock `toggleEventChecklistTask`).
+- Include at least one fixture item from a draft event to prove the widget does not silently filter by event status.
+
+## Risks & rollback
+
+- **Risk:** the right rail narrows the calendar/list view on mid-width screens. Mitigated by the `xl` breakpoint (rail only sits beside content on wide screens; stacks below otherwise).
+- **Risk:** the rail may be dominated by draft events because `getChecklistTodos()` includes all current/future event statuses. This is accepted for this implementation because it preserves the existing `/events/todo` dataset.
+- **Risk:** stale task keys exist in historical checklist status rows and one auto-close migration. Mitigated by deriving display rows only from current `EVENT_CHECKLIST_DEFINITIONS`.
+- **Risk:** sticky positioning interaction with the flex row. Verify during implementation in-browser.
+- **Rollback:** the change is additive and isolated to `page.tsx` (wrapper) + one new component. Reverting the `page.tsx` wrapper restores the original single-column page; `EventsClient`, `getChecklistTodos`, and `/events/todo` are untouched.
+
+## Files
+
+- **Modify:** `src/app/(authenticated)/events/page.tsx` — add `getChecklistTodos()` + `canManage` to the fetch, pass `loadError`, wrap content in the two-column row, render `EventTodosWidget`.
+- **Create:** `src/app/(authenticated)/events/_components/EventTodosWidget.tsx`.
+- **Create:** `src/app/(authenticated)/events/_components/eventTodosWidget.helpers.ts` (+ co-located test).

--- a/src/app/(authenticated)/error.tsx
+++ b/src/app/(authenticated)/error.tsx
@@ -58,7 +58,7 @@ export default function AuthenticatedError({
       <button
         type="button"
         onClick={reset}
-        className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
+        className="px-4 py-2 bg-primary text-primary-fg rounded-md hover:bg-primary/90"
       >
         Try again
       </button>

--- a/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
+++ b/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+
+vi.mock('@/app/actions/event-checklist', () => ({
+  toggleEventChecklistTask: vi.fn(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={typeof href === 'string' ? href : '#'} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+// Full, lightweight mock of the design-system barrel so the test does not load the heavy shell.
+vi.mock('@/ds', async () => {
+  const React = await import('react')
+  return {
+    Card: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+    CardHeader: ({ title, subtitle }: { title?: string; subtitle?: string }) =>
+      React.createElement('div', null, title, subtitle ? React.createElement('p', null, subtitle) : null),
+    CardBody: ({ children }: { children: React.ReactNode }) => React.createElement('div', null, children),
+    Badge: ({ tone, children }: { tone?: string; children: React.ReactNode }) =>
+      React.createElement('span', { 'data-tone': tone }, children),
+    Checkbox: ({
+      onChange,
+      checked,
+      ...rest
+    }: {
+      onChange?: (v: boolean) => void
+      checked?: boolean
+      'aria-label'?: string
+    }) =>
+      React.createElement('button', {
+        type: 'button',
+        role: 'checkbox',
+        'aria-checked': Boolean(checked),
+        'aria-label': rest['aria-label'],
+        onClick: () => onChange?.(!checked),
+      }),
+    toast: { error: vi.fn(), success: vi.fn() },
+  }
+})
+
+import EventTodosWidget from './EventTodosWidget'
+import { toggleEventChecklistTask } from '@/app/actions/event-checklist'
+import { toast } from '@/ds'
+
+const mockToggle = vi.mocked(toggleEventChecklistTask)
+const TODAY = '2026-05-21'
+
+function makeItem(overrides: Partial<ChecklistTodoItem> = {}): ChecklistTodoItem {
+  return {
+    key: 'write_event_brief',
+    label: 'Write event brief',
+    offsetDays: -28,
+    channel: 'Admin',
+    required: true,
+    order: 1,
+    eventId: 'evt-1',
+    dueDate: '2026-05-18',
+    dueDateFormatted: '18 May 2026',
+    completed: false,
+    completedAt: null,
+    status: 'overdue',
+    eventName: 'Draft Quiz Night',
+    eventDate: '2026-06-15',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('EventTodosWidget', () => {
+  it('renders todos in the order received with correct urgency tone, including draft-event items', () => {
+    const items = [
+      makeItem({ key: 'a', label: 'Alpha task', status: 'overdue', dueDate: '2026-05-18', eventName: 'Draft Quiz Night' }),
+      makeItem({ key: 'b', label: 'Beta task', status: 'due_today', dueDate: '2026-05-21', eventName: 'Scheduled Gig' }),
+    ]
+    render(<EventTodosWidget initialTodos={items} canManage todayIso={TODAY} />)
+
+    const labels = screen.getAllByText(/ task$/).map((el) => el.textContent)
+    expect(labels).toEqual(['Alpha task', 'Beta task'])
+
+    expect(screen.getByText('Overdue by 3d')).toHaveAttribute('data-tone', 'danger')
+    expect(screen.getByText('Due today')).toHaveAttribute('data-tone', 'warning')
+    // Draft-event item is shown (widget must not filter by event_status).
+    expect(screen.getByText('Draft Quiz Night')).toBeInTheDocument()
+  })
+
+  it('shows the caught-up empty state when there are no todos and no error', () => {
+    render(<EventTodosWidget initialTodos={[]} canManage todayIso={TODAY} />)
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument()
+  })
+
+  it('shows a load-error state instead of the caught-up state when loadError is set', () => {
+    render(<EventTodosWidget initialTodos={[]} canManage todayIso={TODAY} loadError="boom" />)
+    expect(screen.getByText(/could not be loaded/i)).toBeInTheDocument()
+    expect(screen.queryByText(/all caught up/i)).not.toBeInTheDocument()
+  })
+
+  it('hides checkboxes when the user cannot manage', () => {
+    render(<EventTodosWidget initialTodos={[makeItem()]} canManage={false} todayIso={TODAY} />)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+  })
+
+  it('gives each checkbox an accessible name', () => {
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    expect(
+      screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }),
+    ).toBeInTheDocument()
+  })
+
+  it('optimistically removes a todo on successful completion', async () => {
+    mockToggle.mockResolvedValue({ success: true })
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+
+    await waitFor(() => expect(screen.queryByText('Write event brief')).not.toBeInTheDocument())
+    expect(mockToggle).toHaveBeenCalledWith('evt-1', 'write_event_brief', true)
+  })
+
+  it('restores the todo and shows a toast when completion fails', async () => {
+    mockToggle.mockResolvedValue({ success: false, error: 'nope' })
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('nope'))
+    expect(screen.getByText('Write event brief')).toBeInTheDocument()
+  })
+})

--- a/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
+++ b/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
@@ -137,4 +137,41 @@ describe('EventTodosWidget', () => {
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('nope'))
     expect(screen.getByText('Write event brief')).toBeInTheDocument()
   })
+
+  it('restores the todo and shows a toast when the action throws/rejects', async () => {
+    mockToggle.mockRejectedValue(new Error('network'))
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled())
+    expect(screen.getByText('Write event brief')).toBeInTheDocument()
+  })
+
+  it('restores only the failed item when an earlier completion fails after a later one succeeds', async () => {
+    let rejectFirst!: (reason?: unknown) => void
+    const firstPromise = new Promise<{ success: boolean; error?: string }>((_resolve, reject) => {
+      rejectFirst = reject
+    })
+    mockToggle.mockImplementation((_eventId: string, key: string) =>
+      key === 'first' ? firstPromise : Promise.resolve({ success: true }),
+    )
+    const items = [
+      makeItem({ key: 'first', label: 'First task', dueDate: '2026-05-18' }),
+      makeItem({ key: 'second', label: 'Second task', dueDate: '2026-05-19' }),
+    ]
+    const user = userEvent.setup()
+    render(<EventTodosWidget initialTodos={items} canManage todayIso={TODAY} />)
+
+    // Begin completing "first" (request stays pending), then complete "second" (succeeds).
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "First task" complete' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Second task" complete' }))
+    await waitFor(() => expect(screen.queryByText('Second task')).not.toBeInTheDocument())
+
+    // Now fail "first": only it should be restored; "second" must stay removed.
+    rejectFirst(new Error('network'))
+    await waitFor(() => expect(screen.getByText('First task')).toBeInTheDocument())
+    expect(screen.queryByText('Second task')).not.toBeInTheDocument()
+  })
 })

--- a/src/app/(authenticated)/events/_components/EventTodosWidget.tsx
+++ b/src/app/(authenticated)/events/_components/EventTodosWidget.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import Link from 'next/link'
+import { Card, CardHeader, CardBody, Checkbox, Badge, toast } from '@/ds'
+import { cn } from '@/lib/utils'
+import { toggleEventChecklistTask } from '@/app/actions/event-checklist'
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+import { formatRelativeDue, summariseTodos, formatSummaryLine } from './eventTodosWidget.helpers'
+
+interface EventTodosWidgetProps {
+  initialTodos: ChecklistTodoItem[]
+  canManage: boolean
+  todayIso: string
+  loadError?: string | null
+}
+
+export default function EventTodosWidget({
+  initialTodos,
+  canManage,
+  todayIso,
+  loadError = null,
+}: EventTodosWidgetProps) {
+  const [todos, setTodos] = useState<ChecklistTodoItem[]>(initialTodos)
+  const [isPending, startTransition] = useTransition()
+
+  function handleComplete(item: ChecklistTodoItem) {
+    const snapshot = todos
+    setTodos((prev) => prev.filter((t) => !(t.eventId === item.eventId && t.key === item.key)))
+    startTransition(async () => {
+      const result = await toggleEventChecklistTask(item.eventId, item.key, true)
+      if (!result.success) {
+        setTodos(snapshot)
+        toast.error(result.error ?? 'Could not update todo')
+      }
+    })
+  }
+
+  const summary = formatSummaryLine(summariseTodos(todos))
+
+  return (
+    <div className="xl:sticky xl:top-6">
+      <Card>
+        <CardHeader
+          title="Outstanding Todos"
+          subtitle={!loadError && todos.length > 0 ? summary : undefined}
+        />
+        <CardBody className="max-h-96 xl:max-h-[calc(100vh-7rem)] overflow-y-auto">
+          {loadError ? (
+            <p className="py-6 text-center text-sm text-text-muted">
+              Outstanding todos could not be loaded.
+            </p>
+          ) : todos.length === 0 ? (
+            <p className="py-6 text-center text-sm text-text-muted">
+              You&apos;re all caught up — no outstanding todos.
+            </p>
+          ) : (
+            <ul className={cn('flex flex-col gap-1', isPending && 'opacity-60')}>
+              {todos.map((item) => (
+                <li
+                  key={`${item.eventId}:${item.key}`}
+                  className={cn(
+                    'flex items-start gap-2 border-l-4 pl-3 py-2',
+                    item.status === 'overdue' ? 'border-danger' : 'border-warning',
+                  )}
+                >
+                  {canManage && (
+                    <Checkbox
+                      aria-label={`Mark "${item.label}" complete`}
+                      checked={false}
+                      onChange={() => handleComplete(item)}
+                    />
+                  )}
+                  <Link href={`/events/${item.eventId}`} className="group block min-w-0 flex-1">
+                    <span className="block truncate text-sm text-text group-hover:underline">
+                      {item.label}
+                    </span>
+                    <span className="mt-1 flex flex-wrap items-center gap-2">
+                      <span className="max-w-[10rem] truncate text-xs text-text-muted">
+                        {item.eventName}
+                      </span>
+                      <Badge tone={item.status === 'overdue' ? 'danger' : 'warning'}>
+                        {formatRelativeDue(item.dueDate, todayIso)}
+                      </Badge>
+                      <span className="text-xs text-text-subtle">{item.channel}</span>
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardBody>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/(authenticated)/events/_components/EventTodosWidget.tsx
+++ b/src/app/(authenticated)/events/_components/EventTodosWidget.tsx
@@ -25,13 +25,24 @@ export default function EventTodosWidget({
   const [isPending, startTransition] = useTransition()
 
   function handleComplete(item: ChecklistTodoItem) {
-    const snapshot = todos
     setTodos((prev) => prev.filter((t) => !(t.eventId === item.eventId && t.key === item.key)))
+    // Restore only this item (functional + re-sorted) so an overlapping completion isn't resurrected.
+    const restore = () =>
+      setTodos((prev) =>
+        prev.some((t) => t.eventId === item.eventId && t.key === item.key)
+          ? prev
+          : [...prev, item].sort((a, b) => a.dueDate.localeCompare(b.dueDate) || a.order - b.order),
+      )
     startTransition(async () => {
-      const result = await toggleEventChecklistTask(item.eventId, item.key, true)
-      if (!result.success) {
-        setTodos(snapshot)
-        toast.error(result.error ?? 'Could not update todo')
+      try {
+        const result = await toggleEventChecklistTask(item.eventId, item.key, true)
+        if (!result.success) {
+          restore()
+          toast.error(result.error ?? 'Could not update todo')
+        }
+      } catch {
+        restore()
+        toast.error('Could not update todo')
       }
     })
   }

--- a/src/app/(authenticated)/events/_components/eventTodosWidget.helpers.test.ts
+++ b/src/app/(authenticated)/events/_components/eventTodosWidget.helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import {
+  daysBetweenIso,
+  formatRelativeDue,
+  summariseTodos,
+  formatSummaryLine,
+} from './eventTodosWidget.helpers'
+
+describe('daysBetweenIso', () => {
+  it('counts whole days between ISO dates regardless of local timezone', () => {
+    expect(daysBetweenIso('2026-05-18', '2026-05-21')).toBe(3)
+    expect(daysBetweenIso('2026-05-21', '2026-05-21')).toBe(0)
+  })
+})
+
+describe('formatRelativeDue', () => {
+  it('labels overdue items by day count', () => {
+    expect(formatRelativeDue('2026-05-18', '2026-05-21')).toBe('Overdue by 3d')
+  })
+  it('labels due-today items', () => {
+    expect(formatRelativeDue('2026-05-21', '2026-05-21')).toBe('Due today')
+  })
+  it('labels future items', () => {
+    expect(formatRelativeDue('2026-05-26', '2026-05-21')).toBe('Due in 5d')
+  })
+})
+
+describe('summariseTodos', () => {
+  it('counts by status', () => {
+    expect(
+      summariseTodos([{ status: 'overdue' }, { status: 'overdue' }, { status: 'due_today' }]),
+    ).toEqual({ overdue: 2, dueToday: 1 })
+  })
+  it('handles empty input', () => {
+    expect(summariseTodos([])).toEqual({ overdue: 0, dueToday: 0 })
+  })
+})
+
+describe('formatSummaryLine', () => {
+  it('joins non-zero parts', () => {
+    expect(formatSummaryLine({ overdue: 3, dueToday: 2 })).toBe('3 overdue · 2 due today')
+  })
+  it('omits zero parts', () => {
+    expect(formatSummaryLine({ overdue: 0, dueToday: 2 })).toBe('2 due today')
+  })
+})

--- a/src/app/(authenticated)/events/_components/eventTodosWidget.helpers.ts
+++ b/src/app/(authenticated)/events/_components/eventTodosWidget.helpers.ts
@@ -1,0 +1,40 @@
+import type { ChecklistTodoItem } from '@/lib/event-checklist'
+
+const MS_PER_DAY = 86_400_000
+
+/** Whole-day difference (toIso - fromIso) using UTC-anchored ISO dates — deterministic and timezone-safe. */
+export function daysBetweenIso(fromIso: string, toIso: string): number {
+  const from = Date.parse(`${fromIso}T00:00:00Z`)
+  const to = Date.parse(`${toIso}T00:00:00Z`)
+  return Math.round((to - from) / MS_PER_DAY)
+}
+
+/** Human relative-due label for a todo's due date relative to today. */
+export function formatRelativeDue(dueDate: string, todayIso: string): string {
+  const overdueBy = daysBetweenIso(dueDate, todayIso) // positive => overdue
+  if (overdueBy > 0) return `Overdue by ${overdueBy}d`
+  if (overdueBy === 0) return 'Due today'
+  return `Due in ${-overdueBy}d`
+}
+
+export interface TodoCounts {
+  overdue: number
+  dueToday: number
+}
+
+export function summariseTodos(items: Pick<ChecklistTodoItem, 'status'>[]): TodoCounts {
+  let overdue = 0
+  let dueToday = 0
+  for (const item of items) {
+    if (item.status === 'overdue') overdue += 1
+    else if (item.status === 'due_today') dueToday += 1
+  }
+  return { overdue, dueToday }
+}
+
+export function formatSummaryLine(counts: TodoCounts): string {
+  const parts: string[] = []
+  if (counts.overdue > 0) parts.push(`${counts.overdue} overdue`)
+  if (counts.dueToday > 0) parts.push(`${counts.dueToday} due today`)
+  return parts.join(' · ')
+}

--- a/src/app/(authenticated)/events/page.tsx
+++ b/src/app/(authenticated)/events/page.tsx
@@ -5,9 +5,11 @@ import { getActiveEventCategories } from '@/app/actions/event-categories'
 import { fetchPrivateBookingsForCalendar } from '@/app/actions/private-bookings-dashboard'
 import { listCalendarNotes } from '@/app/actions/calendar-notes'
 import { listParkingBookings } from '@/app/actions/parking'
+import { getChecklistTodos } from '@/app/actions/event-checklist'
 import { getTodayIsoDate } from '@/lib/dateUtils'
 import type { VenueCalendarBooking, VenueCalendarParking } from '@/components/schedule-calendar'
 import EventsClient from './_components/EventsClient'
+import EventTodosWidget from './_components/EventTodosWidget'
 
 export const metadata = {
   title: 'Events',
@@ -20,26 +22,49 @@ export default async function EventsPage() {
     redirect('/unauthorized')
   }
 
-  const [eventsResult, categoriesResult, calEventsResult, bookingsResult, notesResult, parkingResult] = await Promise.all([
+  const [
+    eventsResult,
+    categoriesResult,
+    calEventsResult,
+    bookingsResult,
+    notesResult,
+    parkingResult,
+    todosResult,
+    canManageEvents,
+  ] = await Promise.all([
     getEvents({ status: 'all', dateFrom: getTodayIsoDate(), page: 1, pageSize: 25 }),
     getActiveEventCategories(),
     getEvents({ status: 'all', page: 1, pageSize: 500 }),
     fetchPrivateBookingsForCalendar(),
     listCalendarNotes(),
     listParkingBookings({ limit: 500 }),
+    getChecklistTodos(),
+    checkUserPermission('events', 'manage'),
   ])
 
   return (
     <div className="p-6">
-      <EventsClient
-        initialEvents={eventsResult.data ?? []}
-        initialPagination={eventsResult.pagination}
-        categories={categoriesResult.data ?? []}
-        initialCalendarEvents={calEventsResult.data ?? []}
-        initialCalendarBookings={'data' in bookingsResult && bookingsResult.data ? bookingsResult.data as VenueCalendarBooking[] : []}
-        initialCalendarNotes={notesResult.data ?? []}
-        initialCalendarParking={'data' in parkingResult && parkingResult.data ? parkingResult.data as VenueCalendarParking[] : []}
-      />
+      <div className="flex flex-col gap-6 xl:flex-row">
+        <div className="min-w-0 flex-1">
+          <EventsClient
+            initialEvents={eventsResult.data ?? []}
+            initialPagination={eventsResult.pagination}
+            categories={categoriesResult.data ?? []}
+            initialCalendarEvents={calEventsResult.data ?? []}
+            initialCalendarBookings={'data' in bookingsResult && bookingsResult.data ? bookingsResult.data as VenueCalendarBooking[] : []}
+            initialCalendarNotes={notesResult.data ?? []}
+            initialCalendarParking={'data' in parkingResult && parkingResult.data ? parkingResult.data as VenueCalendarParking[] : []}
+          />
+        </div>
+        <aside className="xl:w-80 xl:shrink-0">
+          <EventTodosWidget
+            initialTodos={todosResult.items ?? []}
+            canManage={canManageEvents}
+            todayIso={getTodayIsoDate()}
+            loadError={todosResult.success ? null : todosResult.error ?? 'Unable to load outstanding todos'}
+          />
+        </aside>
+      </div>
     </div>
   )
 }

--- a/src/app/(authenticated)/events/page.tsx
+++ b/src/app/(authenticated)/events/page.tsx
@@ -38,7 +38,12 @@ export default async function EventsPage() {
     fetchPrivateBookingsForCalendar(),
     listCalendarNotes(),
     listParkingBookings({ limit: 500 }),
-    getChecklistTodos(),
+    getChecklistTodos().catch(
+      () =>
+        ({ success: false, error: 'Unable to load outstanding todos' }) as Awaited<
+          ReturnType<typeof getChecklistTodos>
+        >,
+    ),
     checkUserPermission('events', 'manage'),
   ])
 

--- a/src/components/schedule-calendar/ScheduleCalendarMonth.tsx
+++ b/src/components/schedule-calendar/ScheduleCalendarMonth.tsx
@@ -166,7 +166,7 @@ export function ScheduleCalendarMonth({
                                             className={cn(
                                                 'text-xs font-medium rounded-full h-5 min-w-5 px-1.5 text-left',
                                                 isToday(day) &&
-                                                    'bg-primary text-primary-foreground text-center font-semibold'
+                                                    'bg-primary text-primary-fg text-center font-semibold'
                                             )}
                                             onClick={(ev) => {
                                                 if (ev.target === ev.currentTarget && onEmptyDayClick) {

--- a/tasks/codex-qa-review/events-todos-rail/2026-05-21-events-todos-rail-adversarial-review.md
+++ b/tasks/codex-qa-review/events-todos-rail/2026-05-21-events-todos-rail-adversarial-review.md
@@ -1,0 +1,36 @@
+# Adversarial Review: Events Outstanding-Todos Rail
+
+**Date:** 2026-05-21
+**Mode:** B (Code Review)
+**Scope:** `main...HEAD` committed diff — 7 files (EventTodosWidget + helpers + tests, events/page.tsx, ScheduleCalendarMonth.tsx, error.tsx)
+**Pack:** `tasks/codex-qa-review/events-todos-rail/2026-05-21-events-todos-rail-review-pack.md`
+**Reviewers:** assumption-breaker, integration-architecture, workflow-failure-path (Codex 0.125.0)
+
+## Executive Summary
+The feature is close to solid. Server/client split, RBAC prop flow, page-level `events:view` guard, UTC-anchored date helpers, and load-error precedence are all sound. Two real unhappy-path gaps need fixing before this is production-robust: (1) optimistic completion does not handle a thrown/rejected server action and can corrupt state under concurrent completions, and (2) a thrown todos-load failure bypasses the load-error state and can crash the whole Events page.
+
+## What Appears Solid (do not rewrite)
+- Server Component fetches data; only serializable props cross into the client widget.
+- `events:view` page guard retained; `canManage` fetched server-side and only gates UI.
+- `loadError` takes precedence over the caught-up empty state.
+- UTC-anchored ISO date arithmetic in helpers (no DST/local drift).
+- Draft-event visibility intentionally preserved and test-encoded.
+
+## Implementation Defects
+- **[Medium, blocking] Thrown/rejected completion unhandled** (`EventTodosWidget.tsx` `handleComplete`). `await toggleEventChecklistTask` is not wrapped in try/catch; only `{success:false}` is handled. A network/runtime rejection leaves the row optimistically removed with no rollback and no toast — UI falsely shows "completed". (AB-001, WF-002)
+- **[Medium, blocking] Concurrent-completion snapshot corruption** (`handleComplete`). Restoring the full captured `snapshot` on failure can re-add an item that a later, overlapping completion already succeeded in removing. Checkboxes remain interactive while pending, so this is reachable during fast multi-item processing. (AB-003, ARCH-001, WF-001)
+
+## Architecture & Integration Defects
+- **[Medium, blocking] Non-critical rail can crash the page** (`events/page.tsx`). `getChecklistTodos()` is awaited raw inside `Promise.all`; a thrown (vs returned) failure rejects the whole `Promise.all`, so the rail's `loadError` degradation never runs and the entire Events page errors. (AB-002)
+
+## Unproven Assumptions (resolved by Claude)
+- **AB-005** — server-side `events:manage` enforcement on `toggleEventChecklistTask`: **CONFIRMED present** in `src/app/actions/event-checklist.ts` (`checkUserPermission('events','manage')` before mutation). Not a defect.
+- **AB-004** — summary ignoring upcoming statuses: **N/A** — `getChecklistTodos()` returns only `overdue`/`due_today` by design (`EventChecklistService.getChecklistTodos` filter). Subtitle is correct.
+
+## Recommended Fix Order
+1. Harden `handleComplete`: wrap in try/catch; on any failure restore **only the failed item** via a functional update (re-sorted by `dueDate` then `order`), not the full snapshot.
+2. Make the rail non-critical in `page.tsx`: `getChecklistTodos().catch(() => ({ success:false, error:'Unable to load outstanding todos' }))`.
+3. Add regression tests: thrown rejection → restore + toast; concurrent completion where the earlier call fails after the later succeeds → only the failed item returns.
+
+## Minor Observations
+- `formatRelativeDue` retains a "Due in Nd" branch that the current data contract never hits — harmless defensive code, leave as-is.

--- a/tasks/codex-qa-review/events-todos-rail/2026-05-21-events-todos-rail-claude-handoff.md
+++ b/tasks/codex-qa-review/events-todos-rail/2026-05-21-events-todos-rail-claude-handoff.md
@@ -1,0 +1,28 @@
+# Claude Hand-Off Brief: Events Outstanding-Todos Rail
+
+**Generated:** 2026-05-21
+**Review mode:** B (Code Review)
+**Overall risk:** Medium (two unhappy-path gaps; happy path and architecture sound)
+
+## DO NOT REWRITE
+- Server/client split and serializable props in `events/page.tsx`.
+- `events:view` guard, `canManage` server fetch + UI gating.
+- `loadError`-over-empty precedence; UTC-anchored date helpers; draft-event visibility.
+
+## IMPLEMENTATION CHANGES REQUIRED
+- [ ] **Harden `handleComplete`** — `src/app/(authenticated)/events/_components/EventTodosWidget.tsx`: wrap the awaited `toggleEventChecklistTask` in try/catch; on returned-failure **and** on throw, restore **only the failed item** via a functional `setTodos` update re-sorted by `dueDate` then `order` (guarded against duplicate re-insert), and show an error toast. Removes both the rejection gap and the concurrent-snapshot corruption.
+- [ ] **Make the rail non-critical** — `src/app/(authenticated)/events/page.tsx`: `getChecklistTodos().catch(() => ({ success: false, error: 'Unable to load outstanding todos' }) as Awaited<ReturnType<typeof getChecklistTodos>>)` so a thrown load failure degrades to the `loadError` state instead of crashing the page.
+
+## ASSUMPTIONS RESOLVED (no action)
+- Server-side `events:manage` enforcement on `toggleEventChecklistTask`: confirmed present.
+- Summary scope: `getChecklistTodos()` returns only overdue/due-today by design.
+
+## REPO CONVENTIONS TO PRESERVE
+- Server actions return `{ success?: boolean; error?: string }`; surface errors via `@/ds` `toast`.
+- No direct DB access from client components; mutations stay behind the server action.
+
+## RE-REVIEW REQUIRED AFTER FIXES
+- [ ] Re-run the widget test suite (add: thrown-rejection restore+toast; concurrent earlier-fail-after-later-success → only failed item restored).
+
+## REVISION PROMPT
+In `EventTodosWidget.tsx`, rewrite `handleComplete` to optimistically remove the item, then in a try/catch around `toggleEventChecklistTask`, on failure or throw re-insert only that item via a functional update sorted by `dueDate`/`order` and toast the error. In `events/page.tsx`, add `.catch(...)` to the `getChecklistTodos()` call in `Promise.all` to degrade to `loadError`. Add the two regression tests, then run `npx vitest run` on the two test files, `npx tsc --noEmit`, and `npx eslint` on the changed files.


### PR DESCRIPTION
## Summary
- Adds a sticky right-hand **Outstanding Todos** rail to `/events`: one flat, chronologically-sorted list of overdue + due-today checklist todos, with red/amber urgency (border + badge + relative-due text), per-event links, and optimistic in-place completion (manager-gated, read-only otherwise). `EventsClient` and `/events/todo` are untouched.
- Fixes the calendar **today date-number** (and the error-page retry button) to use the real `text-primary-fg` token — a legacy `text-primary-foreground` class was never wired into the Tailwind v4 `@theme`, so the text rendered dark on green. Now white.
- Includes a Codex adversarial review and the hardening it surfaced: try/catch + single-item restore on completion failure (handles thrown actions + concurrent completions), and a non-critical rail load (`getChecklistTodos().catch(...)` degrades to a load-error state instead of crashing the page).

## Why
Staff wanted an at-a-glance, consolidated list of the event checklist tasks that need action now, visible while working the events page, with urgency obvious.

## Test plan
- [x] `tsc --noEmit` 0 errors · ESLint clean · 17 unit tests · production build succeeds
- [x] Verified live on the authenticated `/events`: 40 todos, header "38 overdue · 2 due today", red overdue / amber due-today borders, manager checkboxes present, today-marker white

## Complexity
S (2) — one new client component + a page wrapper; no schema or data-layer changes (reuses existing `getChecklistTodos`).

## Breaking changes
None.

## Migration risk
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)