### PR TITLE
feat(events): manager-chosen refund (full/partial) on booking cancel

### DIFF
--- a/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
+++ b/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
@@ -30,6 +30,7 @@ import {
   createEventManualBooking,
   updateEventManualBookingSeats,
   cancelEventManualBooking,
+  getEventBookingRefundInfo,
   markEventBookingPaidManually,
   transferEventBooking,
   deleteEvent,
@@ -190,6 +191,16 @@ export default function EventDetailClient({
 
   // Cancel confirmation state
   const [cancellingBookingId, setCancellingBookingId] = useState<string | null>(null)
+  const [cancelRefundInfo, setCancelRefundInfo] = useState<{
+    canRefund: boolean
+    maxRefundable: number
+    policySuggestion: number
+    amountPaid: number
+  } | null>(null)
+  const [cancelRefundLoading, setCancelRefundLoading] = useState(false)
+  const [cancelRefundOn, setCancelRefundOn] = useState(false)
+  const [cancelRefundMode, setCancelRefundMode] = useState<'full' | 'partial'>('full')
+  const [cancelRefundAmount, setCancelRefundAmount] = useState('')
   const [transferringBookingId, setTransferringBookingId] = useState<string | null>(null)
   const [transferTargetEventId, setTransferTargetEventId] = useState('')
 
@@ -299,11 +310,49 @@ export default function EventDetailClient({
 
   /* ---- Cancel booking ---- */
 
+  // Load refund context (max refundable, policy suggestion, permission) when the
+  // cancel dialog opens, and reset the refund choice when it closes.
+  useEffect(() => {
+    if (!cancellingBookingId) {
+      setCancelRefundInfo(null)
+      setCancelRefundLoading(false)
+      setCancelRefundOn(false)
+      setCancelRefundMode('full')
+      setCancelRefundAmount('')
+      return
+    }
+    let cancelled = false
+    setCancelRefundLoading(true)
+    setCancelRefundInfo(null)
+    getEventBookingRefundInfo(cancellingBookingId)
+      .then((res) => {
+        if (cancelled || 'error' in res) return
+        setCancelRefundInfo(res.data)
+        if (res.data.maxRefundable > 0 && res.data.canRefund) {
+          setCancelRefundOn(true)
+          setCancelRefundMode('full')
+          setCancelRefundAmount(res.data.maxRefundable.toFixed(2))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setCancelRefundLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [cancellingBookingId])
+
   const handleConfirmCancel = useCallback(() => {
     if (!cancellingBookingId || !event) return
+    const refundDecision: 'none' | 'full' | 'partial' =
+      cancelRefundInfo && cancelRefundInfo.canRefund && cancelRefundInfo.maxRefundable > 0 && cancelRefundOn
+        ? cancelRefundMode
+        : 'none'
     startTransition(async () => {
       const result = await cancelEventManualBooking({
         bookingId: cancellingBookingId,
+        refundDecision,
+        ...(refundDecision === 'partial' ? { refundAmount: Number(cancelRefundAmount) || 0 } : {}),
       })
       if ('error' in result) {
         toast.error(result.error)
@@ -322,7 +371,7 @@ export default function EventDetailClient({
         await refreshBookings()
       }
     })
-  }, [cancellingBookingId, event, refreshBookings])
+  }, [cancellingBookingId, event, refreshBookings, cancelRefundInfo, cancelRefundOn, cancelRefundMode, cancelRefundAmount])
 
   const handleMarkPaid = useCallback((bookingId: string, method: 'cash' | 'card_terminal' | 'comp') => {
     startTransition(async () => {
@@ -595,7 +644,68 @@ export default function EventDetailClient({
         onClose={() => setCancellingBookingId(null)}
         onConfirm={handleConfirmCancel}
         title="Cancel Booking"
-        message="Are you sure you want to cancel this booking? This action cannot be undone."
+        message={
+          <div className="space-y-3">
+            <p className="text-sm text-text-muted">
+              Are you sure you want to cancel this booking? This action cannot be undone.
+            </p>
+            {cancelRefundLoading ? (
+              <p className="text-sm text-text-muted">Checking payment…</p>
+            ) : cancelRefundInfo && cancelRefundInfo.maxRefundable > 0 ? (
+              cancelRefundInfo.canRefund ? (
+                <div className="space-y-2 rounded-md border border-line bg-surface-sunk p-3">
+                  <label className="flex items-center gap-2 text-sm font-medium text-text">
+                    <input
+                      type="checkbox"
+                      checked={cancelRefundOn}
+                      onChange={(e) => setCancelRefundOn(e.target.checked)}
+                      className="h-4 w-4"
+                    />
+                    Issue a refund (paid {formatCurrency(cancelRefundInfo.amountPaid)})
+                  </label>
+                  {cancelRefundOn && (
+                    <div className="space-y-2 pl-6">
+                      <Select
+                        value={cancelRefundMode}
+                        onChange={(e) => {
+                          const mode = e.target.value === 'partial' ? 'partial' : 'full'
+                          setCancelRefundMode(mode)
+                          if (mode === 'full' && cancelRefundInfo) {
+                            setCancelRefundAmount(cancelRefundInfo.maxRefundable.toFixed(2))
+                          }
+                        }}
+                        options={[
+                          { value: 'full', label: `Full refund (${formatCurrency(cancelRefundInfo.maxRefundable)})` },
+                          { value: 'partial', label: 'Partial refund' },
+                        ]}
+                      />
+                      {cancelRefundMode === 'partial' && (
+                        <Input
+                          type="number"
+                          min={0}
+                          max={cancelRefundInfo.maxRefundable}
+                          step="0.01"
+                          value={cancelRefundAmount}
+                          onChange={(e) => setCancelRefundAmount(e.target.value)}
+                          placeholder="Refund amount"
+                        />
+                      )}
+                      <p className="text-xs text-text-muted">
+                        Up to {formatCurrency(cancelRefundInfo.maxRefundable)}. Policy suggests{' '}
+                        {formatCurrency(cancelRefundInfo.policySuggestion)}.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-sm text-amber-700">
+                  This booking is paid ({formatCurrency(cancelRefundInfo.amountPaid)}). Only a manager can
+                  cancel a paid booking, so the refund can be decided.
+                </p>
+              )
+            ) : null}
+          </div>
+        }
         confirmLabel="Cancel Booking"
         tone="danger"
       />

--- a/src/app/actions/events.ts
+++ b/src/app/actions/events.ts
@@ -18,6 +18,7 @@ import {
   updateEventBookingSeatsById,
   type EventRefundResult
 } from '@/lib/events/manage-booking'
+import { canIssueEventRefund } from '@/lib/events/refund-permissions'
 import {
   sendEventBookingSeatUpdateSms,
   sendEventPaymentConfirmationSms,
@@ -954,7 +955,11 @@ export async function createEventManualBooking(input: {
 
 const cancelEventManualBookingSchema = z.object({
   bookingId: z.string().uuid(),
-  sendSms: z.boolean().optional().default(true)
+  sendSms: z.boolean().optional().default(true),
+  // Manager-only: whether to refund and how much. 'full' refunds everything still
+  // refundable; 'partial' uses refundAmount. Defaults to no refund.
+  refundDecision: z.enum(['none', 'full', 'partial']).optional().default('none'),
+  refundAmount: z.number().min(0).max(100000).optional()
 })
 
 const updateEventManualBookingSeatsSchema = z.object({
@@ -1295,9 +1300,55 @@ export async function updateEventManualBookingSeats(input: {
   }
 }
 
+async function resolveEventRefundActor(
+  supabase: ReturnType<typeof createAdminClient>
+): Promise<{ userId: string | null; email: string | null; mayRefund: boolean }> {
+  const authClient = await createClient()
+  const { data: { user } } = await authClient.auth.getUser()
+  let roleNames: string[] = []
+  if (user?.id) {
+    const { data: roleRows } = await supabase.rpc('get_user_roles', { p_user_id: user.id })
+    roleNames = ((roleRows as Array<{ role_name?: string }> | null) ?? [])
+      .map((row) => row.role_name)
+      .filter((name): name is string => typeof name === 'string')
+  }
+  return {
+    userId: user?.id ?? null,
+    email: user?.email ?? null,
+    mayRefund: canIssueEventRefund({ email: user?.email, roleNames })
+  }
+}
+
+async function computeEventBookingRefundable(
+  supabase: ReturnType<typeof createAdminClient>,
+  bookingId: string
+): Promise<{ amountPaid: number; alreadyRefunded: number; maxRefundable: number }> {
+  const [paidResult, refundResult] = await Promise.all([
+    supabase.from('payments').select('amount')
+      .eq('event_booking_id', bookingId)
+      .in('charge_type', ['prepaid_event', 'seat_increase'])
+      .in('status', ['succeeded', 'partially_refunded']),
+    supabase.from('payments').select('amount')
+      .eq('event_booking_id', bookingId)
+      .eq('charge_type', 'refund')
+      .in('status', ['refunded', 'pending', 'succeeded'])
+  ])
+  if (paidResult.error) throw paidResult.error
+  if (refundResult.error) throw refundResult.error
+  const amountPaid = (paidResult.data || []).reduce((sum, row) => sum + Math.max(0, Number(row.amount || 0)), 0)
+  const alreadyRefunded = (refundResult.data || []).reduce((sum, row) => sum + Math.max(0, Number(row.amount || 0)), 0)
+  return {
+    amountPaid: toMoney(amountPaid),
+    alreadyRefunded: toMoney(alreadyRefunded),
+    maxRefundable: toMoney(Math.max(0, amountPaid - alreadyRefunded))
+  }
+}
+
 export async function cancelEventManualBooking(input: {
   bookingId: string
   sendSms?: boolean
+  refundDecision?: 'none' | 'full' | 'partial'
+  refundAmount?: number
 }): Promise<CancelEventManualBookingResult> {
   try {
     const canManageEvents = await checkUserPermission('events', 'manage')
@@ -1356,6 +1407,45 @@ export async function cancelEventManualBooking(input: {
           refund_amount: 0
         }
       }
+    }
+
+    // ── Manager refund decision (money actions are manager-only) ───────────────
+    const eventForRefund = Array.isArray(bookingRow.event) ? bookingRow.event[0] : bookingRow.event
+    const isPrepaidConfirmed =
+      bookingStatus === 'confirmed' &&
+      bookingRow.is_reminder_only !== true &&
+      Boolean(bookingRow.customer_id) &&
+      Boolean(bookingRow.event_id) &&
+      Boolean(eventForRefund) &&
+      (eventForRefund as any).payment_mode === 'prepaid'
+
+    const { maxRefundable } = isPrepaidConfirmed
+      ? await computeEventBookingRefundable(supabase, bookingRow.id)
+      : { maxRefundable: 0 }
+
+    const { userId: actingUserId, mayRefund } = await resolveEventRefundActor(supabase)
+    const refundDecision = parsed.data.refundDecision ?? 'none'
+
+    // A paid booking can only be cancelled by a manager — it entails a refund decision.
+    if (maxRefundable > 0 && !mayRefund) {
+      return { error: 'Only a manager can cancel a paid booking. Please ask a manager to do this.' }
+    }
+    if (refundDecision !== 'none' && !mayRefund) {
+      return { error: 'Only a manager can issue refunds.' }
+    }
+
+    let resolvedRefundAmount = 0
+    if (refundDecision === 'full') {
+      resolvedRefundAmount = maxRefundable
+    } else if (refundDecision === 'partial') {
+      const requested = toMoney(Math.max(0, Number(parsed.data.refundAmount ?? 0)))
+      if (requested <= 0) {
+        return { error: 'Enter a refund amount, or choose “No refund”.' }
+      }
+      if (requested > maxRefundable) {
+        return { error: `Refund cannot exceed the amount paid (£${maxRefundable.toFixed(2)}).` }
+      }
+      resolvedRefundAmount = requested
     }
 
     const nowIso = new Date().toISOString()
@@ -1527,68 +1617,36 @@ export async function cancelEventManualBooking(input: {
     let refundStatus: EventRefundResult['status'] = 'none'
     let refundAmount = 0
 
-    if (
-      bookingStatus === 'confirmed' &&
-      bookingRow.is_reminder_only !== true &&
-      bookingRow.customer_id &&
-      bookingRow.event_id &&
-      eventRecord &&
-      (eventRecord as any).payment_mode === 'prepaid'
-    ) {
-      const eventStartIso =
-        (eventRecord as any).start_datetime ||
-        ((eventRecord as any).date ? `${(eventRecord as any).date}T${((eventRecord as any).time || '00:00').slice(0, 5)}:00` : null)
-      const policy = eventStartIso
-        ? getEventRefundPolicy(eventStartIso)
-        : { refundRate: 0, policyBand: 'none' as const }
-      const seatCount = Math.max(1, Number(bookingRow.seats || 1))
-      const { data: paidRows, error: paidRowsError } = await supabase
-        .from('payments')
-        .select('id, amount, status, charge_type')
-        .eq('event_booking_id', bookingRow.id)
-        .in('charge_type', ['prepaid_event', 'seat_increase'])
-        .in('status', ['succeeded', 'partially_refunded'])
-
-      if (paidRowsError) {
-        throw paidRowsError
-      }
-
-      const amountPaid = (paidRows || []).reduce(
-        (sum, row) => sum + Math.max(0, Number(row.amount || 0)),
-        0,
-      )
-      const candidateRefundAmount = toMoney(amountPaid * policy.refundRate)
-
-      if (candidateRefundAmount > 0) {
-        try {
-          const refundResult = await processEventRefund(supabase, {
+    if (resolvedRefundAmount > 0 && bookingRow.customer_id && bookingRow.event_id) {
+      try {
+        const refundResult = await processEventRefund(supabase, {
+          bookingId: bookingRow.id,
+          customerId: bookingRow.customer_id,
+          eventId: bookingRow.event_id,
+          amount: resolvedRefundAmount,
+          reason: 'staff_cancel_refund',
+          metadata: {
+            idempotency_key: `staff-cancel-refund:${bookingRow.id}`,
+            cancelled_by: 'admin',
+            initiated_by: actingUserId,
+            decision: refundDecision,
+            max_refundable: maxRefundable
+          }
+        })
+        refundStatus = refundResult.status
+        refundAmount = refundResult.amount
+      } catch (refundError) {
+        refundStatus = 'manual_required'
+        refundAmount = resolvedRefundAmount
+        logger.error('Failed to process event refund during staff cancellation', {
+          error: refundError instanceof Error ? refundError : new Error(String(refundError)),
+          metadata: {
             bookingId: bookingRow.id,
             customerId: bookingRow.customer_id,
             eventId: bookingRow.event_id,
-            amount: candidateRefundAmount,
-            reason: `staff_cancel_${policy.policyBand}`,
-            metadata: {
-              cancelled_by: 'admin',
-              policy_band: policy.policyBand,
-              amount_paid: toMoney(amountPaid),
-              seats: seatCount
-            }
-          })
-          refundStatus = refundResult.status
-          refundAmount = refundResult.amount
-        } catch (refundError) {
-          refundStatus = 'manual_required'
-          refundAmount = candidateRefundAmount
-          logger.error('Failed to process event refund during staff cancellation', {
-            error: refundError instanceof Error ? refundError : new Error(String(refundError)),
-            metadata: {
-              bookingId: bookingRow.id,
-              customerId: bookingRow.customer_id,
-              eventId: bookingRow.event_id,
-              refundAmount: candidateRefundAmount
-            }
-          })
-        }
+            refundAmount: resolvedRefundAmount
+          }
+        })
       }
     }
 
@@ -1664,6 +1722,21 @@ export async function cancelEventManualBooking(input: {
       reason: 'staff_cancel'
     })
 
+    await logAuditEvent({
+      user_id: actingUserId ?? undefined,
+      operation_type: 'update',
+      resource_type: 'event_booking',
+      resource_id: bookingRow.id,
+      operation_status: 'success',
+      additional_info: {
+        action: 'cancel',
+        refund_decision: refundDecision,
+        refund_status: refundStatus,
+        refund_amount: refundAmount,
+        max_refundable: maxRefundable
+      }
+    })
+
     if (bookingRow.customer_id) {
       await recordEventAnalyticsSafe(supabase, {
         customerId: bookingRow.customer_id,
@@ -1709,6 +1782,78 @@ export async function cancelEventManualBooking(input: {
       error: error instanceof Error ? error : new Error(String(error)),
     })
     return { error: getErrorMessage(error, 'Failed to cancel booking.') }
+  }
+}
+
+type EventBookingRefundInfo =
+  | { error: string }
+  | {
+      success: true
+      data: {
+        canRefund: boolean
+        amountPaid: number
+        alreadyRefunded: number
+        maxRefundable: number
+        policySuggestion: number
+      }
+    }
+
+/** Refund context for the staff cancel dialog: how much is refundable, a policy
+ *  suggestion, and whether the current user may issue refunds. */
+export async function getEventBookingRefundInfo(bookingId: string): Promise<EventBookingRefundInfo> {
+  try {
+    const canManageEvents = await checkUserPermission('events', 'manage')
+    if (!canManageEvents) {
+      return { error: 'You do not have permission to view this.' }
+    }
+    const parsedId = z.string().uuid().safeParse(bookingId)
+    if (!parsedId.success) {
+      return { error: 'Invalid booking id.' }
+    }
+
+    const supabase = createAdminClient()
+    const { data: bookingRow, error: bookingError } = await supabase.from('bookings')
+      .select('id, status, is_reminder_only, event:events(payment_mode, start_datetime, date, time)')
+      .eq('id', parsedId.data)
+      .maybeSingle()
+
+    if (bookingError || !bookingRow) {
+      return { error: 'Booking not found.' }
+    }
+
+    const eventRecord = Array.isArray(bookingRow.event) ? bookingRow.event[0] : bookingRow.event
+    const isPrepaidConfirmed =
+      bookingRow.status === 'confirmed' &&
+      bookingRow.is_reminder_only !== true &&
+      Boolean(eventRecord) &&
+      (eventRecord as any).payment_mode === 'prepaid'
+
+    const { amountPaid, alreadyRefunded, maxRefundable } = isPrepaidConfirmed
+      ? await computeEventBookingRefundable(supabase, bookingRow.id)
+      : { amountPaid: 0, alreadyRefunded: 0, maxRefundable: 0 }
+
+    let policySuggestion = 0
+    if (maxRefundable > 0 && eventRecord) {
+      const startIso =
+        (eventRecord as any).start_datetime ||
+        ((eventRecord as any).date
+          ? `${(eventRecord as any).date}T${(((eventRecord as any).time || '00:00') as string).slice(0, 5)}:00`
+          : null)
+      const policy = startIso ? getEventRefundPolicy(startIso) : { refundRate: 0 }
+      policySuggestion = toMoney(maxRefundable * policy.refundRate)
+    }
+
+    const { mayRefund } = await resolveEventRefundActor(supabase)
+
+    return {
+      success: true,
+      data: { canRefund: mayRefund, amountPaid, alreadyRefunded, maxRefundable, policySuggestion }
+    }
+  } catch (error) {
+    logger.error('Failed to load event booking refund info', {
+      error: error instanceof Error ? error : new Error(String(error))
+    })
+    return { error: getErrorMessage(error, 'Failed to load refund details.') }
   }
 }
 

--- a/src/lib/events/manage-booking.ts
+++ b/src/lib/events/manage-booking.ts
@@ -251,6 +251,46 @@ export async function processEventRefund(
     }
   }
 
+  // Idempotency: when the caller supplies a stable metadata.idempotency_key,
+  // return any prior refund carrying that key instead of issuing a new one.
+  // Guards against double-refund on retries / concurrent cancels regardless of
+  // the (per-reason) dedup below.
+  const idempotencyKey =
+    input.metadata && typeof input.metadata['idempotency_key'] === 'string'
+      ? (input.metadata['idempotency_key'] as string)
+      : null
+  if (idempotencyKey) {
+    const { data: priorRefunds, error: priorRefundError } = await supabase.from('payments')
+      .select('id, amount, currency, status, metadata')
+      .eq('charge_type', 'refund')
+      .contains('metadata', { idempotency_key: idempotencyKey })
+      .in('status', ['refunded', 'pending', 'succeeded'])
+      .order('created_at', { ascending: false })
+
+    if (priorRefundError) {
+      throw priorRefundError
+    }
+
+    if (Array.isArray(priorRefunds) && priorRefunds.length > 0) {
+      const totalPrior = priorRefunds.reduce(
+        (sum, row) => sum + Math.max(0, Number(row.amount || 0)),
+        0
+      )
+      const anyPending = priorRefunds.some((row) => row.status === 'pending')
+      const refundIds = priorRefunds
+        .map((row) => (row.metadata as Record<string, unknown> | null)?.['paypal_refund_id'])
+        .filter((id): id is string => typeof id === 'string')
+      return {
+        status: anyPending ? 'pending' : 'succeeded',
+        amount: roundCurrencyAmount(totalPrior),
+        currency: (priorRefunds[0]?.currency || 'GBP').toUpperCase(),
+        paypalRefundId: refundIds[0],
+        paypalRefundIds: refundIds.length > 0 ? refundIds : undefined,
+        reason: 'idempotent_replay'
+      }
+    }
+  }
+
   let paymentQuery = supabase
     .from('payments')
     .select('id, amount, currency, paypal_capture_id')

--- a/src/lib/events/refund-permissions.test.ts
+++ b/src/lib/events/refund-permissions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { canIssueEventRefund, SHARED_MANAGER_EMAIL } from './refund-permissions'
+
+describe('canIssueEventRefund', () => {
+  it('allows a manager', () => {
+    expect(canIssueEventRefund({ email: 'sam@the-anchor.pub', roleNames: ['manager'] })).toBe(true)
+  })
+
+  it('allows a super_admin', () => {
+    expect(canIssueEventRefund({ email: 'boss@the-anchor.pub', roleNames: ['super_admin'] })).toBe(true)
+  })
+
+  it('blocks the shared manager@the-anchor.pub account even with the manager role', () => {
+    expect(canIssueEventRefund({ email: SHARED_MANAGER_EMAIL, roleNames: ['manager'] })).toBe(false)
+    // case-insensitive
+    expect(canIssueEventRefund({ email: 'Manager@The-Anchor.PUB', roleNames: ['super_admin'] })).toBe(false)
+  })
+
+  it('blocks non-manager staff', () => {
+    expect(canIssueEventRefund({ email: 'staff@the-anchor.pub', roleNames: ['staff'] })).toBe(false)
+    expect(canIssueEventRefund({ email: 'staff@the-anchor.pub', roleNames: [] })).toBe(false)
+  })
+
+  it('blocks a missing email', () => {
+    expect(canIssueEventRefund({ email: null, roleNames: ['manager'] })).toBe(false)
+    expect(canIssueEventRefund({ email: '  ', roleNames: ['manager'] })).toBe(false)
+  })
+})

--- a/src/lib/events/refund-permissions.ts
+++ b/src/lib/events/refund-permissions.ts
@@ -1,0 +1,27 @@
+/**
+ * Who may issue an event-booking refund.
+ *
+ * Refunds move real money, so they're restricted to real managers: a user must
+ * hold the `manager` or `super_admin` role AND must NOT be the shared
+ * `manager@the-anchor.pub` login (a communal account we don't want issuing
+ * refunds unattributably). Cancelling a booking WITHOUT a refund is unaffected.
+ *
+ * The decision is a pure function so it can be unit-tested; callers fetch the
+ * user's email + role names (via the `get_user_roles` RPC) and pass them in.
+ */
+
+export const SHARED_MANAGER_EMAIL = (process.env.MANAGER_EMAIL || 'manager@the-anchor.pub')
+  .trim()
+  .toLowerCase()
+
+export const EVENT_REFUND_ROLES = ['manager', 'super_admin'] as const
+
+export function canIssueEventRefund(input: {
+  email: string | null | undefined
+  roleNames: readonly string[]
+}): boolean {
+  const email = (input.email || '').trim().toLowerCase()
+  if (!email) return false
+  if (email === SHARED_MANAGER_EMAIL) return false
+  return input.roleNames.some((name) => (EVENT_REFUND_ROLES as readonly string[]).includes(name))
+}


### PR DESCRIPTION
## What
Replaces the automatic time-tiered refund on event-booking cancellation with a **manager decision**: at cancel time a manager chooses whether to refund and how much (full or partial).

- **Guard** `canIssueEventRefund` — `manager`/`super_admin` only, **excluding** the shared `manager@the-anchor.pub` account (unit-tested).
- **`cancelEventManualBooking`** — new `refundDecision` (`none|full|partial`) + `refundAmount`; a **paid** booking can only be cancelled by someone who may refund; refund is capped at `captured − already refunded`; the 7d/3d/0 policy is now only a UI *suggestion*. Adds an audit-log entry.
- **`getEventBookingRefundInfo`** — feeds the dialog (max refundable, policy suggestion, whether the user may refund).
- **Cancel dialog** (`EventDetailClient`) — refund checkbox + full/partial amount, shown only to permitted managers; others see why a paid booking needs a manager.
- **`processEventRefund`** — honours `metadata.idempotency_key` to prevent double-refunds on retry / concurrent cancels.

## Decisions (with owner)
Manager **or** super_admin, never the shared login. Manager sets the amount (default full, editable down). Whole-event venue cancels unchanged (100%). A paid booking is manager-only to cancel.

## Testing
- [x] `canIssueEventRefund` unit tests (manager ✓ / super_admin ✓ / shared email ✗ / staff ✗)
- [x] `npx tsc --noEmit` clean, `npm run lint` (0 warnings), `npm run build` success
- [ ] Manual (recommend before/after merge): manager cancel none/full/partial against PayPal sandbox; non-manager blocked from refund + from cancelling a paid booking; double-submit doesn't double-refund.

## Depends on / part of
Part 2 of 3 (PR1 removed guest self-cancel; PR3 adds refund reconciliation + notify). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)