### PR TITLE
feat(events): reconcile + notify async PayPal refunds

### DIFF
--- a/src/app/api/cron/event-paypal-reconciliation/route.ts
+++ b/src/app/api/cron/event-paypal-reconciliation/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { authorizeCronRequest } from '@/lib/cron-auth'
 import { createAdminClient } from '@/lib/supabase/admin'
-import { getPayPalOrder } from '@/lib/paypal'
+import { getPayPalOrder, getPayPalRefund } from '@/lib/paypal'
 import { logger } from '@/lib/logger'
 import {
   sendEventPaymentConfirmationSms,
@@ -11,6 +11,7 @@ import {
   sendEventPaymentConfirmationEmail,
   sendEventPaymentManualReviewEmail,
 } from '@/lib/email/event-ticket-emails'
+import { reconcileEventRefund } from '@/lib/events/refund-reconciliation'
 
 function extractCapture(order: any): { id: string; amount: number; currency: string } | null {
   const capture = order?.purchase_units?.[0]?.payments?.captures?.[0]
@@ -36,6 +37,9 @@ export async function GET(request: NextRequest) {
     manualReview: 0,
     skipped: 0,
     failed: 0,
+    refundsChecked: 0,
+    refundsResolved: 0,
+    refundsFailed: 0,
   }
 
   const { data: rows, error } = await supabase
@@ -118,6 +122,49 @@ export async function GET(request: NextRequest) {
           orderId: row.paypal_order_id,
         },
       })
+    }
+  }
+
+  // Sweep pending refunds that PayPal accepted but hasn't reported terminal yet
+  // (backstop for a missed PAYMENT.REFUND.* webhook).
+  const { data: refundRows, error: refundError } = await supabase
+    .from('payments')
+    .select('id, event_booking_id, metadata')
+    .eq('payment_provider', 'paypal')
+    .eq('charge_type', 'refund')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(100)
+
+  if (refundError) {
+    logger.error('Failed to load pending event refunds for reconciliation', {
+      error: new Error(refundError.message),
+    })
+  } else {
+    for (const row of refundRows || []) {
+      const refundId = (row.metadata as Record<string, unknown> | null)?.['paypal_refund_id']
+      if (typeof refundId !== 'string' || !refundId) {
+        result.skipped++
+        continue
+      }
+      result.refundsChecked++
+      try {
+        const refund = await getPayPalRefund(refundId)
+        const reconciled = await reconcileEventRefund(supabase, {
+          paypalRefundId: refundId,
+          paypalStatus: refund.status,
+        })
+        if (reconciled.changed) {
+          if (reconciled.outcome === 'failed') result.refundsFailed++
+          else result.refundsResolved++
+        }
+      } catch (err) {
+        result.refundsFailed++
+        logger.error('Failed to reconcile event PayPal refund', {
+          error: err instanceof Error ? err : new Error(String(err)),
+          metadata: { paymentId: row.id, bookingId: row.event_booking_id, refundId },
+        })
+      }
     }
   }
 

--- a/src/app/api/webhooks/paypal/event-bookings/route.ts
+++ b/src/app/api/webhooks/paypal/event-bookings/route.ts
@@ -16,10 +16,18 @@ import {
   persistIdempotencyResponse,
   releaseIdempotencyClaim,
 } from '@/lib/api/idempotency'
+import { reconcileEventRefund } from '@/lib/events/refund-reconciliation'
 
 export const dynamic = 'force-dynamic'
 
 const IDEMPOTENCY_TTL_HOURS = 24 * 30
