### PR TITLE
feat(events): remove guest self-cancel for event bookings

### DIFF
--- a/src/app/g/[token]/manage-booking/action/route.ts
+++ b/src/app/g/[token]/manage-booking/action/route.ts
@@ -2,22 +2,17 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendEventBookingSeatUpdateSms } from '@/lib/events/event-payments'
 import {
-  cancelEventBookingByRawToken,
   createSeatIncreaseCheckoutByManageToken,
   getEventManagePreviewByRawToken,
   getEventRefundPolicy,
   processEventRefund,
   updateEventBookingSeatsByRawToken,
-  type EventManageCancelResult,
-  type EventRefundResult,
 } from '@/lib/events/manage-booking'
 import { checkGuestTokenThrottle } from '@/lib/guest/token-throttle'
-import { recordAnalyticsEvent } from '@/lib/analytics/events'
 import {
   syncPubOpsEventCalendarByBookingId,
   syncPubOpsEventCalendarByEventId,
 } from '@/lib/google-calendar-events'
-import { sendEventBookingCancelledEmail } from '@/lib/email/event-ticket-emails'
 import { logger } from '@/lib/logger'
 
 type RouteContext = {
@@ -40,104 +35,6 @@ function redirectToState(request: NextRequest, token: string, params: Record<str
     redirectUrl.searchParams.set(key, value)
   }
   return NextResponse.redirect(redirectUrl, { status: 303 })
-}
-
-async function recordGuestManageBookingAnalyticsSafe(
-  supabase: ReturnType<typeof createAdminClient>,
-  payload: Parameters<typeof recordAnalyticsEvent>[1],
-  context: Record<string, unknown>
-) {
-  try {
-    await recordAnalyticsEvent(supabase, payload)
-  } catch (analyticsError) {
-    logger.warn('Failed to record guest manage-booking analytics event', {
-      metadata: {
-        ...context,
-        error: analyticsError instanceof Error ? analyticsError.message : String(analyticsError)
-      }
-    })
-  }
-}
-
-async function processGuestCancellationRefundSafe(
-  supabase: ReturnType<typeof createAdminClient>,
-  cancelResult: EventManageCancelResult
-): Promise<{ refundStatus: EventRefundResult['status']; refundAmount: number }> {
-  if (
-    cancelResult.payment_mode !== 'prepaid' ||
-    cancelResult.previous_status !== 'confirmed' ||
-    !cancelResult.booking_id ||
-    !cancelResult.customer_id ||
-    !cancelResult.event_id ||
-    !cancelResult.event_start_datetime
-  ) {
-    return { refundStatus: 'none', refundAmount: 0 }
-  }
-
-  const seatCount = Math.max(1, Number(cancelResult.seats ?? 1))
-  const pricePerSeat = Math.max(0, Number(cancelResult.price_per_seat ?? 0))
-  const policy = getEventRefundPolicy(cancelResult.event_start_datetime)
-  const candidateRefundAmount = toMoney(seatCount * pricePerSeat * policy.refundRate)
-
-  if (candidateRefundAmount <= 0) {
-    return { refundStatus: 'none', refundAmount: 0 }
-  }
-
-  try {
-    const refundResult = await processEventRefund(supabase, {
-      bookingId: cancelResult.booking_id,
-      customerId: cancelResult.customer_id,
-      eventId: cancelResult.event_id,
-      amount: candidateRefundAmount,
-      reason: `event_cancel_${policy.policyBand}`
-    })
-
-    return {
-      refundStatus: refundResult.status,
-      refundAmount: refundResult.amount
-    }
-  } catch (refundError) {
-    logger.error('Failed to process refund after guest event booking cancellation', {
-      error: refundError instanceof Error ? refundError : new Error(String(refundError)),
-      metadata: {
-        bookingId: cancelResult.booking_id,
-        customerId: cancelResult.customer_id,
-        eventId: cancelResult.event_id,
-        refundAmount: candidateRefundAmount
-      }
-    })
-
-    return {
-      refundStatus: 'manual_required',
-      refundAmount: candidateRefundAmount
-    }
-  }
-}
-
-async function syncGuestCancellationCalendarSafe(
-  supabase: ReturnType<typeof createAdminClient>,
-  cancelResult: EventManageCancelResult
-): Promise<void> {
-  try {
-    if (cancelResult.event_id) {
-      await syncPubOpsEventCalendarByEventId(supabase, cancelResult.event_id, {
-        bookingId: cancelResult.booking_id ?? null,
-        context: 'guest_event_booking_cancelled',
-      })
-    } else if (cancelResult.booking_id) {
-      await syncPubOpsEventCalendarByBookingId(supabase, cancelResult.booking_id, {
-        context: 'guest_event_booking_cancelled',
-      })
-    }
-  } catch (calendarError) {
-    logger.warn('Failed to sync calendar after guest event booking cancellation', {
-      metadata: {
-        bookingId: cancelResult.booking_id ?? null,
-        eventId: cancelResult.event_id ?? null,
-        error: calendarError instanceof Error ? calendarError.message : String(calendarError)
-      }
-    })
-  }
 }
 
 export async function POST(request: NextRequest, context: RouteContext) {
@@ -170,56 +67,12 @@ export async function POST(request: NextRequest, context: RouteContext) {
       })
     }
 
