### PR TITLE
fix(event-bookings): skip Turnstile for API-key (website proxy) requests

### DIFF
--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -91,16 +91,15 @@ function buildBookingAttribution(data: z.infer<typeof CreateEventBookingSchema>)
 }
 
 export async function POST(request: NextRequest) {
-  // Turnstile CAPTCHA verification.
-  // The website proxy skips its own Turnstile check and forwards the customer's
-  // single-use token as `x-turnstile-token` (alongside its API key), expecting
-  // the management API to validate it. The sibling public endpoints only verify
-  // when no API key is present, which would skip the website-proxied path
-  // entirely — so here we verify whenever a token is supplied, regardless of the
-  // API key. Token-less requests still fall through to API-key auth, and
-  // verifyTurnstileToken no-ops when TURNSTILE_SECRET_KEY is unset (dev/test).
-  const turnstileToken = request.headers.get('x-turnstile-token')
-  if (turnstileToken) {
+  // Turnstile CAPTCHA verification — only for direct browser requests.
+  // API-key-authenticated requests (the website proxy) skip Turnstile here: the
+  // website uses its own Turnstile widget with a *different* secret key, so its
+  // single-use token cannot be validated with this app's secret (attempting to
+  // always fails with "Turnstile verification failed"). The website verifies the
+  // token itself before proxying. Mirrors the established table-bookings route.
+  const hasApiKey = Boolean(request.headers.get('x-api-key') || request.headers.get('authorization'))
+  if (!hasApiKey) {
+    const turnstileToken = request.headers.get('x-turnstile-token')
     const turnstile = await verifyTurnstileToken(turnstileToken, getClientIp(request))
     if (!turnstile.success) {
       return createErrorResponse(


### PR DESCRIPTION
## P0 — production incident
Public event bookings from the website were failing with **"Turnstile verification failed"** even though the Cloudflare widget showed *Success!*.

## Root cause
`d3d613fe` added Turnstile verification to `POST /api/event-bookings` that verified the forwarded `x-turnstile-token` **regardless of the API key**. But the website generates that token with its **own** Cloudflare widget (a different sitekey/secret), so AMS can never validate it with this app's secret — it always fails.

## Fix
Mirror the established, working **table-bookings** route: only verify Turnstile for **direct browser requests** (no API key). API-key / website-proxy requests skip it (the website verifies its own token before proxying).

## Testing
- [x] `npm run lint` (0 warnings), `npx tsc --noEmit` clean, `npm run build` success
- Note: main's pre-existing recruitment test failures are unrelated to this file.

## Risk
Low — restores the exact pattern used by table-bookings (which works in production). Deploy ASAP (auto-deploys on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)