### PR TITLE
Guard table booking capacity updates

### DIFF
--- a/src/app/(authenticated)/table-bookings/foh/utils.ts
+++ b/src/app/(authenticated)/table-bookings/foh/utils.ts
@@ -245,6 +245,8 @@ export function mapFohEventBlockedReason(reason?: string | null): string {
   switch (reason) {
     case 'insufficient_capacity':
       return 'This event is full for the requested seats.'
+    case 'table_capacity_insufficient':
+      return 'The assigned table is too small for that party size. Move the booking to a larger table first.'
     case 'booking_closed':
       return 'Booking is closed for this event.'
     case 'not_bookable':

--- a/src/app/g/[token]/manage-booking/page.tsx
+++ b/src/app/g/[token]/manage-booking/page.tsx
@@ -50,6 +50,8 @@ function blockedReasonMessage(reason: string | undefined): string {
       return 'This event has already started, so online changes are closed.'
     case 'insufficient_capacity':
       return 'No more seats are available for that increase.'
+    case 'table_capacity_insufficient':
+      return 'Your assigned table is not large enough for that increase. Please contact the venue and we will move you if space is available.'
     case 'invalid_target_seats':
       return 'Please enter a seat count larger than your current booking.'
     case 'booking_not_confirmed':

--- a/src/lib/events/staff-seat-updates.ts
+++ b/src/lib/events/staff-seat-updates.ts
@@ -49,6 +49,29 @@ function normalizeThrownSmsSafety(error: unknown): { code: string; logFailure: b
   }
 }
 
+async function getAssignedTableCapacity(
+  supabase: SupabaseClient<any, 'public', any>,
+  tableBookingId: string
+): Promise<number | null> {
+  const { data, error } = await supabase.from('booking_table_assignments')
+    .select('table_id, tables(capacity)')
+    .eq('table_booking_id', tableBookingId)
+
+  if (error) {
+    throw error
+  }
+
+  const rows = Array.isArray(data) ? data : []
+  if (rows.length === 0) {
+    return null
+  }
+
+  return rows.reduce((sum, row) => {
+    const table = Array.isArray(row?.tables) ? row.tables[0] : row?.tables
+    return sum + Math.max(0, Number(table?.capacity || 0))
+  }, 0)
+}
+
 export function mapSeatUpdateBlockedReason(reason: string | null | undefined): string {
   switch (reason) {
     case 'invalid_seats':
@@ -59,6 +82,8 @@ export function mapSeatUpdateBlockedReason(reason: string | null | undefined): s
       return 'This event has already started.'
     case 'insufficient_capacity':
       return 'There are not enough seats available for that increase.'
+    case 'table_capacity_insufficient':
+      return 'The assigned table is too small for that party size. Move the booking to a larger table first.'
     case 'booking_not_found':
       return 'Booking was not found.'
     case 'event_not_found':
@@ -128,6 +153,24 @@ export async function updateTableBookingPartySizeWithLinkedEventSeats(
         sms_sent: false,
         sms: null,
         event_id: tableBooking.event_id || null
+      }
+    }
+
+    if (newPartySize > oldPartySize) {
+      const assignedCapacity = await getAssignedTableCapacity(supabase, tableBooking.id)
+      if (assignedCapacity !== null && assignedCapacity < newPartySize) {
+        return {
+          state: 'blocked',
+          reason: 'table_capacity_insufficient',
+          table_booking_id: tableBooking.id,
+          event_booking_id: null,
+          old_party_size: oldPartySize,
+          new_party_size: oldPartySize,
+          delta: 0,
+          sms_sent: false,
+          sms: null,
+          event_id: tableBooking.event_id || null
+        }
       }
     }
 

--- a/supabase/migrations/20260708000000_guard_linked_event_table_capacity.sql
+++ b/supabase/migrations/20260708000000_guard_linked_event_table_capacity.sql
@@ -1,0 +1,514 @@
+-- Prevent linked event/table booking seat updates from leaving a booking assigned
+-- to tables with insufficient physical capacity.
+
+CREATE OR REPLACE FUNCTION public.table_booking_assigned_capacity_v01(
+  p_table_booking_id uuid
+)
+RETURNS TABLE (
+  assignment_count integer,
+  assigned_capacity integer
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    COUNT(bta.table_id)::integer AS assignment_count,
+    COALESCE(SUM(GREATEST(COALESCE(t.capacity, 0), 0)), 0)::integer AS assigned_capacity
+  FROM public.booking_table_assignments bta
+  LEFT JOIN public.tables t ON t.id = bta.table_id
+  WHERE bta.table_booking_id = p_table_booking_id;
+$$;
+
+CREATE OR REPLACE FUNCTION public.table_booking_assignment_capacity_ok_v01(
+  p_table_booking_id uuid,
+  p_party_size integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_booking RECORD;
+  v_capacity RECORD;
+BEGIN
+  IF p_table_booking_id IS NULL OR p_party_size IS NULL OR p_party_size < 1 THEN
+    RETURN false;
+  END IF;
+
+  SELECT tb.id, tb.status
+  INTO v_booking
+  FROM public.table_bookings tb
+  WHERE tb.id = p_table_booking_id;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  IF v_booking.status::text IN ('cancelled', 'no_show', 'completed') THEN
+    RETURN true;
+  END IF;
+
+  SELECT *
+  INTO v_capacity
+  FROM public.table_booking_assigned_capacity_v01(p_table_booking_id);
+
+  -- Unassigned active bookings are handled by the unassigned workflow. This
+  -- guard only prevents assigned bookings from becoming over-capacity.
+  IF COALESCE(v_capacity.assignment_count, 0) = 0 THEN
+    RETURN true;
+  END IF;
+
+  RETURN COALESCE(v_capacity.assigned_capacity, 0) >= p_party_size;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.event_booking_table_capacity_ok_v01(
+  p_event_booking_id uuid,
+  p_party_size integer
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_table_booking RECORD;
+BEGIN
+  IF p_event_booking_id IS NULL OR p_party_size IS NULL OR p_party_size < 1 THEN
+    RETURN false;
+  END IF;
+
+  FOR v_table_booking IN
+    SELECT tb.id
+    FROM public.table_bookings tb
+    WHERE tb.event_booking_id = p_event_booking_id
+      AND tb.status::text NOT IN ('cancelled', 'no_show', 'completed')
+  LOOP
+    IF NOT public.table_booking_assignment_capacity_ok_v01(v_table_booking.id, p_party_size) THEN
+      RETURN false;
+    END IF;
+  END LOOP;
+
+  RETURN true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.enforce_table_booking_assignment_capacity_v01()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_capacity RECORD;
+BEGIN
+  IF TG_OP <> 'UPDATE' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.status::text IN ('cancelled', 'no_show', 'completed') THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.party_size IS NOT DISTINCT FROM OLD.party_size
+     AND NEW.status IS NOT DISTINCT FROM OLD.status THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT *
+  INTO v_capacity
+  FROM public.table_booking_assigned_capacity_v01(NEW.id);
+
+  IF COALESCE(v_capacity.assignment_count, 0) > 0
+     AND COALESCE(v_capacity.assigned_capacity, 0) < COALESCE(NEW.party_size, 0) THEN
+    RAISE EXCEPTION 'table_booking_assigned_capacity_insufficient'
+      USING
+        ERRCODE = '23514',
+        DETAIL = format(
+          'table_booking_id=%s party_size=%s assigned_capacity=%s',
+          NEW.id,
+          NEW.party_size,
+          COALESCE(v_capacity.assigned_capacity, 0)
+        );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enforce_table_booking_assignment_capacity_v01 ON public.table_bookings;
+CREATE TRIGGER trg_enforce_table_booking_assignment_capacity_v01
+  BEFORE UPDATE OF party_size, status ON public.table_bookings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_table_booking_assignment_capacity_v01();
+
+CREATE OR REPLACE FUNCTION public.update_event_booking_seats_v05(
+  p_hashed_token text,
+  p_new_seats integer,
+  p_actor text DEFAULT 'guest'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_token RECORD;
+  v_booking RECORD;
+  v_event RECORD;
+  v_event_start timestamptz;
+  v_now timestamptz := NOW();
+  v_delta integer;
+  v_capacity_snapshot RECORD;
+BEGIN
+  IF p_new_seats IS NULL OR p_new_seats < 1 THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_seats');
+  END IF;
+
+  SELECT
+    gt.customer_id,
+    gt.event_booking_id,
+    gt.expires_at
+  INTO v_token
+  FROM public.guest_tokens gt
+  WHERE gt.hashed_token = p_hashed_token
+    AND gt.action_type = 'manage'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_token');
+  END IF;
+
+  IF v_token.expires_at <= v_now THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'token_expired');
+  END IF;
+
+  IF v_token.event_booking_id IS NULL THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_not_found');
+  END IF;
+
+  SELECT
+    b.id,
+    b.customer_id,
+    b.event_id,
+    b.seats,
+    b.status,
+    b.hold_expires_at
+  INTO v_booking
+  FROM public.bookings b
+  WHERE b.id = v_token.event_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_not_found');
+  END IF;
+
+  IF v_booking.customer_id <> v_token.customer_id THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'token_customer_mismatch');
+  END IF;
+
+  IF v_booking.status NOT IN ('confirmed', 'pending_payment') THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'status_not_changeable');
+  END IF;
+
+  SELECT
+    e.id,
+    e.name,
+    e.payment_mode,
+    e.price_per_seat,
+    e.price,
+    e.start_datetime,
+    e.date,
+    e.time
+  INTO v_event
+  FROM public.events e
+  WHERE e.id = v_booking.event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_not_found');
+  END IF;
+
+  v_event_start := COALESCE(
+    v_event.start_datetime,
+    ((v_event.date::text || ' ' || v_event.time)::timestamp AT TIME ZONE 'Europe/London')
+  );
+
+  IF v_event_start IS NULL OR v_event_start <= v_now THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+  END IF;
+
+  v_delta := p_new_seats - COALESCE(v_booking.seats, 1);
+
+  IF v_delta = 0 THEN
+    RETURN jsonb_build_object(
+      'state', 'unchanged',
+      'booking_id', v_booking.id,
+      'customer_id', v_booking.customer_id,
+      'event_id', v_event.id,
+      'event_name', v_event.name,
+      'event_start_datetime', v_event_start,
+      'status', v_booking.status,
+      'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+      'price_per_seat', COALESCE(v_event.price_per_seat, v_event.price, 0),
+      'old_seats', COALESCE(v_booking.seats, 1),
+      'new_seats', COALESCE(v_booking.seats, 1),
+      'delta', 0
+    );
+  END IF;
+
+  IF v_delta > 0 THEN
+    SELECT *
+    INTO v_capacity_snapshot
+    FROM public.get_event_capacity_snapshot_v05(ARRAY[v_event.id]::uuid[])
+    LIMIT 1;
+
+    IF COALESCE(v_capacity_snapshot.seats_remaining, 0) < v_delta THEN
+      RETURN jsonb_build_object(
+        'state', 'blocked',
+        'reason', 'insufficient_capacity',
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+        'requested_increase', v_delta
+      );
+    END IF;
+
+    IF NOT public.event_booking_table_capacity_ok_v01(v_booking.id, p_new_seats) THEN
+      RETURN jsonb_build_object(
+        'state', 'blocked',
+        'reason', 'table_capacity_insufficient',
+        'requested_seats', p_new_seats
+      );
+    END IF;
+  END IF;
+
+  UPDATE public.bookings
+  SET
+    seats = p_new_seats,
+    updated_at = v_now
+  WHERE id = v_booking.id;
+
+  IF v_booking.status = 'pending_payment' THEN
+    UPDATE public.booking_holds
+    SET
+      seats_or_covers_held = p_new_seats,
+      updated_at = v_now
+    WHERE event_booking_id = v_booking.id
+      AND hold_type = 'payment_hold'
+      AND status = 'active';
+  END IF;
+
+  UPDATE public.table_bookings
+  SET
+    party_size = p_new_seats,
+    committed_party_size = p_new_seats,
+    hold_expires_at = CASE
+      WHEN v_booking.status = 'pending_payment' THEN v_booking.hold_expires_at
+      ELSE NULL
+    END,
+    updated_at = v_now
+  WHERE event_booking_id = v_booking.id
+    AND status <> 'cancelled'::public.table_booking_status;
+
+  RETURN jsonb_build_object(
+    'state', 'updated',
+    'booking_id', v_booking.id,
+    'customer_id', v_booking.customer_id,
+    'event_id', v_event.id,
+    'event_name', v_event.name,
+    'event_start_datetime', v_event_start,
+    'status', v_booking.status,
+    'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+    'price_per_seat', COALESCE(v_event.price_per_seat, v_event.price, 0),
+    'old_seats', COALESCE(v_booking.seats, 1),
+    'new_seats', p_new_seats,
+    'delta', v_delta,
+    'actor', COALESCE(NULLIF(TRIM(p_actor), ''), 'guest')
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.update_event_booking_seats_staff_v05(
+  p_booking_id uuid,
+  p_new_seats integer,
+  p_actor text DEFAULT 'staff'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_booking RECORD;
+  v_event RECORD;
+  v_event_start timestamptz;
+  v_now timestamptz := NOW();
+  v_delta integer;
+  v_capacity_snapshot RECORD;
+BEGIN
+  IF p_booking_id IS NULL THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_booking_id');
+  END IF;
+
+  IF p_new_seats IS NULL OR p_new_seats < 1 THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_seats');
+  END IF;
+
+  SELECT
+    b.id,
+    b.customer_id,
+    b.event_id,
+    b.seats,
+    b.status,
+    b.hold_expires_at
+  INTO v_booking
+  FROM public.bookings b
+  WHERE b.id = p_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_not_found');
+  END IF;
+
+  IF v_booking.status NOT IN ('confirmed', 'pending_payment') THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'status_not_changeable');
+  END IF;
+
+  SELECT
+    e.id,
+    e.name,
+    e.capacity,
+    e.payment_mode,
+    e.price_per_seat,
+    e.price,
+    e.start_datetime,
+    e.date,
+    e.time
+  INTO v_event
+  FROM public.events e
+  WHERE e.id = v_booking.event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_not_found');
+  END IF;
+
+  v_event_start := COALESCE(
+    v_event.start_datetime,
+    ((v_event.date::text || ' ' || v_event.time)::timestamp AT TIME ZONE 'Europe/London')
+  );
+
+  IF v_event_start IS NULL OR v_event_start <= v_now THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+  END IF;
+
+  v_delta := p_new_seats - COALESCE(v_booking.seats, 1);
+
+  IF v_delta = 0 THEN
+    RETURN jsonb_build_object(
+      'state', 'unchanged',
+      'booking_id', v_booking.id,
+      'customer_id', v_booking.customer_id,
+      'event_id', v_event.id,
+      'event_name', v_event.name,
+      'event_start_datetime', v_event_start,
+      'status', v_booking.status,
+      'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+      'price_per_seat', COALESCE(v_event.price_per_seat, v_event.price, 0),
+      'old_seats', COALESCE(v_booking.seats, 1),
+      'new_seats', COALESCE(v_booking.seats, 1),
+      'delta', 0
+    );
+  END IF;
+
+  IF v_delta > 0 THEN
+    SELECT *
+    INTO v_capacity_snapshot
+    FROM public.get_event_capacity_snapshot_v05(ARRAY[v_event.id]::uuid[])
+    LIMIT 1;
+
+    IF v_event.capacity IS NOT NULL
+       AND (v_capacity_snapshot.seats_remaining IS NULL OR v_capacity_snapshot.seats_remaining < v_delta) THEN
+      RETURN jsonb_build_object(
+        'state', 'blocked',
+        'reason', 'insufficient_capacity',
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+        'requested_increase', v_delta
+      );
+    END IF;
+
+    IF NOT public.event_booking_table_capacity_ok_v01(v_booking.id, p_new_seats) THEN
+      RETURN jsonb_build_object(
+        'state', 'blocked',
+        'reason', 'table_capacity_insufficient',
+        'requested_seats', p_new_seats
+      );
+    END IF;
+  END IF;
+
+  UPDATE public.bookings
+  SET
+    seats = p_new_seats,
+    updated_at = v_now
+  WHERE id = v_booking.id;
+
+  IF v_booking.status = 'pending_payment' THEN
+    UPDATE public.booking_holds
+    SET
+      seats_or_covers_held = p_new_seats,
+      updated_at = v_now
+    WHERE event_booking_id = v_booking.id
+      AND hold_type = 'payment_hold'
+      AND status = 'active';
+  END IF;
+
+  UPDATE public.table_bookings
+  SET
+    party_size = p_new_seats,
+    committed_party_size = p_new_seats,
+    hold_expires_at = CASE
+      WHEN v_booking.status = 'pending_payment' THEN v_booking.hold_expires_at
+      ELSE NULL
+    END,
+    updated_at = v_now
+  WHERE event_booking_id = v_booking.id
+    AND status <> 'cancelled'::public.table_booking_status;
+
+  RETURN jsonb_build_object(
+    'state', 'updated',
+    'booking_id', v_booking.id,
+    'customer_id', v_booking.customer_id,
+    'event_id', v_event.id,
+    'event_name', v_event.name,
+    'event_start_datetime', v_event_start,
+    'status', v_booking.status,
+    'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+    'price_per_seat', COALESCE(v_event.price_per_seat, v_event.price, 0),
+    'old_seats', COALESCE(v_booking.seats, 1),
+    'new_seats', p_new_seats,
+    'delta', v_delta,
+    'actor', COALESCE(NULLIF(TRIM(p_actor), ''), 'staff')
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.table_booking_assigned_capacity_v01(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.table_booking_assigned_capacity_v01(uuid) TO service_role;
+
+REVOKE ALL ON FUNCTION public.table_booking_assignment_capacity_ok_v01(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.table_booking_assignment_capacity_ok_v01(uuid, integer) TO service_role;
+
+REVOKE ALL ON FUNCTION public.event_booking_table_capacity_ok_v01(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.event_booking_table_capacity_ok_v01(uuid, integer) TO service_role;
+
+REVOKE ALL ON FUNCTION public.enforce_table_booking_assignment_capacity_v01() FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.update_event_booking_seats_v05(text, integer, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_event_booking_seats_v05(text, integer, text) TO service_role;
+
+REVOKE ALL ON FUNCTION public.update_event_booking_seats_staff_v05(uuid, integer, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_event_booking_seats_staff_v05(uuid, integer, text) TO service_role;

--- a/tests/lib/staffSeatUpdatesMutationGuards.test.ts
+++ b/tests/lib/staffSeatUpdatesMutationGuards.test.ts
@@ -39,12 +39,23 @@ describe('staff seat update mutation guards', () => {
     const updateEq = vi.fn().mockReturnValue({ select: updateSelect })
     const update = vi.fn().mockReturnValue({ eq: updateEq })
 
+    const assignmentEq = vi.fn().mockResolvedValue({
+      data: [],
+      error: null,
+    })
+    const assignmentSelect = vi.fn().mockReturnValue({ eq: assignmentEq })
+
     const supabase = {
       from: vi.fn((table: string) => {
         if (table === 'table_bookings') {
           return {
             select: lookupSelect,
             update,
+          }
+        }
+        if (table === 'booking_table_assignments') {
+          return {
+            select: assignmentSelect,
           }
         }
         throw new Error(`Unexpected table: ${table}`)
@@ -60,6 +71,69 @@ describe('staff seat update mutation guards', () => {
 
     expect(result.state).toBe('blocked')
     expect(result.reason).toBe('booking_not_found')
+    expect(sendEventBookingSeatUpdateSms).not.toHaveBeenCalled()
+    expect(updateEventBookingSeatsById).not.toHaveBeenCalled()
+  })
+
+  it('blocks direct table-booking party-size increases that exceed assigned table capacity', async () => {
+    const lookupMaybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'table-booking-1',
+        status: 'confirmed',
+        party_size: 2,
+        event_booking_id: null,
+        event_id: 'event-1',
+      },
+      error: null,
+    })
+    const lookupEq = vi.fn().mockReturnValue({ maybeSingle: lookupMaybeSingle })
+    const lookupSelect = vi.fn().mockReturnValue({ eq: lookupEq })
+
+    const update = vi.fn()
+
+    const assignmentEq = vi.fn().mockResolvedValue({
+      data: [
+        {
+          table_id: 'table-1',
+          tables: { capacity: 2 },
+        },
+      ],
+      error: null,
+    })
+    const assignmentSelect = vi.fn().mockReturnValue({ eq: assignmentEq })
+
+    const supabase = {
+      from: vi.fn((table: string) => {
+        if (table === 'table_bookings') {
+          return {
+            select: lookupSelect,
+            update,
+          }
+        }
+        if (table === 'booking_table_assignments') {
+          return {
+            select: assignmentSelect,
+          }
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    const result = await updateTableBookingPartySizeWithLinkedEventSeats(supabase as any, {
+      tableBookingId: 'table-booking-1',
+      partySize: 4,
+      actor: 'foh',
+      sendSms: true,
+    })
+
+    expect(result).toMatchObject({
+      state: 'blocked',
+      reason: 'table_capacity_insufficient',
+      old_party_size: 2,
+      new_party_size: 2,
+      delta: 0,
+    })
+    expect(update).not.toHaveBeenCalled()
     expect(sendEventBookingSeatUpdateSms).not.toHaveBeenCalled()
     expect(updateEventBookingSeatsById).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- add Supabase capacity guard functions and a trigger for assigned table bookings
- block linked event seat increases when assigned tables are too small
- show clearer staff and guest messages for table-capacity blocks
- add regression coverage for direct table party-size increases

## Validation
- npm run build
- npx vitest run tests/lib/staffSeatUpdatesMutationGuards.test.ts
- npx eslint src/lib/events/staff-seat-updates.ts src/app/g/[token]/manage-booking/page.tsx src/app/(authenticated)/table-bookings/foh/utils.ts tests/lib/staffSeatUpdatesMutationGuards.test.ts
- Supabase migration 20260708000000 applied remotely