+    // Guest self-cancel has been removed — cancellations are handled by staff in
+    // AMS so a manager can make the refund decision. Guests can still change seats.
     if (intent === 'cancel') {
-      const cancelResult = await cancelEventBookingByRawToken(supabase, {
-        rawToken: token,
-        cancelledBy: 'guest'
-      })
-
-      if (cancelResult.state !== 'cancelled') {
-        return redirectToState(request, token, {
-          state: 'blocked',
-          reason: cancelResult.reason || (cancelResult.state === 'already_cancelled' ? 'already_cancelled' : 'unavailable')
-        })
-      }
-
-      const { refundStatus, refundAmount } = await processGuestCancellationRefundSafe(supabase, cancelResult)
-
-      if (cancelResult.booking_id) {
-        await sendEventBookingCancelledEmail(supabase, {
-          bookingId: cancelResult.booking_id,
-          refundStatus,
-          refundAmount,
-          currency: 'GBP',
-          reason: 'guest_cancel',
-        })
-      }
-
-      if (cancelResult.customer_id && cancelResult.booking_id) {
-        await recordGuestManageBookingAnalyticsSafe(supabase, {
-          customerId: cancelResult.customer_id,
-          eventBookingId: cancelResult.booking_id,
-          eventType: 'event_booking_cancelled',
-          metadata: {
-            event_id: cancelResult.event_id ?? null,
-            seats: cancelResult.seats ?? null,
-            payment_mode: cancelResult.payment_mode ?? null,
-            refund_status: refundStatus,
-            refund_amount: refundAmount
-          }
-        }, {
-          customerId: cancelResult.customer_id,
-          eventBookingId: cancelResult.booking_id,
-          eventType: 'event_booking_cancelled'
-        })
-      }
-
-      await syncGuestCancellationCalendarSafe(supabase, cancelResult)
-
       return redirectToState(request, token, {
-        state: 'cancelled',
-        refund_status: refundStatus,
-        refund_amount: String(refundAmount)
+        state: 'blocked',
+        reason: 'cancel_not_available'
       })
     }
 

--- a/src/app/g/[token]/manage-booking/page.tsx
+++ b/src/app/g/[token]/manage-booking/page.tsx
@@ -245,26 +245,14 @@ export default async function ManageBookingPage({ params, searchParams }: Manage
           </form>
         )}
 
-        {preview.can_cancel && (
-          <form method="post" action={`/g/${token}/manage-booking/action`} className="mt-4">
-            <input type="hidden" name="intent" value="cancel" />
-            <button
-              type="submit"
-              className="inline-flex w-full items-center justify-center rounded-md border border-rose-500 bg-white px-4 py-2 text-sm font-semibold text-rose-700 transition hover:bg-rose-50"
-            >
-              Cancel booking
-            </button>
-          </form>
-        )}
-
-        {!preview.can_change_seats && !preview.can_cancel && (
+        {!preview.can_change_seats && (
           <p className="mt-5 rounded-md border border-slate-300 bg-slate-50 px-3 py-2 text-xs text-slate-700">
             This booking can no longer be changed online.
           </p>
         )}
 
         <p className="mt-4 text-xs text-slate-600">
-          Need help? Call {contactPhone}.
+          Need to cancel or need help? Call {contactPhone}.
         </p>
       </div>
     </GuestPageShell>


### PR DESCRIPTION
## What
Guests can no longer self-cancel event bookings via the manage-booking token link. Cancellations are now staff-only in AMS (so a manager makes the refund decision — see the follow-up refund PR).

- Removes the `intent==='cancel'` branch + guest-cancel-only helpers (`processGuestCancellationRefundSafe`, `syncGuestCancellationCalendarSafe`, guest analytics helper) and now-unused imports from `g/[token]/manage-booking/action/route.ts`. A stale cancel POST returns a blocked state instead of cancelling.
- Removes the "Cancel booking" button from `g/[token]/manage-booking/page.tsx`; the page now shows seat-change + "call us to cancel".
- **Unchanged:** the `update_seats` flow (incl. its seat-reduction refund).

## Why
Part 1 of moving refunds to a deliberate manager decision. the-anchor.pub has no cancel logic of its own (only links here), so no website change.

## Testing
- [x] `npx tsc --noEmit` clean, `npm run lint` (0 warnings), `npm run build` success

🤖 Generated with [Claude Code](https://claude.com/claude-code)