### PR TITLE
feat: capture per-ticket attendee names on event bookings

### DIFF
--- a/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
+++ b/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
@@ -1049,6 +1049,19 @@ function AttendeesTab({
                             fallback="-"
                             className="text-blue-600 hover:text-blue-700"
                           />
+                          {(() => {
+                            const attendeeNames = (booking.attendee_names ?? []).filter(
+                              (name) => typeof name === 'string' && name.trim().length > 0
+                            )
+                            if (attendeeNames.length === 0) return null
+                            return (
+                              <ol className="mt-1 list-decimal pl-4 text-xs text-gray-500">
+                                {attendeeNames.map((name, index) => (
+                                  <li key={index}>{name}</li>
+                                ))}
+                              </ol>
+                            )
+                          })()}
                         </TableCell>
                         <TableCell>{booking.customer?.mobile_number ?? '-'}</TableCell>
                         <TableCell>

--- a/src/app/actions/events.ts
+++ b/src/app/actions/events.ts
@@ -54,6 +54,7 @@ export type EventBookingRow = {
   source?: string | null
   hold_expires_at?: string | null
   event_seating_type?: 'seated' | 'standing' | null
+  attendee_names?: string[] | null
   paid_amount?: number | null
   payment_status_summary?: string | null
   payment_method_summary?: string | null
@@ -656,7 +657,7 @@ export async function getEventBookings(eventId: string): Promise<{ data?: EventB
     const supabase = createAdminClient()
     const { data, error } = await supabase
       .from('bookings')
-      .select('id, customer_id, event_id, seats, event_seating_type, is_reminder_only, notes, created_at, status, source, hold_expires_at, customer:customers(id, first_name, last_name, mobile_number, email)')
+      .select('id, customer_id, event_id, seats, event_seating_type, is_reminder_only, notes, attendee_names, created_at, status, source, hold_expires_at, customer:customers(id, first_name, last_name, mobile_number, email)')
       .eq('event_id', eventId)
       .order('created_at', { ascending: false })
 

--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -23,6 +23,7 @@ import {
   SUNDAY_LUNCH_ONLY_EVENT_MESSAGE
 } from '@/lib/events/sunday-lunch-only-policy'
 import { EventBookingService } from '@/services/event-bookings'
+import { normalizeAttendeeNames } from '@/lib/events/attendee-names'
 
 const CreateEventBookingSchema = z.object({
   event_id: z.string().uuid(),
@@ -55,6 +56,9 @@ const CreateEventBookingSchema = z.object({
   event_value: z.number().min(0).optional(),
   food_intent: z.string().trim().min(1).max(80).optional(),
   communication_consent: OptionalCommunicationConsentSchema,
+  // Per-ticket attendee names (ordered; index 0 = lead booker). Basic shape
+  // guard only — the count-vs-seats rule is enforced by normalizeAttendeeNames.
+  attendee_names: z.array(z.string().max(200)).max(20).optional(),
 })
 
 const ATTRIBUTION_KEYS = [
@@ -123,6 +127,14 @@ export async function POST(request: NextRequest) {
       return createErrorResponse('Please enter a valid phone number', 'VALIDATION_ERROR', 400)
     }
 
+    // Per-ticket attendee names are optional here (the website enforces them for
+    // paid events); when provided, they must be non-empty and match the seat count.
+    const attendeeNamesResult = normalizeAttendeeNames(parsed.data.attendee_names, parsed.data.seats)
+    if (!attendeeNamesResult.ok) {
+      return createErrorResponse(attendeeNamesResult.error, 'VALIDATION_ERROR', 400)
+    }
+    const attendeeNames = attendeeNamesResult.names
+
     const requestHash = computeIdempotencyRequestHash({
       event_id: parsed.data.event_id,
       phone: normalizedPhone,
@@ -132,6 +144,7 @@ export async function POST(request: NextRequest) {
       seats: parsed.data.seats,
       seating_preference: parsed.data.seating_preference || 'seated',
       expected_event_date: parsed.data.expected_event_date || null,
+      attendee_names: attendeeNames.length > 0 ? attendeeNames : null,
       communication_consent: consentHashPayload(parsed.data.communication_consent),
     })
     const attribution = buildBookingAttribution(parsed.data)
@@ -256,6 +269,7 @@ export async function POST(request: NextRequest) {
         appBaseUrl,
         shouldSendSms: true,
         firstName: parsed.data.first_name || customerResolution.resolvedFirstName,
+        attendeeNames: attendeeNames.length > 0 ? attendeeNames : undefined,
         attribution
       })
 

--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -144,7 +144,7 @@ export async function POST(request: NextRequest) {
       seats: parsed.data.seats,
       seating_preference: parsed.data.seating_preference || 'seated',
       expected_event_date: parsed.data.expected_event_date || null,
-      attendee_names: attendeeNames.length > 0 ? attendeeNames : null,
+      ...(attendeeNames.length > 0 ? { attendee_names: attendeeNames } : {}),
       communication_consent: consentHashPayload(parsed.data.communication_consent),
     })
     const attribution = buildBookingAttribution(parsed.data)

--- a/src/app/api/events/[id]/booking-sheets/route.ts
+++ b/src/app/api/events/[id]/booking-sheets/route.ts
@@ -41,6 +41,7 @@ type BookingRow = {
   seats: number | null
   event_seating_type: string | null
   notes: string | null
+  attendee_names: string[] | null
   status: string | null
   is_reminder_only: boolean | null
   customer: {
@@ -215,6 +216,7 @@ function toSheetData(input: {
     customerName: customerName(booking),
     seats: String(seats),
     seatingType,
+    attendeeNames: (booking.attendee_names ?? []).filter((name) => typeof name === 'string' && name.trim().length > 0),
     tableNumber: seatingType === 'Standing' ? null : tableName || null,
     price: isFree ? 'Free' : formatCurrency(pricePerSeat * seats),
     priceNote: isFree ? 'Event price: Free' : `Event price: ${formatCurrency(pricePerSeat)} per person · ${seats} guests`,
@@ -248,7 +250,7 @@ export async function GET(_request: NextRequest, context: RouteContext) {
 
     const { data: bookings, error: bookingsError } = await admin
       .from('bookings')
-      .select('id, seats, event_seating_type, notes, status, is_reminder_only, customer:customers(first_name, last_name, mobile_number)')
+      .select('id, seats, event_seating_type, notes, attendee_names, status, is_reminder_only, customer:customers(first_name, last_name, mobile_number)')
       .eq('event_id', eventId)
       .neq('status', 'cancelled')
       .eq('is_reminder_only', false)

--- a/src/lib/email/event-ticket-emails.ts
+++ b/src/lib/email/event-ticket-emails.ts
@@ -98,10 +98,11 @@ async function loadEventTicketEmailContext(
   eventStartIso: string | null
   bookingUrl: string | null
   seats: number
+  attendeeNames: string[]
 } | null> {
   const { data: booking, error } = await supabase
     .from('bookings')
-    .select('id, customer_id, seats, customers!inner(id, first_name, email), events!inner(id, name, start_datetime, date, time, booking_url)')
+    .select('id, customer_id, seats, attendee_names, customers!inner(id, first_name, email), events!inner(id, name, start_datetime, date, time, booking_url)')
     .eq('id', bookingId)
     .maybeSingle()
 
@@ -130,6 +131,11 @@ async function loadEventTicketEmailContext(
     eventStartIso,
     bookingUrl: typeof event?.booking_url === 'string' && event.booking_url.trim() ? event.booking_url.trim() : null,
     seats: Math.max(1, Number((booking as any).seats || 1)),
+    attendeeNames: Array.isArray((booking as any).attendee_names)
+      ? ((booking as any).attendee_names as unknown[])
+          .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+          .map((name) => name.trim())
+      : [],
   }
 }
 
@@ -262,10 +268,19 @@ export async function sendEventPaymentConfirmationEmail(
   const paidLine = amountText
     ? `We have received your ${amountText} payment.`
     : 'We have received your payment.'
+  const hasAttendeeNames = context.attendeeNames.length > 0
+  const namesText = hasAttendeeNames
+    ? `\nTickets:\n${context.attendeeNames.map((name, index) => `${index + 1}. ${name}`).join('\n')}`
+    : ''
+  const namesHtml = hasAttendeeNames
+    ? `<p style="margin-bottom: 4px;"><strong>Tickets</strong></p>
+  <ol style="margin-top: 0;">${context.attendeeNames.map((name) => `<li>${escapeHtml(name)}</li>`).join('')}</ol>`
+    : ''
   const text = [
     `Hi ${context.firstName},`,
     '',
     `${paidLine} Your booking for ${context.eventName} on ${context.eventStart} is confirmed for ${context.seats} ${seatWord}.`,
+    namesText || null,
     manageLink ? `Manage your booking here: ${manageLink}` : null,
     '',
     'The Anchor',
@@ -276,6 +291,7 @@ export async function sendEventPaymentConfirmationEmail(
   <h2 style="font-family: Arial, Helvetica, sans-serif;">Your booking is confirmed</h2>
   <p>Hi ${safeName},</p>
   <p>${escapeHtml(paidLine)} Your booking for <strong>${safeEventName}</strong> on ${escapeHtml(context.eventStart)} is confirmed for ${context.seats} ${seatWord}.</p>
+  ${namesHtml}
   ${safeManageLink ? `<p><a href="${safeManageLink}" style="display: inline-block; padding: 10px 14px; background: #111827; color: #ffffff; text-decoration: none; border-radius: 6px;">Manage booking</a></p>` : ''}
   <p style="font-size: 13px; color: #6b7280;">This is a service message about your booking.</p>
   <p>The Anchor</p>

--- a/src/lib/event-booking-sheet-template.test.ts
+++ b/src/lib/event-booking-sheet-template.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { generateEventBookingSheetsHTML } from './event-booking-sheet-template'
 
-const baseSheet = {
+import type { EventBookingSheetData } from './event-booking-sheet-template'
+
+const baseSheet: EventBookingSheetData = {
   bookingRef: 'TB-123',
   eventName: 'Music Bingo',
   eventDate: 'Friday, 12 June 2026',
@@ -10,6 +12,7 @@ const baseSheet = {
   customerName: 'Test Guest',
   seats: '2',
   seatingType: 'Seated',
+  attendeeNames: [],
   tableNumber: 'Big Bay',
   price: '£6.00',
   priceNote: 'Event price: £3.00 per person · 2 guests',
@@ -17,21 +20,39 @@ const baseSheet = {
   bookingNotes: null,
 }
 
+const options = {
+  logoDataUrl: 'data:image/png;base64,logo',
+  sundayRoastQrDataUrl: 'data:image/png;base64,qr',
+  sundayRoastItems: [
+    { name: 'Roasted Beef', price: '19' },
+    { name: 'Vegan Wellington', price: '18.50', badge: 'VG' },
+  ],
+}
+
 describe('booking sheet template', () => {
   it('renders Sunday roast items from provided menu data', () => {
-    const html = generateEventBookingSheetsHTML([baseSheet], {
-      logoDataUrl: 'data:image/png;base64,logo',
-      sundayRoastQrDataUrl: 'data:image/png;base64,qr',
-      sundayRoastItems: [
-        { name: 'Roasted Beef', price: '19' },
-        { name: 'Vegan Wellington', price: '18.50', badge: 'VG' },
-      ],
-    })
+    const html = generateEventBookingSheetsHTML([baseSheet], options)
 
     expect(html).toContain('Roasted Beef')
     expect(html).toContain('19')
     expect(html).toContain('Vegan Wellington')
     expect(html).toContain('18.50')
     expect(html).not.toContain('Roasted Pork')
+  })
+
+  it('lists per-ticket attendee names when provided', () => {
+    const html = generateEventBookingSheetsHTML(
+      [{ ...baseSheet, attendeeNames: ['Alice Booker', 'Bob Guest'] }],
+      options,
+    )
+
+    expect(html).toContain('Guests')
+    expect(html).toContain('1. Alice Booker')
+    expect(html).toContain('2. Bob Guest')
+  })
+
+  it('omits the guests block when there are no attendee names', () => {
+    const html = generateEventBookingSheetsHTML([baseSheet], options)
+    expect(html).not.toContain('>Guests<')
   })
 })

--- a/src/lib/event-booking-sheet-template.ts
+++ b/src/lib/event-booking-sheet-template.ts
@@ -7,6 +7,8 @@ export interface EventBookingSheetData {
   customerName: string
   seats: string
   seatingType: string
+  /** Ordered per-ticket attendee names (index 0 = lead booker); empty when unknown. */
+  attendeeNames: string[]
   tableNumber: string | null
   price: string
   priceNote: string
@@ -138,6 +140,8 @@ function renderBookingSheetPage(
 ): string {
   const hasTable = Boolean(data.tableNumber?.trim())
   const hasNotes = Boolean(data.bookingNotes?.trim())
+  const attendeeNames = data.attendeeNames.filter((name) => name.trim().length > 0)
+  const hasAttendees = attendeeNames.length > 0
   const menuItems = options.sundayRoastItems.length > 0
     ? options.sundayRoastItems
     : [{ name: 'Ask the team for this Sunday\'s roast menu', price: '', badge: null }]
@@ -186,6 +190,8 @@ function renderBookingSheetPage(
           <p class="pay-method">${escapeHtml(data.paymentMethod)}</p>
         </div>
       </div>
+
+      ${hasAttendees ? `<div class="notes" style="margin-bottom:5mm;"><p class="notes-label">Guests</p><p class="notes-text">${attendeeNames.map((name, index) => `${index + 1}. ${escapeHtml(name)}`).join('<br>')}</p></div>` : ''}
 
       ${hasNotes ? `<div class="notes"><p class="notes-label">Booking notes</p><p class="notes-text">${escapeHtml(data.bookingNotes || '')}</p></div>` : ''}
 

--- a/src/lib/events/attendee-names.test.ts
+++ b/src/lib/events/attendee-names.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_ATTENDEE_NAME_LENGTH, normalizeAttendeeNames } from './attendee-names'
+
+describe('normalizeAttendeeNames', () => {
+  it('treats undefined/null as not provided (valid, empty)', () => {
+    expect(normalizeAttendeeNames(undefined, 3)).toEqual({ ok: true, names: [] })
+    expect(normalizeAttendeeNames(null, 1)).toEqual({ ok: true, names: [] })
+  })
+
+  it('trims each name and keeps order (booker is index 0)', () => {
+    const result = normalizeAttendeeNames(['  Alice Booker ', 'Bob Guest'], 2)
+    expect(result).toEqual({ ok: true, names: ['Alice Booker', 'Bob Guest'] })
+  })
+
+  it('rejects a blank or whitespace-only name', () => {
+    const result = normalizeAttendeeNames(['Alice', '   '], 2)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/each ticket needs a name/i)
+  })
+
+  it('rejects when the count does not match seats', () => {
+    const result = normalizeAttendeeNames(['Alice', 'Bob'], 3)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/expected 3 ticket names but received 2/i)
+  })
+
+  it('uses singular wording for a single missing name', () => {
+    const result = normalizeAttendeeNames([], 1)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/expected 1 ticket name but received 0/i)
+  })
+
+  it('rejects a name longer than the maximum', () => {
+    const result = normalizeAttendeeNames(['A'.repeat(MAX_ATTENDEE_NAME_LENGTH + 1)], 1)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/characters or fewer/i)
+  })
+
+  it('rejects a non-array input', () => {
+    const result = normalizeAttendeeNames('Alice' as unknown, 1)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/must be an array/i)
+  })
+
+  it('coerces non-string entries to blank and rejects them', () => {
+    const result = normalizeAttendeeNames(['Alice', 42 as unknown as string], 2)
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/lib/events/attendee-names.ts
+++ b/src/lib/events/attendee-names.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-ticket attendee names for event bookings.
+ *
+ * Names are an ordered list of full-name strings, one per seat, where index 0
+ * is the lead booker ("booker is ticket 1"). They are captured by the public
+ * website at booking creation and stored on `bookings.attendee_names`.
+ *
+ * This module is the single source of truth for validating that list, so the
+ * rule is unit-testable and shared by the API route and any future caller.
+ */
+
+export const MAX_ATTENDEE_NAME_LENGTH = 120
+
+export type AttendeeNamesResult =
+  | { ok: true; names: string[] }
+  | { ok: false; error: string }
+
+/**
+ * Validate and normalise a caller-supplied attendee-names list.
+ *
+ * - `undefined`/`null` → treated as "not provided" (valid, empty result). The
+ *   caller decides whether names are required (the website enforces them for
+ *   paid events; AMS stays lenient so staff/FOH/SMS bookings keep working).
+ * - When provided, every entry is trimmed and must be a non-empty string within
+ *   {@link MAX_ATTENDEE_NAME_LENGTH}, and the count must equal `seats`.
+ */
+export function normalizeAttendeeNames(input: unknown, seats: number): AttendeeNamesResult {
+  if (input === undefined || input === null) {
+    return { ok: true, names: [] }
+  }
+
+  if (!Array.isArray(input)) {
+    return { ok: false, error: 'attendee_names must be an array of names' }
+  }
+
+  const names = input.map((value) => (typeof value === 'string' ? value.trim() : ''))
+
+  if (names.some((name) => name.length === 0)) {
+    return { ok: false, error: 'Each ticket needs a name' }
+  }
+
+  if (names.some((name) => name.length > MAX_ATTENDEE_NAME_LENGTH)) {
+    return {
+      ok: false,
+      error: `Each name must be ${MAX_ATTENDEE_NAME_LENGTH} characters or fewer`,
+    }
+  }
+
+  if (names.length !== seats) {
+    return {
+      ok: false,
+      error: `Expected ${seats} ticket name${seats === 1 ? '' : 's'} but received ${names.length}`,
+    }
+  }
+
+  return { ok: true, names }
+}

--- a/src/services/event-bookings.ts
+++ b/src/services/event-bookings.ts
@@ -112,6 +112,12 @@ export type CreateBookingParams = {
    */
   firstName?: string
   /**
+   * Per-ticket attendee names (ordered; index 0 = lead booker). Persisted to
+   * bookings.attendee_names once the booking row exists. Optional — staff, FOH
+   * and SMS bookings don't supply them, and legacy rows stay NULL.
+   */
+  attendeeNames?: string[]
+  /**
    * First-party attribution forwarded by the brand site. Stored in analytics
    * metadata so paid-booking truth survives browser pixel failures.
    */
@@ -411,6 +417,24 @@ async function cancelBookingAfterTableReservationFailure(
   }
 }
 
+async function persistAttendeeNames(
+  supabase: ReturnType<typeof createAdminClient>,
+  bookingId: string,
+  attendeeNames: string[]
+): Promise<void> {
+  const { error } = await supabase
+    .from('bookings')
+    .update({ attendee_names: attendeeNames })
+    .eq('id', bookingId)
+
+  if (error) {
+    // Attendee names are non-critical metadata — never fail the booking over them.
+    logger.warn('Failed to persist event booking attendee names', {
+      metadata: { bookingId, error: error.message }
+    })
+  }
+}
+
 async function recordAnalyticsSafe(
   supabase: ReturnType<typeof createAdminClient>,
   payload: Parameters<typeof recordAnalyticsEvent>[1],
@@ -465,6 +489,7 @@ export class EventBookingService {
       supabaseClient,
       logTag = 'event booking',
       firstName,
+      attendeeNames,
       attribution = null,
       paymentHoldMinutes
     } = params
@@ -704,6 +729,13 @@ export class EventBookingService {
           })
         }
       ]
+
+      if (attendeeNames && attendeeNames.length > 0 && rpcResult.booking_id) {
+        tasks.push({
+          label: 'store:attendee_names',
+          promise: persistAttendeeNames(supabase, rpcResult.booking_id, attendeeNames)
+        })
+      }
 
       if (shouldSendSms && normalizedPhone) {
         tasks.push({

--- a/supabase/migrations/20260720000000_event_booking_attendee_names.sql
+++ b/supabase/migrations/20260720000000_event_booking_attendee_names.sql
@@ -1,0 +1,10 @@
+-- Per-ticket attendee names for event bookings.
+-- Ordered array of full names; index 0 = lead booker. NULL for legacy and
+-- non-website (staff, FOH, SMS) bookings, which fall back to the booker name +
+-- seat count everywhere names are displayed. Additive and nullable — no impact
+-- on existing rows or dependent views.
+ALTER TABLE public.bookings
+  ADD COLUMN IF NOT EXISTS attendee_names text[];
+
+COMMENT ON COLUMN public.bookings.attendee_names IS
+  'Ordered per-ticket attendee names captured at booking creation; index 0 = lead booker. NULL for legacy / non-website (staff, FOH, SMS) bookings.';


### PR DESCRIPTION
## What changed
Adds a name per ticket for event bookings. The public website now sends an ordered `attendee_names` array (index 0 = lead booker); AMS stores it on a new nullable `bookings.attendee_names text[]` column and surfaces it on the staff door-list PDF, the staff bookings table, and the payment-confirmation email.

## Why
Previously a multi-ticket purchase captured only the lead booker's name + a seat count, so the venue had no record of who each ticket was for. This gives a real door list.

## Scope / decisions
- **Names required for paid tickets only** (enforced on the website); free-seat events unchanged.
- **Booker is ticket 1.**
- **Website-only capture for now** — the staff manual-booking and FOH walk-in forms are unchanged. AMS stays lenient (does not force names) so staff/FOH/SMS bookings keep working; those rows stay `NULL` and fall back to the booker name + seat count everywhere.

## Storage
`ALTER TABLE public.bookings ADD COLUMN attendee_names text[]` (nullable, additive). **Already applied to production** via Supabase MCP (safe for dependent views; nothing read it until this deploys). Migration file included for repo history.

## Testing done
- [x] Automated: `normalizeAttendeeNames` unit tests + booking-sheet render tests (11 pass)
- [x] `npm run lint` (0 warnings), `npx tsc --noEmit` clean, `npm run build` success
- [x] Prod column verified live in `information_schema`

## Complexity score
M

## Breaking changes
None — additive, backward-compatible.

## Migration risk
Low — nullable column already applied; degrades to current behaviour when absent/NULL.

## Deploy order
Merge **before** the website PR (peterjpitcher/the-anchor.pub) so names are never collected-but-dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)