+
+const REFUND_EVENT_TYPES = new Set([
+  'PAYMENT.CAPTURE.REFUNDED',
+  'PAYMENT.REFUND.COMPLETED',
+  'PAYMENT.REFUND.FAILED',
+  'PAYMENT.REFUND.CANCELLED',
+])
 
 function getCaptureOrderId(resource: any): string | null {
   const raw = resource?.supplementary_data?.related_ids?.order_id
@@ -110,6 +118,44 @@ export async function POST(request: NextRequest): Promise<Response> {
     const eventType = typeof event?.event_type === 'string' ? event.event_type : 'unknown'
     if (!eventId) {
       return NextResponse.json({ error: 'Missing event id' }, { status: 400 })
+    }
+
+    // Refund lifecycle events → reconcile the local refund row + notify.
+    if (REFUND_EVENT_TYPES.has(eventType)) {
+      idempotencyKey = `webhook:paypal:event-bookings:${eventId}`
+      requestHash = computeIdempotencyRequestHash(event)
+      const refundClaim = await claimIdempotencyKey(supabase, idempotencyKey, requestHash, IDEMPOTENCY_TTL_HOURS)
+      if (refundClaim.state === 'conflict') {
+        return NextResponse.json({ error: 'Conflict' }, { status: 409 })
+      }
+      if (refundClaim.state === 'in_progress') {
+        return NextResponse.json({ error: 'Event is currently being processed' }, { status: 409 })
+      }
+      if (refundClaim.state === 'replay') {
+        return NextResponse.json({ received: true, duplicate: true })
+      }
+      claimHeld = true
+
+      const refundResource = event.resource || {}
+      const refundId = typeof refundResource?.id === 'string' ? refundResource.id.trim() : ''
+      const refundStatus = typeof refundResource?.status === 'string' ? refundResource.status : null
+
+      let reconcileState: Record<string, unknown> = { state: 'ignored', reason: 'missing_refund_id', event_id: eventId }
+      if (refundId) {
+        const reconciled = await reconcileEventRefund(supabase, { paypalRefundId: refundId, paypalStatus: refundStatus })
+        reconcileState = {
+          state: 'refund_reconciled',
+          matched: reconciled.matched,
+          changed: reconciled.changed,
+          outcome: reconciled.outcome,
+          event_id: eventId,
+          booking_id: reconciled.bookingId,
+        }
+      }
+
+      await persistIdempotencyResponse(supabase, idempotencyKey, requestHash, reconcileState, IDEMPOTENCY_TTL_HOURS)
+      claimHeld = false
+      return NextResponse.json({ received: true, ...reconcileState })
     }
 
     if (eventType !== 'PAYMENT.CAPTURE.COMPLETED') {

--- a/src/lib/email/event-ticket-emails.ts
+++ b/src/lib/email/event-ticket-emails.ts
@@ -489,6 +489,49 @@ export async function sendEventBookingCancelledEmail(
   })
 }
 
+export async function sendEventRefundStatusUpdateEmail(
+  supabase: SupabaseClient<any, 'public', any>,
+  input: {
+    bookingId: string
+    outcome: 'completed' | 'failed'
+    amount?: number | null
+    currency?: string | null
+  }
+): Promise<EventEmailResult> {
+  const context = await loadEventTicketEmailContext(supabase, input.bookingId)
+  if (!context) return { success: false, skipped: true }
+
+  const amountText = formatCurrency(input.amount ?? null, input.currency || 'GBP')
+  const heading = input.outcome === 'completed' ? 'Refund processed' : 'Refund update'
+  const line = input.outcome === 'completed'
+    ? `Your refund${amountText ? ` of ${amountText}` : ''} for ${context.eventName} has now been processed to your original payment method.`
+    : `We hit a snag processing your refund${amountText ? ` of ${amountText}` : ''} for ${context.eventName}. Our team is sorting it and will be in touch.`
+  const body = [
+    `Hi ${context.firstName},`,
+    line,
+    'Reply to this email or contact us if you need help.',
+  ]
+
+  return sendEmail({
+    requireLog: true,
+    to: context.email,
+    subject: input.outcome === 'completed'
+      ? `Refund processed: ${context.eventName}`
+      : `Refund update: ${context.eventName}`,
+    text: [...body, '', 'The Anchor'].join('\n'),
+    html: buildServiceMessageHtml({ heading, body }),
+    commType: 'event_refund_update',
+    customerId: context.customerId,
+    eventBookingId: context.bookingId,
+    metadata: {
+      template_key: 'event_refund_update_email',
+      refund_outcome: input.outcome,
+      refund_amount: input.amount ?? null,
+      currency: input.currency || 'GBP',
+    },
+  })
+}
+
 export async function sendEventTicketTransferredEmail(
   supabase: SupabaseClient<any, 'public', any>,
   input: {

--- a/src/lib/events/refund-reconciliation.test.ts
+++ b/src/lib/events/refund-reconciliation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { mapPayPalRefundStatus } from './refund-reconciliation'
+
+describe('mapPayPalRefundStatus', () => {
+  it('maps COMPLETED to refunded', () => {
+    expect(mapPayPalRefundStatus('COMPLETED')).toBe('refunded')
+    expect(mapPayPalRefundStatus('completed')).toBe('refunded')
+  })
+
+  it('maps PENDING to pending', () => {
+    expect(mapPayPalRefundStatus('PENDING')).toBe('pending')
+  })
+
+  it('maps FAILED and CANCELLED to failed', () => {
+    expect(mapPayPalRefundStatus('FAILED')).toBe('failed')
+    expect(mapPayPalRefundStatus('CANCELLED')).toBe('failed')
+  })
+
+  it('maps unknown/empty to unknown', () => {
+    expect(mapPayPalRefundStatus('SOMETHING_ELSE')).toBe('unknown')
+    expect(mapPayPalRefundStatus(null)).toBe('unknown')
+    expect(mapPayPalRefundStatus(undefined)).toBe('unknown')
+  })
+})

--- a/src/lib/events/refund-reconciliation.ts
+++ b/src/lib/events/refund-reconciliation.ts
@@ -1,0 +1,112 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { logger } from '@/lib/logger'
+import { sendEventRefundStatusUpdateEmail } from '@/lib/email/event-ticket-emails'
+
+export type RefundOutcome = 'refunded' | 'pending' | 'failed' | 'unknown'
+
+/** Map a PayPal refund status to our `payments.status` value. */
+export function mapPayPalRefundStatus(status: string | null | undefined): RefundOutcome {
+  switch ((status || '').toUpperCase()) {
+    case 'COMPLETED':
+      return 'refunded'
+    case 'PENDING':
+      return 'pending'
+    case 'FAILED':
+    case 'CANCELLED':
+      return 'failed'
+    default:
+      return 'unknown'
+  }
+}
+
+export type ReconcileRefundResult = {
+  matched: boolean
+  changed: boolean
+  outcome: RefundOutcome
+  bookingId: string | null
+}
+
+/**
+ * Reconcile an event refund's local status against PayPal. Finds the refund
+ * `payments` row by its PayPal refund id and — only on a `pending` → terminal
+ * transition — flips it once (concurrency-safe via a conditional update),
+ * notifies the customer, and raises a staff exception on failure. Safe to call
+ * from both the PayPal webhook and the reconciliation cron.
+ */
+export async function reconcileEventRefund(
+  supabase: SupabaseClient<any, 'public', any>,
+  input: { paypalRefundId: string; paypalStatus: string | null | undefined }
+): Promise<ReconcileRefundResult> {
+  const outcome = mapPayPalRefundStatus(input.paypalStatus)
+
+  const { data: row, error } = await supabase
+    .from('payments')
+    .select('id, status, amount, currency, event_booking_id, metadata')
+    .eq('charge_type', 'refund')
+    .contains('metadata', { paypal_refund_id: input.paypalRefundId })
+    .limit(1)
+    .maybeSingle()
+
+  if (error) throw error
+  if (!row) {
+    return { matched: false, changed: false, outcome, bookingId: null }
+  }
+
+  const bookingId = (row.event_booking_id as string | null) ?? null
+
+  // Only act on a pending → terminal transition; anything else is already settled.
+  if (row.status !== 'pending' || outcome === 'pending' || outcome === 'unknown') {
+    return { matched: true, changed: false, outcome, bookingId }
+  }
+
+  const mergedMetadata = {
+    ...((row.metadata as Record<string, unknown> | null) ?? {}),
+    paypal_refund_status: input.paypalStatus ?? null,
+    refund_reconciled_at: new Date().toISOString(),
+  }
+
+  // Concurrency-safe: only the caller that actually flips it out of 'pending'
+  // (webhook or cron, whichever wins) proceeds to notify.
+  const { data: updated, error: updateError } = await supabase
+    .from('payments')
+    .update({ status: outcome, metadata: mergedMetadata })
+    .eq('id', row.id)
+    .eq('status', 'pending')
+    .select('id')
+
+  if (updateError) throw updateError
+  if (!updated || updated.length === 0) {
+    return { matched: true, changed: false, outcome, bookingId }
+  }
+
+  const amount = Math.max(0, Number(row.amount || 0))
+  const currency = typeof row.currency === 'string' ? row.currency : 'GBP'
+
+  if (!bookingId) {
+    return { matched: true, changed: true, outcome, bookingId }
+  }
+
+  if (outcome === 'refunded') {
+    await sendEventRefundStatusUpdateEmail(supabase, { bookingId, outcome: 'completed', amount, currency })
+      .catch((e) => logger.warn('Failed to send refund completed email', {
+        metadata: { bookingId, error: e instanceof Error ? e.message : String(e) }
+      }))
+  } else if (outcome === 'failed') {
+    const { error: exceptionError } = await supabase.from('event_payment_exceptions').insert({
+      event_booking_id: bookingId,
+      payment_id: row.id,
+      reason: 'manual_refund_required',
+    })
+    if (exceptionError) {
+      logger.error('Failed to raise event refund exception', {
+        metadata: { bookingId, paymentId: row.id, error: exceptionError.message }
+      })
+    }
+    await sendEventRefundStatusUpdateEmail(supabase, { bookingId, outcome: 'failed', amount, currency })
+      .catch((e) => logger.warn('Failed to send refund failed email', {
+        metadata: { bookingId, error: e instanceof Error ? e.message : String(e) }
+      }))
+  }
+
+  return { matched: true, changed: true, outcome, bookingId }
+}

--- a/src/lib/paypal.ts
+++ b/src/lib/paypal.ts
@@ -463,6 +463,48 @@ export async function refundPayPalPayment(
   };
 }
 
+// Fetch the current status of a PayPal refund (used to reconcile refunds that
+// PayPal accepted as PENDING and later completed/failed asynchronously).
+export async function getPayPalRefund(refundId: string): Promise<{
+  refundId: string;
+  status: string;
+  statusDetails?: string;
+  amount: string | null;
+  currency: string | null;
+}> {
+  const accessToken = await getAccessToken();
+  const { baseUrl } = getPayPalConfig();
+
+  const response = await retry(
+    async () => fetch(`${baseUrl}/v2/payments/refunds/${refundId}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }),
+    RetryConfigs.api
+  );
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(
+      error?.details?.[0]?.description || error?.message || `Failed to fetch PayPal refund ${refundId}`
+    );
+  }
+
+  const data = await response.json();
+  return {
+    refundId: data.id ?? refundId,
+    status: data.status,
+    statusDetails: data.status_details?.reason,
+    amount: typeof data.amount?.value === 'string' ? data.amount.value : null,
+    currency: typeof data.amount?.currency_code === 'string'
+      ? data.amount.currency_code.trim().toUpperCase()
+      : null,
+  };
+}
+
 // Verify webhook signature
 const PAYPAL_WEBHOOK_TRANSMISSION_TOLERANCE_MS = 5 * 60 * 1000
 


### PR DESCRIPTION
## What
Completes refund handling so a PayPal refund left **PENDING** (or that later **fails**) is reconciled and the customer re-notified — previously it could stick indefinitely with no follow-up.

- **`reconcileEventRefund`** — finds the refund `payments` row by PayPal refund id; on a `pending` → terminal transition flips it **once** (concurrency-safe conditional update), emails the customer on completion, and on failure raises an `event_payment_exceptions` (`manual_refund_required`) worklist item + a calm customer notice.
- **Event PayPal webhook** — now handles `PAYMENT.CAPTURE.REFUNDED` / `PAYMENT.REFUND.{COMPLETED,FAILED,CANCELLED}` (signature-verified + idempotent).
- **Reconciliation cron** — sweeps pending refunds as a backstop via a new `getPayPalRefund()` helper.
- **`sendEventRefundStatusUpdateEmail`** — refund completed / failed notice.

## Testing
- [x] `mapPayPalRefundStatus` unit tests; `npx tsc --noEmit` clean, `npm run lint` (0 warnings), `npm run build` success

## Config note
For real-time reconciliation, the PayPal app webhook (`PAYPAL_EVENT_BOOKINGS_WEBHOOK_ID`) must be subscribed to the `PAYMENT.REFUND.*` / `PAYMENT.CAPTURE.REFUNDED` events. The cron is the backstop if a webhook is missed.

## Part of
Part 3 of 3 (PR1 removed guest self-cancel; PR2 added the manager refund choice). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)