### PR TITLE
Update calendar sync and event operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,8 @@ STRIPE_WEBHOOK_SECRET=whsec_your_webhook_secret
 SYSTEM_USER_ID=00000000-0000-0000-0000-000000000000
 
 # Google Calendar Configuration (Optional)
-# Private bookings, birthdays, event booking aggregates, AND recruitment interviews/trials
-# use the shared Pub Ops calendar.
+# Private bookings, birthdays, event booking aggregates, calendar notes, AND
+# recruitment interviews/trials use the shared Pub Ops calendar.
 # GOOGLE_CALENDAR_ID is kept for legacy tooling and should match that shared calendar if present.
 GOOGLE_CALENDAR_ID=f9712733d9040b99f0ac9846911447034a4d70e8a6f06b571be130014606c504@group.calendar.google.com
 # Optional: put recruitment interviews/trials on a separate calendar instead of the shared one.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -61,7 +61,7 @@ RBAC check in actions: `checkUserPermission('module', 'action')`. Roles: `super_
 | Stripe (8) | `src/lib/table-bookings/{refunds,charge-approvals,bookings}.ts` | Card capture/charges/refunds; webhook |
 | PayPal (REST, no SDK) | `src/lib/paypal.ts`, `src/lib/paypal-refund-webhook.ts`, `src/lib/table-bookings/paypal-deposit.ts`, `src/lib/parking/payments.ts` | Deposits/payments for table bookings, parking, private bookings, events; 4 webhooks |
 | OpenAI (7) | `src/lib/openai.ts`, `src/lib/receipts/ai-classification.ts`, `src/lib/recruitment/ai.ts` | Receipt classification, recruitment CV parsing, event content |
-| Google Calendar (3) | `src/lib/google-calendar.ts`, `-rota.ts`, `-events.ts` | Rota/interview/event calendar sync |
+| Google Calendar (4) | `src/lib/google-calendar.ts`, `-rota.ts`, `-events.ts`, `-notes.ts` | Rota/interview/event/calendar-note sync |
 | Resend (2) | `src/lib/email/emailService.ts` | Alternate email provider + svix-verified webhook |
 | Puppeteer / PDFKit / ExcelJS | `src/lib/pdf-generator.ts`, `src/lib/receipts/export/claim-summary-pdf.ts`, `src/lib/rota/excel-export.ts`, `src/lib/pnl/spreadsheet-export.ts` | PDF/Excel generation |
 | QR codes | `src/services/event-marketing.ts` | Event marketing short-link QRs |

--- a/docs/architecture/relationships.md
+++ b/docs/architecture/relationships.md
@@ -49,7 +49,7 @@ Most-referenced tables (from `.from('…')` usage in `'use server'` files; via-s
 | menu_dishes (+ menu ingredients/recipes via lib) | menu-management.ts, `src/lib/menu/*` |
 | customer_labels / customer_label_assignments | customer-labels.ts, customer-labels-bulk.ts |
 | message_templates | messageTemplates.ts |
-| calendar_notes | calendar-notes.ts, rota-day-info.ts, dashboard-data.ts |
+| calendar_notes / calendar_note_google_sync_queue | calendar-notes.ts, rota-day-info.ts, dashboard-data.ts, `src/lib/google-calendar-notes.ts` |
 | business_hours / special_hours | business-hours.ts, missing-cashups.ts |
 | api_keys | `settings/api-keys/actions.ts`; validated by external API routes |
 | audit_logs | audit.ts (writer used by ~60 action files), auditLogs.ts (reader), portalPayPalActions.ts |
@@ -69,7 +69,7 @@ Most-referenced tables (from `.from('…')` usage in `'use server'` files; via-s
 | PayPal | `src/lib/paypal.ts` (orders + `verifyPayPalWebhook`), `src/lib/paypal-refund-webhook.ts` | table-booking deposits (`src/lib/table-bookings/paypal-deposit.ts`), parking (`src/lib/parking/payments.ts`), private bookings (portalPayPalActions.ts), event payments (`src/lib/events/event-payments.ts`); 4 webhook routes + `/api/cron/paypal-deposit-reconciliation` |
 | Stripe | `src/lib/table-bookings/{charge-approvals,refunds,bookings}.ts` | card capture (`/g/[token]/card-capture`), charge requests (`/m/[token]/charge-request`), `/api/stripe/webhook` |
 | OpenAI | `src/lib/openai.ts`, `src/lib/openai/config.ts` | receipts classification (`src/lib/receipts/ai-classification.ts`), recruitment CV parsing (`src/lib/recruitment/ai.ts`), menu AI parse (`/api/menu/ai-parse`), event content (ai model env overrides) |
-| Google Calendar | `src/lib/google-calendar.ts`, `google-calendar-rota.ts`, `google-calendar-events.ts` | rota shift sync (`/api/rota/resync-calendar`), interview bookings, `/api/cron/pub-ops-event-calendar-sync`, `/api/cron/recruitment-calendar-retry` |
+| Google Calendar | `src/lib/google-calendar.ts`, `google-calendar-rota.ts`, `google-calendar-events.ts`, `google-calendar-notes.ts` | rota shift sync (`/api/rota/resync-calendar`), interview bookings, event sync (`/api/cron/pub-ops-event-calendar-sync`), calendar-note sync (`/api/cron/pub-ops-calendar-note-sync`), `/api/cron/recruitment-calendar-retry` |
 | Puppeteer PDF | `src/lib/pdf-generator.ts` | invoice/quote PDFs (`/api/invoices/[id]/pdf`, `/api/quotes/[id]/pdf`), contracts |
 | PDFKit | `src/lib/receipts/export/claim-summary-pdf.ts` | receipts/expense claim exports |
 | ExcelJS | `src/lib/rota/excel-export.ts`, `src/lib/pnl/spreadsheet-export.ts` | `/api/rota/export`, P&L export |

--- a/scripts/database/update-upcoming-event-menu-copy.ts
+++ b/scripts/database/update-upcoming-event-menu-copy.ts
@@ -1,0 +1,334 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+
+import dotenv from 'dotenv'
+import path from 'path'
+import { createAdminClient } from '../../src/lib/supabase/admin'
+import {
+  assertScriptExpectedRowCount,
+  assertScriptMutationAllowed,
+  assertScriptMutationSucceeded,
+  assertScriptQuerySucceeded,
+} from '../../src/lib/script-mutation-safety'
+
+const SCRIPT_NAME = 'update-upcoming-event-menu-copy'
+const RUN_MUTATION_ENV = 'RUN_UPDATE_EVENT_MENU_COPY_MUTATION'
+const ALLOW_MUTATION_ENV = 'ALLOW_UPDATE_EVENT_MENU_COPY_MUTATION_SCRIPT'
+const HARD_CAP = 4
+
+const EVENT_CHANGES = [
+  {
+    id: '27e85126-e3cd-40ae-81c3-e1bf804664b5',
+    name: 'Music Bingo',
+    date: '2026-07-17',
+    fields: {
+      brief: [
+        {
+          from: 'Food is served from **4:00pm to 9:00pm**, including our stone-baked pizzas, perfect for sharing before the bingo madness begins.',
+          to: 'Our full menu is available from **4:00pm to 9:00pm**, so come early, order some food and settle in before the bingo madness begins.',
+        },
+      ],
+      long_description: [
+        {
+          from: 'Our kitchen will be serving up delicious stone-baked pizzas from 4pm to 9pm. So, grab a slice and a drink, and soak up the buzzing atmosphere before the bingo madness kicks off.',
+          to: 'Our full menu will be available from 4pm to 9pm. Grab some food and a drink, then soak up the buzzing atmosphere before the bingo madness kicks off.',
+        },
+      ],
+    },
+    highlight: {
+      from: 'delicious stone-baked pizzas available',
+      to: 'full menu available until 9pm',
+    },
+  },
+  {
+    id: '39881f94-d652-407b-8075-ae371a295c6f',
+    name: 'Quiz Night',
+    date: '2026-07-22',
+    fields: {
+      brief: [
+        {
+          from: 'The kitchen is open from **4:00pm to 9:00pm**, so you can come early, grab food, get a drink, settle in and be ready for the quiz to kick off.',
+          to: 'Our full menu is available from **4:00pm to 9:00pm**, so you can come early, order food, get a drink, settle in and be ready for the quiz to kick off.',
+        },
+      ],
+      long_description: [
+        {
+          from: 'The kitchen is serving pizza from 4:00pm to 9:00pm, so you can enjoy some tasty food while you get ready to quiz.',
+          to: 'Our full menu is available from 4:00pm to 9:00pm, so you can enjoy some food while you get ready to quiz.',
+        },
+      ],
+    },
+  },
+  {
+    id: '50997319-dae7-45f1-ad0f-8ad55002d5af',
+    name: 'Cash Bingo',
+    date: '2026-07-29',
+    fields: {
+      brief: [
+        {
+          from: 'Kitchen open **4:00pm to 9:00pm**.',
+          to: 'Our full menu is available from **4:00pm to 9:00pm**.',
+        },
+        {
+          from: 'Don’t miss our freshly stone-baked authentic Italian pizzas. There’s a wide range to choose from, seriously good ingredients, and if you can’t finish it, you can take the rest home.',
+          to: 'Come early, order some food and get settled before the games begin.',
+        },
+      ],
+      long_description: [
+        {
+          from: 'Our kitchen serves up delicious stone-baked pizzas until 9:00pm, perfect for a bite while you play.',
+          to: 'Our full menu is available until 9:00pm, perfect for ordering a bite while you play.',
+        },
+      ],
+    },
+    highlight: {
+      from: 'delicious stone-baked pizzas',
+      to: 'full menu available until 9pm',
+    },
+  },
+] as const
+
+const FAQ_CHANGE = {
+  id: 'bd9b8d6f-f4a6-401a-ac5a-a1febab0958d',
+  from: 'The kitchen serves pizza from 4:00pm to 9:00pm on quiz nights, and there are plenty of drinks available at the bar.',
+  to: 'Our full menu is available from 4:00pm to 9:00pm on quiz nights, with drinks available from the bar throughout the event.',
+} as const
+
+type EventRow = {
+  id: string
+  name: string
+  date: string
+  brief: string | null
+  long_description: string | null
+  highlights: unknown
+}
+
+type EventUpdate = {
+  brief?: string
+  long_description?: string
+  highlights?: string[]
+}
+
+const TRUTHY = new Set(['1', 'true', 'yes', 'on'])
+
+function isTruthy(value: string | undefined): boolean {
+  return value ? TRUTHY.has(value.trim().toLowerCase()) : false
+}
+
+function readLimit(argv: string[]): number | null {
+  const index = argv.indexOf('--limit')
+  const raw = index >= 0 ? argv[index + 1] : null
+  if (!raw || !/^[1-9]\d*$/.test(raw)) return null
+  return Number(raw)
+}
+
+function replaceExact(
+  current: string,
+  replacement: { from: string; to: string },
+  label: string,
+): { value: string; changed: boolean } {
+  if (current.includes(replacement.from)) {
+    return {
+      value: current.replace(replacement.from, replacement.to),
+      changed: true,
+    }
+  }
+  if (current.includes(replacement.to)) {
+    return { value: current, changed: false }
+  }
+  throw new Error(`[${SCRIPT_NAME}] Expected copy not found in ${label}`)
+}
+
+function buildEventUpdate(
+  row: EventRow,
+  change: (typeof EVENT_CHANGES)[number],
+): EventUpdate {
+  if (row.name !== change.name || row.date !== change.date) {
+    throw new Error(
+      `[${SCRIPT_NAME}] Event identity mismatch for ${change.id}: expected ${change.name} on ${change.date}, found ${row.name} on ${row.date}`,
+    )
+  }
+
+  const update: EventUpdate = {}
+  for (const field of ['brief', 'long_description'] as const) {
+    const replacements = change.fields[field]
+    if (!replacements) continue
+
+    const current = row[field]
+    if (!current) {
+      throw new Error(`[${SCRIPT_NAME}] ${change.name} has no ${field}`)
+    }
+
+    let next = current
+    let changed = false
+    for (const replacement of replacements) {
+      const result = replaceExact(next, replacement, `${change.name}.${field}`)
+      next = result.value
+      changed ||= result.changed
+    }
+    if (changed) update[field] = next
+  }
+
+  if ('highlight' in change) {
+    if (!Array.isArray(row.highlights) || !row.highlights.every((item) => typeof item === 'string')) {
+      throw new Error(`[${SCRIPT_NAME}] ${change.name} highlights are not a string array`)
+    }
+    const currentHighlights = row.highlights as string[]
+    if (currentHighlights.includes(change.highlight.from)) {
+      update.highlights = currentHighlights.map((item) =>
+        item === change.highlight.from ? change.highlight.to : item
+      )
+    } else if (!currentHighlights.includes(change.highlight.to)) {
+      throw new Error(`[${SCRIPT_NAME}] Expected highlight not found for ${change.name}`)
+    }
+  }
+
+  return update
+}
+
+async function main(): Promise<void> {
+  dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
+
+  const confirm = process.argv.includes('--confirm')
+  const dryRun = !confirm || process.argv.includes('--dry-run')
+  const limit = readLimit(process.argv)
+  const supabase = createAdminClient()
+  const ids = EVENT_CHANGES.map((change) => change.id)
+
+  const { data: eventData, error: eventError } = await supabase
+    .from('events')
+    .select('id, name, date, brief, long_description, highlights')
+    .in('id', ids)
+
+  const events = (assertScriptQuerySucceeded({
+    operation: 'Load target events',
+    error: eventError,
+    data: (eventData ?? []) as EventRow[],
+  }) ?? []) as EventRow[]
+
+  assertScriptExpectedRowCount({
+    operation: 'Load target events',
+    expected: EVENT_CHANGES.length,
+    actual: events.length,
+  })
+
+  const eventById = new Map(events.map((event) => [event.id, event]))
+  const eventPlans = EVENT_CHANGES.map((change) => {
+    const row = eventById.get(change.id)
+    if (!row) throw new Error(`[${SCRIPT_NAME}] Missing target event ${change.id}`)
+    return { id: change.id, name: change.name, update: buildEventUpdate(row, change) }
+  }).filter((plan) => Object.keys(plan.update).length > 0)
+
+  const { data: faqData, error: faqError } = await supabase
+    .from('event_faqs')
+    .select('id, answer')
+    .eq('id', FAQ_CHANGE.id)
+    .maybeSingle()
+
+  const faq = assertScriptQuerySucceeded({
+    operation: 'Load target event FAQ',
+    error: faqError,
+    data: faqData,
+  }) as { id: string; answer: string }
+  const faqResult = replaceExact(faq.answer, FAQ_CHANGE, 'Quiz Night FAQ')
+  const plannedOperations = eventPlans.length + (faqResult.changed ? 1 : 0)
+
+  console.log(`[${SCRIPT_NAME}] ${dryRun ? 'DRY RUN' : 'MUTATION'}`)
+  console.log(`[${SCRIPT_NAME}] event updates=${eventPlans.length}; FAQ updates=${faqResult.changed ? 1 : 0}`)
+  for (const plan of eventPlans) {
+    console.log(`[${SCRIPT_NAME}] ${plan.name}: ${Object.keys(plan.update).join(', ')}`)
+  }
+
+  if (dryRun) {
+    console.log(`[${SCRIPT_NAME}] No database changes made.`)
+    return
+  }
+
+  if (!isTruthy(process.env[RUN_MUTATION_ENV])) {
+    throw new Error(`[${SCRIPT_NAME}] Set ${RUN_MUTATION_ENV}=true to allow updates`)
+  }
+  assertScriptMutationAllowed({ scriptName: SCRIPT_NAME, envVar: ALLOW_MUTATION_ENV })
+  if (limit === null || limit > HARD_CAP || plannedOperations > limit) {
+    throw new Error(
+      `[${SCRIPT_NAME}] Use --limit ${HARD_CAP}; planned operations=${plannedOperations}, hard cap=${HARD_CAP}`,
+    )
+  }
+
+  for (const plan of eventPlans) {
+    const { data, error } = await supabase
+      .from('events')
+      .update(plan.update)
+      .eq('id', plan.id)
+      .select('id')
+    const { updatedCount } = assertScriptMutationSucceeded({
+      operation: `Update ${plan.name}`,
+      error,
+      updatedRows: data,
+    })
+    assertScriptExpectedRowCount({
+      operation: `Update ${plan.name}`,
+      expected: 1,
+      actual: updatedCount,
+    })
+  }
+
+  if (faqResult.changed) {
+    const { data, error } = await supabase
+      .from('event_faqs')
+      .update({ answer: faqResult.value })
+      .eq('id', FAQ_CHANGE.id)
+      .select('id')
+    const { updatedCount } = assertScriptMutationSucceeded({
+      operation: 'Update Quiz Night FAQ',
+      error,
+      updatedRows: data,
+    })
+    assertScriptExpectedRowCount({
+      operation: 'Update Quiz Night FAQ',
+      expected: 1,
+      actual: updatedCount,
+    })
+  }
+
+  const { data: verifiedEvents, error: verifyEventError } = await supabase
+    .from('events')
+    .select('id, brief, long_description, highlights')
+    .in('id', ids)
+  const verified = assertScriptQuerySucceeded({
+    operation: 'Verify updated events',
+    error: verifyEventError,
+    data: verifiedEvents ?? [],
+  }) as Array<{ id: string; brief: string | null; long_description: string | null; highlights: unknown }>
+
+  for (const row of verified) {
+    const text = [
+      row.brief ?? '',
+      row.long_description ?? '',
+      ...(Array.isArray(row.highlights) ? row.highlights.map(String) : []),
+    ].join(' ')
+    if (/pizzas?/i.test(text) || !/full menu/i.test(text)) {
+      throw new Error(`[${SCRIPT_NAME}] Verification failed for event ${row.id}`)
+    }
+  }
+
+  const { data: verifiedFaq, error: verifyFaqError } = await supabase
+    .from('event_faqs')
+    .select('answer')
+    .eq('id', FAQ_CHANGE.id)
+    .single()
+  const checkedFaq = assertScriptQuerySucceeded({
+    operation: 'Verify updated FAQ',
+    error: verifyFaqError,
+    data: verifiedFaq,
+  }) as { answer: string }
+  if (/pizzas?/i.test(checkedFaq.answer) || !/full menu/i.test(checkedFaq.answer)) {
+    throw new Error(`[${SCRIPT_NAME}] FAQ verification failed`)
+  }
+
+  console.log(`[${SCRIPT_NAME}] Update and verification complete.`)
+}
+
+void main().catch((error) => {
+  console.error(`[${SCRIPT_NAME}] Failed`, error)
+  process.exitCode = 1
+})

--- a/src/app/(authenticated)/events/_components/EventDrawer.tsx
+++ b/src/app/(authenticated)/events/_components/EventDrawer.tsx
@@ -496,6 +496,7 @@ export function EventDrawer({ open, onClose, event, categories, onSave }: EventD
         name: name.trim(),
         date: date || null,
         time: time || null,
+        endTime: endTime || null,
         categoryName: selectedCategory?.name ?? null,
         capacity: bookingMode === 'communal'
           ? (Number.parseInt(seatedCapacity || '0', 10) || 0) + (Number.parseInt(standingCapacity || '0', 10) || 0)

--- a/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
+++ b/src/app/(authenticated)/events/_components/EventTodosWidget.test.tsx
@@ -55,7 +55,7 @@ const TODAY = '2026-05-21'
 function makeItem(overrides: Partial<ChecklistTodoItem> = {}): ChecklistTodoItem {
   return {
     key: 'write_event_brief',
-    label: 'Write event brief',
+    label: 'Write Event Brief',
     offsetDays: -28,
     channel: 'Admin',
     required: true,
@@ -110,43 +110,43 @@ describe('EventTodosWidget', () => {
   })
 
   it('gives each checkbox an accessible name', () => {
-    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write Event Brief' })]} canManage todayIso={TODAY} />)
     expect(
-      screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }),
+      screen.getByRole('checkbox', { name: 'Mark "Write Event Brief" complete' }),
     ).toBeInTheDocument()
   })
 
   it('optimistically removes a todo on successful completion', async () => {
     mockToggle.mockResolvedValue({ success: true })
     const user = userEvent.setup()
-    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write Event Brief' })]} canManage todayIso={TODAY} />)
 
-    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write Event Brief" complete' }))
 
-    await waitFor(() => expect(screen.queryByText('Write event brief')).not.toBeInTheDocument())
+    await waitFor(() => expect(screen.queryByText('Write Event Brief')).not.toBeInTheDocument())
     expect(mockToggle).toHaveBeenCalledWith('evt-1', 'write_event_brief', true)
   })
 
   it('restores the todo and shows a toast when completion fails', async () => {
     mockToggle.mockResolvedValue({ success: false, error: 'nope' })
     const user = userEvent.setup()
-    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write Event Brief' })]} canManage todayIso={TODAY} />)
 
-    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write Event Brief" complete' }))
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('nope'))
-    expect(screen.getByText('Write event brief')).toBeInTheDocument()
+    expect(screen.getByText('Write Event Brief')).toBeInTheDocument()
   })
 
   it('restores the todo and shows a toast when the action throws/rejects', async () => {
     mockToggle.mockRejectedValue(new Error('network'))
     const user = userEvent.setup()
-    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write event brief' })]} canManage todayIso={TODAY} />)
+    render(<EventTodosWidget initialTodos={[makeItem({ label: 'Write Event Brief' })]} canManage todayIso={TODAY} />)
 
-    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write event brief" complete' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Mark "Write Event Brief" complete' }))
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled())
-    expect(screen.getByText('Write event brief')).toBeInTheDocument()
+    expect(screen.getByText('Write Event Brief')).toBeInTheDocument()
   })
 
   it('restores only the failed item when an earlier completion fails after a later one succeeds', async () => {

--- a/src/app/(authenticated)/settings/calendar-notes/page.tsx
+++ b/src/app/(authenticated)/settings/calendar-notes/page.tsx
@@ -19,7 +19,7 @@ export default async function CalendarNotesSettingsPage() {
   return (
     <PageLayout
       title="Calendar Notes"
-      subtitle="Manage important dates and generate AI-assisted calendar notes for holidays and key occasions."
+      subtitle="Manage important dates and generate AI-assisted notes. Saved notes sync to the shared Pub Ops Google Calendar."
       backButton={{ label: 'Back to Settings', href: '/settings' }}
     >
       <Section

--- a/src/app/actions/__tests__/event-content.test.ts
+++ b/src/app/actions/__tests__/event-content.test.ts
@@ -30,6 +30,10 @@ vi.mock('@/lib/openai/config', () => ({
   }),
 }))
 
+vi.mock('@/services/business-hours', () => ({
+  getKitchenWindowForDate: vi.fn().mockResolvedValue(null),
+}))
+
 // Mock retry to just call the function directly (no delay)
 vi.mock('@/lib/retry', () => ({
   retry: vi.fn(async (fn: () => Promise<unknown>) => fn()),
@@ -66,8 +70,8 @@ function buildValidSeoResponse(): Record<string, unknown> {
     'Expect an intimate atmosphere where every note resonates through the venue during this acoustic night performance. Jessica brings a unique blend of folk and contemporary acoustic sounds that create the perfect backdrop for a relaxed evening out with friends and family. Her setlist spans original compositions and carefully selected covers that showcase her remarkable vocal range and impressive guitar skills. The warmth of the room combined with the quality of the sound system make every seat feel like the best in the house for this live music experience.',
     // Para 3: ~85 words, performer
     'Jessica Lovelock has been captivating audiences across the south of England for over a decade with her live music performances at venues large and small. Known for her warm stage presence and natural ability to connect with every listener in the room, she transforms each performance into a shared experience that leaves lasting memories for all who attend. Her latest album received critical acclaim from music publications across the country and her touring schedule continues to grow as word spreads about her extraordinary talent and engaging stage presence.',
-    // Para 4: ~80 words, food/drink/venue, includes local keyword
-    'The Anchor provides the ideal setting for an acoustic night out at this popular pub near Heathrow, with a welcoming bar serving a selection of craft beers, wines, and cocktails throughout the evening. The kitchen will be open serving freshly made pizza so you can enjoy great food alongside the live music. The relaxed and friendly atmosphere makes The Anchor the perfect venue for enjoying quality entertainment in a comfortable Surrey setting.',
+    // Para 4: ~70 words, drink/venue, includes local keyword; kitchen is closed on Monday
+    'The Anchor provides the ideal setting for an acoustic night out at this popular pub near Heathrow, with a welcoming bar serving a selection of craft beers, wines, and cocktails throughout the evening. Settle in with a drink and enjoy the music in a relaxed, friendly local where it is easy to feel at home. The comfortable Surrey setting makes it a great place to catch up with friends while enjoying the live performance.',
     // Para 5: ~80 words, practical + booking
     'Tickets for this live music event are priced at just fifteen pounds per person, offering exceptional value for an evening of quality entertainment at The Anchor. With limited capacity available at the venue, early booking is strongly recommended to avoid disappointment and secure your preferred table position. Reserve your spot now to guarantee your place at what is expected to be one of the most popular live music events of the summer season.',
     // Para 6: ~85 words, local context
@@ -81,7 +85,7 @@ function buildValidSeoResponse(): Record<string, unknown> {
     longDescription: longParas.join('\n\n'),
     highlights: [
       'live music by jessica lovelock performing acoustic favourites',
-      'intimate acoustic night venue atmosphere with craft beers and pizza',
+      'intimate acoustic night venue atmosphere with craft beers',
       'free parking and just seven minutes from heathrow terminal five',
       'limited capacity so book early to secure your spot',
     ],
@@ -138,6 +142,7 @@ const VALID_INPUT = {
   name: 'Jessica Lovelock',
   date: '2026-06-15',
   time: '20:00',
+  endTime: '22:00',
   categoryName: 'Live Music',
   capacity: 60,
   brief: 'Acoustic set by Jessica Lovelock',

--- a/src/app/actions/calendar-notes.ts
+++ b/src/app/actions/calendar-notes.ts
@@ -6,6 +6,10 @@ import { createClient } from '@/lib/supabase/server'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { checkUserPermission } from '@/app/actions/rbac'
 import { getOpenAIConfig } from '@/lib/openai/config'
+import {
+  isPubOpsCalendarNoteSyncQueueAvailable,
+  processPubOpsCalendarNoteQueueItem,
+} from '@/lib/google-calendar-notes'
 import { logAuditEvent } from './audit'
 
 const DEFAULT_NOTE_COLOR = '#0EA5E9'
@@ -378,6 +382,11 @@ export async function createCalendarNote(input: CalendarNoteCreateInput): Promis
       console.error('Failed to write calendar note create audit log:', auditError)
     }
 
+    await processPubOpsCalendarNoteQueueItem(admin, note.id, {
+      operation: 'upsert',
+      context: { context: 'calendar_note_created' },
+    })
+
     revalidateCalendarSurfaces()
     return { data: note }
   } catch (error) {
@@ -478,6 +487,11 @@ export async function updateCalendarNote(noteId: string, input: CalendarNoteUpda
       console.error('Failed to write calendar note update audit log:', auditError)
     }
 
+    await processPubOpsCalendarNoteQueueItem(admin, note.id, {
+      operation: 'upsert',
+      context: { context: 'calendar_note_updated' },
+    })
+
     revalidateCalendarSurfaces()
     return { data: note }
   } catch (error) {
@@ -514,6 +528,10 @@ export async function deleteCalendarNote(noteId: string): Promise<{ success?: bo
       return { error: 'Calendar note not found.' }
     }
 
+    if (!await isPubOpsCalendarNoteSyncQueueAvailable(admin)) {
+      return { error: 'Calendar sync is not ready. The note was not deleted.' }
+    }
+
     const { data: deleted, error: deleteError } = await calendarNotesTable(admin)
       .delete()
       .eq('id', idParse.data)
@@ -543,6 +561,11 @@ export async function deleteCalendarNote(noteId: string): Promise<{ success?: bo
     } catch (auditError) {
       console.error('Failed to write calendar note delete audit log:', auditError)
     }
+
+    await processPubOpsCalendarNoteQueueItem(admin, noteId, {
+      operation: 'delete',
+      context: { context: 'calendar_note_deleted' },
+    })
 
     revalidateCalendarSurfaces()
     return { success: true }
@@ -821,6 +844,9 @@ export async function generateCalendarNotesWithAI(
     console.error('Failed to write AI calendar note generation audit log:', auditError)
   }
 
+  // The database trigger queues every inserted note. The scheduled Pub Ops
+  // worker processes the batch without blocking this request or bursting the
+  // Google Calendar API.
   revalidateCalendarSurfaces()
 
   return {

--- a/src/app/actions/event-checklist.ts
+++ b/src/app/actions/event-checklist.ts
@@ -106,7 +106,7 @@ async function getEventChecklistProgress(eventIds: string[]): Promise<{ success:
   }
 
   statuses?.forEach((status) => {
-    if (!status.completed_at) return
+    if (!status.completed_at || !EVENT_CHECKLIST_TASK_KEYS.has(status.task_key)) return
     const current = progress[status.event_id]
     if (!current) {
       progress[status.event_id] = { completed: 1, total: EVENT_CHECKLIST_DEFINITIONS.length }

--- a/src/app/actions/event-content.ts
+++ b/src/app/actions/event-content.ts
@@ -14,6 +14,7 @@ import {
 import type { SeoValidationIssue } from '@/lib/seo-validation'
 import {
   buildEventSeoFacts,
+  describeKitchenServiceForEvent,
   preflightCheck,
   ANCHOR_VENUE_CONTEXT,
   CONTENT_RETRY_CONFIG,
@@ -23,6 +24,7 @@ import {
 } from '@/lib/event-seo/generation'
 import type { BuildFactsInput, BuildFactsDbData } from '@/lib/event-seo/generation'
 import { buildGenerationMessages, buildRepairMessages } from '@/lib/event-seo/prompts'
+import { getKitchenWindowForDate } from '@/services/business-hours'
 
 // ---------------------------------------------------------------------------
 // Constants & helpers
@@ -151,6 +153,7 @@ type EventSeoContentInput = {
   name: string
   date?: string | null
   time?: string | null
+  endTime?: string | null
   categoryName?: string | null
   capacity?: number | null
   brief?: string | null
@@ -243,6 +246,7 @@ export async function generateEventSeoContent(input: EventSeoContentInput): Prom
     name: input.name,
     date: input.date,
     time: input.time,
+    endTime: input.endTime,
     categoryName: input.categoryName,
     capacity: input.capacity,
     brief: input.brief,
@@ -272,6 +276,7 @@ export async function generateEventSeoContent(input: EventSeoContentInput): Prom
         name,
         date,
         time,
+        end_time,
         capacity,
         category_details:event_categories(name),
         performer_name,
@@ -293,6 +298,7 @@ export async function generateEventSeoContent(input: EventSeoContentInput): Prom
         name: data.name,
         date: data.date,
         start_time: data.time,
+        end_time: data.end_time,
         category_name: categoryName ?? null,
         capacity: data.capacity,
         description: null,
@@ -303,6 +309,25 @@ export async function generateEventSeoContent(input: EventSeoContentInput): Prom
         booking_url: data.booking_url ?? null,
         brief: data.brief ?? null,
       }
+    }
+  }
+
+  const resolvedDate = input.date?.trim() || dbData?.date?.trim() || null
+  const resolvedStartTime = input.time?.trim() || dbData?.start_time?.trim() || null
+  const resolvedEndTime = input.endTime?.trim() || dbData?.end_time?.trim() || null
+
+  if (resolvedDate) {
+    try {
+      const kitchenWindow = await getKitchenWindowForDate(resolvedDate)
+      factsInput.kitchenService = describeKitchenServiceForEvent(
+        kitchenWindow,
+        resolvedStartTime,
+        resolvedEndTime,
+      )
+    } catch (error) {
+      console.error('Failed to resolve kitchen hours for event content', error)
+      factsInput.kitchenService =
+        'Kitchen hours could not be verified. Do not say food or the menu is available.'
     }
   }
 

--- a/src/app/api/cron/pub-ops-calendar-note-sync/route.ts
+++ b/src/app/api/cron/pub-ops-calendar-note-sync/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { formatInTimeZone } from 'date-fns-tz'
+import { authorizeCronRequest } from '@/lib/cron-auth'
+import {
+  processPubOpsCalendarNoteQueueItem,
+  type PubOpsCalendarNoteQueueItem,
+} from '@/lib/google-calendar-notes'
+import { logger } from '@/lib/logger'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+const DEFAULT_LIMIT = 100
+const HARD_LIMIT = 200
+const SYNC_CONCURRENCY = 2
+const BATCH_DELAY_MS = 500
+const RECONCILIATION_LIMIT = 25
+const RECONCILIATION_INTERVAL_MS = 24 * 60 * 60 * 1000
+const CALENDAR_TIME_ZONE = 'Europe/London'
+
+export const maxDuration = 300
+
+function parseLimit(raw: string | null): number {
+  const parsed = Number.parseInt(raw || '', 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_LIMIT
+  }
+  return Math.min(parsed, HARD_LIMIT)
+}
+
+function chunkItems<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size))
+  }
+  return chunks
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function calendarNoteSyncQueue(client: unknown) {
+  return (client as { from: (table: string) => any }).from('calendar_note_google_sync_queue')
+}
+
+function calendarNoteSyncRpc(client: unknown) {
+  return client as {
+    rpc: (
+      fn: string,
+      args: Record<string, unknown>
+    ) => Promise<{ data: unknown; error: { message: string } | null }>
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authorizeCronRequest(request)
+  if (!auth.authorized) {
+    return NextResponse.json({ error: auth.reason || 'Unauthorized' }, { status: 401 })
+  }
+
+  const url = new URL(request.url)
+  const limit = parseLimit(url.searchParams.get('limit'))
+  const noteId = url.searchParams.get('noteId')?.trim() || null
+  const supabase = createAdminClient()
+
+  try {
+    if (noteId) {
+      const result = await processPubOpsCalendarNoteQueueItem(supabase, noteId, {
+        force: true,
+        context: { context: 'pub_ops_calendar_note_single_sync' },
+      })
+
+      return NextResponse.json({
+        success: result.state !== 'failed',
+        processed: 1,
+        result,
+      })
+    }
+
+    const { data, error } = await calendarNoteSyncQueue(supabase)
+      .select('note_id, operation, generation, attempts')
+      .eq('status', 'pending')
+      .lte('available_at', new Date().toISOString())
+      .order('available_at', { ascending: true })
+      .order('updated_at', { ascending: true })
+      .limit(limit)
+
+    if (error) {
+      throw error
+    }
+
+    const queueItems = (data || []) as PubOpsCalendarNoteQueueItem[]
+    let reconciliationItems: PubOpsCalendarNoteQueueItem[] = []
+    const remainingCapacity = Math.min(
+      limit - queueItems.length,
+      RECONCILIATION_LIMIT
+    )
+
+    if (remainingCapacity > 0) {
+      const reconciliationNow = new Date()
+      const { data: reconciliationData, error: reconciliationError } =
+        await calendarNoteSyncRpc(supabase).rpc(
+          'requeue_stale_calendar_note_google_sync',
+          {
+            p_today: formatInTimeZone(
+              reconciliationNow,
+              CALENDAR_TIME_ZONE,
+              'yyyy-MM-dd'
+            ),
+            p_synced_before: new Date(
+              reconciliationNow.getTime() - RECONCILIATION_INTERVAL_MS
+            ).toISOString(),
+            p_limit: remainingCapacity,
+          }
+        )
+
+      if (reconciliationError) {
+        throw new Error(reconciliationError.message)
+      }
+
+      reconciliationItems = (reconciliationData || []) as PubOpsCalendarNoteQueueItem[]
+    }
+
+    const workItems = [
+      ...queueItems.map((item) => ({
+        item,
+        context: 'pub_ops_calendar_note_queue',
+      })),
+      ...reconciliationItems.map((item) => ({
+        item,
+        context: 'pub_ops_calendar_note_reconciliation',
+      })),
+    ]
+    const results = []
+    const counts = {
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      skipped: 0,
+      failed: 0,
+    }
+    const batches = chunkItems(workItems, SYNC_CONCURRENCY)
+
+    for (const [batchIndex, batch] of batches.entries()) {
+      const batchResults = await Promise.all(
+        batch.map(({ item, context }) =>
+          processPubOpsCalendarNoteQueueItem(supabase, item.note_id, {
+            expectedGeneration: item.generation,
+            context: { context },
+          })
+        )
+      )
+
+      for (const result of batchResults) {
+        counts[result.state] += 1
+        results.push(result)
+      }
+
+      if (batchIndex < batches.length - 1) {
+        await delay(BATCH_DELAY_MS)
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      processed: workItems.length,
+      queued: queueItems.length,
+      reconciled: reconciliationItems.length,
+      limit,
+      counts,
+      results,
+    })
+  } catch (error) {
+    logger.error('Failed to reconcile Pub Ops calendar notes', {
+      error: error instanceof Error ? error : new Error(String(error)),
+    })
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to sync Pub Ops calendar notes',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/event-checklist.test.ts
+++ b/src/lib/event-checklist.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildEventChecklist, EVENT_CHECKLIST_DEFINITIONS } from './event-checklist'
+
+describe('event checklist definitions', () => {
+  it('uses the consolidated, title-style event todo labels', () => {
+    expect(EVENT_CHECKLIST_DEFINITIONS.map(({ label }) => label)).toEqual([
+      'Write Event Brief',
+      'Design Printed Materials',
+      'Create Facebook Event',
+      'Add GBP Event Post',
+      'Schedule Social Posts',
+      'Scheduled Stories',
+      'Set Up Paid Advertising',
+      'Whatsapp Reminder (Day of)'
+    ])
+  })
+
+  it('keeps existing table-talker completion against the consolidated print todo', () => {
+    const checklist = buildEventChecklist(
+      { id: 'event-1', name: 'Test Event', date: '2026-08-20' },
+      [{ event_id: 'event-1', task_key: 'design_table_talkers', completed_at: '2026-07-01T10:00:00Z' }],
+      '2026-07-09'
+    )
+
+    expect(checklist).toHaveLength(8)
+    expect(checklist.find(({ label }) => label === 'Design Printed Materials')).toMatchObject({
+      completed: true,
+      completedAt: '2026-07-01T10:00:00Z'
+    })
+  })
+})

--- a/src/lib/event-checklist.ts
+++ b/src/lib/event-checklist.ts
@@ -28,20 +28,18 @@ export interface EventChecklistItem extends EventChecklistDefinition {
 }
 
 export const EVENT_CHECKLIST_DEFINITIONS: EventChecklistDefinition[] = [
-  { key: 'update_event_details', label: 'Update all event details', offsetDays: -42, channel: 'Website', required: true, order: 0 },
-  { key: 'write_event_brief', label: 'Write event brief', offsetDays: -28, channel: 'Admin', required: true, order: 1 },
-  { key: 'design_table_talkers', label: 'Design table-talkers', offsetDays: -28, channel: 'Print file', required: true, order: 2 },
-  { key: 'design_bar_strut_cards', label: 'Design bar-strut cards', offsetDays: -28, channel: 'Print file', required: true, order: 3 },
-  { key: 'design_poster', label: 'Design poster', offsetDays: -28, channel: 'Print file', required: false, order: 4 },
-  { key: 'create_facebook_event', label: 'Create Facebook Event', offsetDays: -28, channel: 'Facebook', required: true, order: 5 },
-  { key: 'add_google_business_post', label: 'Add Google Business Profile Event post', offsetDays: -28, channel: 'Google', required: true, order: 6 },
-  { key: 'schedule_social_content', label: 'Create & schedule social content', offsetDays: -28, channel: 'FB/IG', required: true, order: 7 },
-  { key: 'schedule_stories', label: 'Schedule Stories (day-before & day-of)', offsetDays: -28, channel: 'FB/IG', required: true, order: 8 },
-  { key: 'setup_paid_advertising', label: 'Set up paid advertising', offsetDays: -28, channel: 'Paid Ads', required: true, order: 9 },
-  { key: 'send_whatsapp_reminder', label: 'WhatsApp reminder to local group', offsetDays: 0, channel: 'WhatsApp', required: true, order: 10 }
+  { key: 'write_event_brief', label: 'Write Event Brief', offsetDays: -28, channel: 'Admin', required: true, order: 0 },
+  { key: 'design_table_talkers', label: 'Design Printed Materials', offsetDays: -28, channel: 'Print File', required: true, order: 1 },
+  { key: 'create_facebook_event', label: 'Create Facebook Event', offsetDays: -28, channel: 'Facebook', required: true, order: 2 },
+  { key: 'add_google_business_post', label: 'Add GBP Event Post', offsetDays: -28, channel: 'Google', required: true, order: 3 },
+  { key: 'schedule_social_content', label: 'Schedule Social Posts', offsetDays: -28, channel: 'FB/IG', required: true, order: 4 },
+  { key: 'schedule_stories', label: 'Scheduled Stories', offsetDays: -28, channel: 'FB/IG', required: true, order: 5 },
+  { key: 'setup_paid_advertising', label: 'Set Up Paid Advertising', offsetDays: -28, channel: 'Paid Ads', required: true, order: 6 },
+  { key: 'send_whatsapp_reminder', label: 'Whatsapp Reminder (Day of)', offsetDays: 0, channel: 'WhatsApp', required: true, order: 7 }
 ]
 
 const EVENT_CHECKLIST_TOTAL_TASKS = EVENT_CHECKLIST_DEFINITIONS.length
+const EVENT_CHECKLIST_TASK_KEYS = new Set(EVENT_CHECKLIST_DEFINITIONS.map(task => task.key))
 
 function addDays(dateString: string, offsetDays: number): string {
   const date = new Date(`${dateString}T00:00:00Z`)
@@ -112,7 +110,9 @@ export function getOutstandingTodos(
 function calculateChecklistProgress(
   statuses: EventChecklistStatusRecord[] = []
 ): { completed: number; total: number } {
-  const completed = statuses.filter((status) => Boolean(status.completed_at)).length
+  const completed = statuses.filter(
+    (status) => EVENT_CHECKLIST_TASK_KEYS.has(status.task_key) && Boolean(status.completed_at)
+  ).length
   return {
     completed,
     total: EVENT_CHECKLIST_TOTAL_TASKS

--- a/src/lib/event-seo/__tests__/generation.test.ts
+++ b/src/lib/event-seo/__tests__/generation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildEventSeoFacts,
+  describeKitchenServiceForEvent,
   preflightCheck,
   ANCHOR_VENUE_CONTEXT,
   CONTENT_RETRY_CONFIG,
@@ -31,9 +32,11 @@ function completeInput(): BuildFactsInput {
     name: 'Live Music — Jessica Lovelock',
     date: '2026-06-14',
     time: '7:00 PM',
+    endTime: '10:00 PM',
     categoryName: 'Live Music',
     capacity: 80,
     brief: 'An evening of acoustic folk and indie covers.',
+    kitchenService: 'The kitchen is closed on this event date.',
     performerName: 'Jessica Lovelock',
     performerType: 'Singer-Songwriter',
     price: '£10',
@@ -56,6 +59,7 @@ function completeDbData(): BuildFactsDbData {
     name: 'DB Event Name',
     date: '2026-06-15',
     start_time: '8:00 PM',
+    end_time: '10:00 PM',
     category_name: 'DB Category',
     capacity: 100,
     description: 'DB description text.',
@@ -77,6 +81,7 @@ describe('buildEventSeoFacts', () => {
     expect(facts.name).toBe('Live Music — Jessica Lovelock')
     expect(facts.date).toBe('2026-06-14')
     expect(facts.time).toBe('7:00 PM')
+    expect(facts.endTime).toBe('10:00 PM')
     expect(facts.categoryName).toBe('Live Music')
     expect(facts.capacity).toBe(80)
     expect(facts.pricingLabel).toBe('£10')
@@ -84,6 +89,7 @@ describe('buildEventSeoFacts', () => {
     expect(facts.performerType).toBe('Singer-Songwriter')
     expect(facts.bookingUrlPresent).toBe(true)
     expect(facts.brief).toBe('An evening of acoustic folk and indie covers.')
+    expect(facts.kitchenService).toBe('The kitchen is closed on this event date.')
     expect(facts.isFree).toBe(false)
     expect(facts.existingContent.metaTitle).toBe('Old Title')
     expect(facts.existingContent.highlights).toEqual(['Great atmosphere', 'Free parking'])
@@ -110,6 +116,7 @@ describe('buildEventSeoFacts', () => {
     expect(facts.name).toBe('DB Event Name')
     expect(facts.date).toBe('2026-06-15')
     expect(facts.time).toBe('8:00 PM')
+    expect(facts.endTime).toBe('10:00 PM')
     expect(facts.categoryName).toBe('DB Category')
     expect(facts.capacity).toBe(100)
     expect(facts.performerName).toBe('DB Performer')
@@ -130,11 +137,13 @@ describe('buildEventSeoFacts', () => {
 
     expect(facts.date).toBeNull()
     expect(facts.time).toBeNull()
+    expect(facts.endTime).toBeNull()
     expect(facts.categoryName).toBeNull()
     expect(facts.capacity).toBeNull()
     expect(facts.performerName).toBeNull()
     expect(facts.performerType).toBeNull()
     expect(facts.brief).toBeNull()
+    expect(facts.kitchenService).toBeNull()
     expect(facts.pricingLabel).toBeNull()
     expect(facts.bookingUrlPresent).toBe(false)
   })
@@ -190,6 +199,31 @@ describe('buildEventSeoFacts', () => {
     const facts = buildEventSeoFacts({ name: 'Test' })
     expect(facts.venue).toBe(ANCHOR_VENUE_CONTEXT)
     expect(facts.venue.phone).toBe('01753 682707')
+  })
+})
+
+describe('describeKitchenServiceForEvent', () => {
+  const weekdayWindow = { openMinutes: 16 * 60, closeMinutes: 21 * 60 }
+
+  it('promotes the full menu when an event overlaps kitchen hours', () => {
+    const result = describeKitchenServiceForEvent(weekdayWindow, '19:00', '23:00')
+
+    expect(result).toContain('full menu is available from 4:00pm to 9:00pm')
+    expect(result).toContain('event overlaps')
+    expect(result).toContain('not pizza on its own')
+  })
+
+  it('does not claim food is available when an event starts after the kitchen closes', () => {
+    const result = describeKitchenServiceForEvent(weekdayWindow, '21:00', '23:00')
+
+    expect(result).toContain('does not overlap')
+    expect(result).toContain('Do not say food or the menu is available')
+  })
+
+  it('treats a closed kitchen as unavailable', () => {
+    expect(describeKitchenServiceForEvent(null, '19:00', '21:00')).toContain(
+      'kitchen is closed'
+    )
   })
 })
 
@@ -394,6 +428,8 @@ describe('buildFactsJson', () => {
     const parsed = JSON.parse(json)
     expect(parsed.name).toBe('Live Music — Jessica Lovelock')
     expect(parsed.date).toBe('2026-06-14')
+    expect(parsed.end_time).toBe('10:00 PM')
+    expect(parsed.kitchen_service).toBe('The kitchen is closed on this event date.')
     expect(parsed.performer_name).toBe('Jessica Lovelock')
     expect(parsed.venue.phone).toBe('01753 682707')
   })
@@ -472,6 +508,13 @@ describe('prompt constants', () => {
   it('ANCHOR_VENUE_CONTEXT_PROMPT includes address and phone', () => {
     expect(ANCHOR_VENUE_CONTEXT_PROMPT).toContain('01753 682707')
     expect(ANCHOR_VENUE_CONTEXT_PROMPT).toContain('TW19 6AQ')
+  })
+
+  it('uses full-menu wording and makes food conditional on kitchen hours', () => {
+    expect(ANCHOR_VENUE_CONTEXT_PROMPT).toContain('Full menu available while the kitchen is open')
+    expect(ANCHOR_VENUE_CONTEXT_PROMPT).not.toContain('Kitchen serves pizza on event nights')
+    expect(FIELD_RULES).toContain('only when FACTS_JSON.kitchen_service confirms')
+    expect(FIELD_RULES).toContain('Never present pizza as the only food available')
   })
 
   it('OUTPUT_RUBRIC bans filler phrases', () => {

--- a/src/lib/event-seo/generation.ts
+++ b/src/lib/event-seo/generation.ts
@@ -36,7 +36,7 @@ export const ANCHOR_VENUE_CONTEXT: VenueContext = {
   accessibility: 'Ground-floor venue with step-free access from car park',
   facilities: [
     'Dog and family friendly',
-    'Kitchen serves pizza on event nights',
+    'Full menu available while the kitchen is open',
   ],
   nearby: [
     'Stanwell Moor',
@@ -52,6 +52,7 @@ export type EventSeoFacts = {
   name: string
   date: string | null
   time: string | null
+  endTime: string | null
   categoryName: string | null
   capacity: number | null
   pricingLabel: string | null
@@ -59,6 +60,7 @@ export type EventSeoFacts = {
   performerType: string | null
   bookingUrlPresent: boolean
   brief: string | null
+  kitchenService: string | null
   isFree: boolean
   existingContent: {
     metaTitle: string | null
@@ -80,9 +82,11 @@ export type BuildFactsInput = {
   name: string
   date?: string | null
   time?: string | null
+  endTime?: string | null
   categoryName?: string | null
   capacity?: number | null
   brief?: string | null
+  kitchenService?: string | null
   performerName?: string | null
   performerType?: string | null
   price?: string | null
@@ -103,6 +107,7 @@ export type BuildFactsDbData = {
   name?: string | null
   date?: string | null
   start_time?: string | null
+  end_time?: string | null
   category_name?: string | null
   capacity?: number | null
   description?: string | null
@@ -112,6 +117,11 @@ export type BuildFactsDbData = {
   is_free?: boolean
   booking_url?: string | null
   brief?: string | null
+}
+
+export type EventKitchenWindow = {
+  openMinutes: number
+  closeMinutes: number
 }
 
 // ── Helpers ─────────────────────────────────────────────────
@@ -204,6 +214,85 @@ function buildPricingLabel(
   return null
 }
 
+function parseClockMinutes(value: string | null | undefined): number | null {
+  if (!value) return null
+
+  const normalized = value.trim().toLowerCase()
+  const twelveHour = normalized.match(/^(\d{1,2}):(\d{2})(?::\d{2})?\s*(am|pm)$/)
+  if (twelveHour) {
+    let hours = Number(twelveHour[1])
+    const minutes = Number(twelveHour[2])
+    if (hours < 1 || hours > 12 || minutes > 59) return null
+    if (hours === 12) hours = 0
+    if (twelveHour[3] === 'pm') hours += 12
+    return hours * 60 + minutes
+  }
+
+  const twentyFourHour = normalized.match(/^(\d{1,2}):(\d{2})(?::\d{2})?$/)
+  if (!twentyFourHour) return null
+
+  const hours = Number(twentyFourHour[1])
+  const minutes = Number(twentyFourHour[2])
+  if (hours > 23 || minutes > 59) return null
+  return hours * 60 + minutes
+}
+
+function formatClockMinutes(totalMinutes: number): string {
+  const minutesInDay = 24 * 60
+  const normalized = ((totalMinutes % minutesInDay) + minutesInDay) % minutesInDay
+  const hours24 = Math.floor(normalized / 60)
+  const minutes = normalized % 60
+  const suffix = hours24 >= 12 ? 'pm' : 'am'
+  const hours12 = hours24 % 12 || 12
+  return `${hours12}:${String(minutes).padStart(2, '0')}${suffix}`
+}
+
+/**
+ * Build a date-specific menu fact for the content generator. The kitchen window
+ * comes from business_hours/special_hours, so generated copy follows live hours
+ * and never falls back to a pizza-only claim.
+ */
+export function describeKitchenServiceForEvent(
+  window: EventKitchenWindow | null,
+  startTime?: string | null,
+  endTime?: string | null,
+): string {
+  if (!window) {
+    return 'The kitchen is closed on this event date. Do not say food or the menu is available.'
+  }
+
+  const opens = formatClockMinutes(window.openMinutes)
+  const closes = formatClockMinutes(window.closeMinutes)
+  const hours = `${opens} to ${closes}`
+  const startMinutes = parseClockMinutes(startTime)
+  const parsedEndMinutes = parseClockMinutes(endTime)
+
+  if (startMinutes === null) {
+    return `The full menu is available from ${hours}. Only mention it if the event overlaps these kitchen hours. Never describe the food offer as pizza-only.`
+  }
+
+  let overlap: boolean | null = null
+  if (parsedEndMinutes !== null) {
+    let endMinutes = parsedEndMinutes
+    if (endMinutes <= startMinutes) endMinutes += 24 * 60
+    overlap = startMinutes < window.closeMinutes && endMinutes > window.openMinutes
+  } else if (startMinutes >= window.openMinutes && startMinutes < window.closeMinutes) {
+    overlap = true
+  } else if (startMinutes >= window.closeMinutes) {
+    overlap = false
+  }
+
+  if (overlap === false) {
+    return `The full menu hours on this event date are ${hours}, but the event does not overlap them. Do not say food or the menu is available during the event.`
+  }
+
+  if (overlap === true) {
+    return `The full menu is available from ${hours}, and the event overlaps these kitchen hours. Mention the full menu, not pizza on its own, and make the kitchen closing time clear if the event continues later.`
+  }
+
+  return `The full menu is available from ${hours}. Only mention it if the event overlaps these kitchen hours. Never describe the food offer as pizza-only.`
+}
+
 // ── Facts builder ───────────────────────────────────────────
 
 export function buildEventSeoFacts(
@@ -224,6 +313,7 @@ export function buildEventSeoFacts(
     name: coalesce(input.name, db?.name) ?? input.name,
     date: coalesce(input.date, db?.date),
     time: coalesce(input.time, db?.start_time),
+    endTime: coalesce(input.endTime, db?.end_time),
     categoryName: coalesce(input.categoryName, db?.category_name),
     capacity: coalesceNumber(input.capacity, db?.capacity),
     pricingLabel: buildPricingLabel(price, isFree),
@@ -233,6 +323,7 @@ export function buildEventSeoFacts(
       nonEmpty(input.bookingUrl) ?? nonEmpty(db?.booking_url)
     ),
     brief: coalesce(input.brief, db?.brief ?? db?.description),
+    kitchenService: nonEmpty(input.kitchenService),
     isFree,
     existingContent: {
       metaTitle: nonEmpty(input.existingMetaTitle) ?? null,

--- a/src/lib/event-seo/prompts.ts
+++ b/src/lib/event-seo/prompts.ts
@@ -58,7 +58,7 @@ longDescription: 5-6 short paragraphs separated by double newlines (\\n\\n), aro
   Paragraph 1: hook them. What the night is and why it is a good time, plus the event name, date and time. Work a primary keyword in naturally.
   Paragraph 2: what actually happens on the night — the format, the rounds, the music, whatever the facts say.
   Paragraph 3: the host or performer and what they bring.
-  Paragraph 4: food, drink and the feel of the room, using VENUE_CONTEXT.
+  Paragraph 4: drinks and the feel of the room, using VENUE_CONTEXT. Mention food only when FACTS_JSON.kitchen_service confirms the event overlaps kitchen hours. When it does, say the full menu is available and state when service ends. Never present pizza as the only food available. If the kitchen is closed or the event does not overlap its hours, do not claim food is available.
   Paragraph 5: the practical bits — price, booking, capacity, when to arrive, walk-ins.
   Paragraph 6: where to find us — Stanwell Moor, parking, nearby areas. Mention Heathrow only if it genuinely adds something.
   Write it the way you'd tell a regular. No section labels, no posh words, no padding.
@@ -96,6 +96,7 @@ export function buildFactsJson(facts: EventSeoFacts): string {
   obj.name = facts.name
   if (facts.date) obj.date = facts.date
   if (facts.time) obj.time = facts.time
+  if (facts.endTime) obj.end_time = facts.endTime
   if (facts.categoryName) obj.category = facts.categoryName
   if (facts.capacity != null) obj.capacity = facts.capacity
   if (facts.pricingLabel) obj.pricing = facts.pricingLabel
@@ -103,6 +104,7 @@ export function buildFactsJson(facts: EventSeoFacts): string {
   if (facts.performerType) obj.performer_type = facts.performerType
   obj.booking_url_present = facts.bookingUrlPresent
   if (facts.brief) obj.brief = facts.brief
+  if (facts.kitchenService) obj.kitchen_service = facts.kitchenService
   obj.is_free = facts.isFree
 
   // Existing content — only non-empty fields
@@ -182,7 +184,7 @@ export function buildRepairMessages(
         '',
         currentWordCount > 700
           ? `LENGTH: the long description is ${currentWordCount} words — too long. Tighten it to under 700 by cutting anything repetitive or padded. Keep the voice punchy.`
-          : `LENGTH: the long description is only ${currentWordCount} words — too thin to be useful. Add real, specific detail from FACTS_JSON and VENUE_CONTEXT (the format, the host, food and drink, parking) to reach about 280-360 words. Keep sentences short and human; never pad with filler or hype.`,
+          : `LENGTH: the long description is only ${currentWordCount} words — too thin to be useful. Add real, specific detail from FACTS_JSON and VENUE_CONTEXT (the format, the host, drinks, kitchen service when confirmed, parking) to reach about 280-360 words. Keep sentences short and human; never pad with filler or hype.`,
       ].join('\n')
     : ''
 

--- a/src/lib/google-calendar-notes.ts
+++ b/src/lib/google-calendar-notes.ts
@@ -1,0 +1,716 @@
+import 'server-only'
+
+import { createHash } from 'crypto'
+import { addHours } from 'date-fns'
+import { fromZonedTime } from 'date-fns-tz'
+import { google } from 'googleapis'
+import type { OAuth2Client } from 'google-auth-library'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { getOAuth2Client } from '@/lib/google-calendar'
+import { PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID } from '@/lib/google-calendar-targets'
+import { logger } from '@/lib/logger'
+
+export { PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID } from '@/lib/google-calendar-targets'
+
+const CALENDAR_TIME_ZONE = 'Europe/London'
+const SOURCE_PROPERTY = 'anchor_calendar_note'
+
+const calendar = google.calendar('v3')
+
+type CalendarAuth = Awaited<ReturnType<typeof getOAuth2Client>>
+
+export type PubOpsCalendarNoteSyncResult =
+  | { state: 'created' | 'updated' | 'deleted' | 'skipped'; noteId: string; googleEventId: string; reason?: string }
+  | { state: 'failed'; noteId: string; googleEventId: string; reason: string }
+
+export type PubOpsCalendarNoteQueueItem = {
+  note_id: string
+  operation: 'upsert' | 'delete'
+  generation: number
+  attempts: number
+}
+
+type ClaimedPubOpsCalendarNoteQueueItem = PubOpsCalendarNoteQueueItem & {
+  processing_token: string
+}
+
+type PubOpsCalendarNoteQueueState = PubOpsCalendarNoteQueueItem & {
+  status: 'pending' | 'synced'
+  processing_token: string | null
+  lease_expires_at: string | null
+}
+
+export type PubOpsCalendarNoteRow = {
+  id: string
+  note_date: string
+  end_date: string | null
+  title: string
+  notes: string | null
+  source: string | null
+  start_time: string | null
+  end_time: string | null
+}
+
+type CalendarDate = { date: string }
+type CalendarDateTime = { dateTime: string; timeZone: string }
+
+export type PubOpsCalendarNoteEntry = {
+  googleEventId: string
+  requestBody: {
+    id: string
+    summary: string
+    description: string
+    start: CalendarDate | CalendarDateTime
+    end: CalendarDate | CalendarDateTime
+    transparency: 'transparent'
+    reminders: { useDefault: false }
+    extendedProperties: {
+      private: Record<string, string>
+    }
+  }
+}
+
+function calendarAuth(auth: CalendarAuth): OAuth2Client {
+  return auth as unknown as OAuth2Client
+}
+
+function hasCalendarAuthConfig(): boolean {
+  return Boolean(
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY ||
+      (process.env.GOOGLE_CLIENT_ID &&
+        process.env.GOOGLE_CLIENT_SECRET &&
+        process.env.GOOGLE_REFRESH_TOKEN)
+  )
+}
+
+function calendarNoteSyncQueue(client: unknown) {
+  return (client as { from: (table: string) => any }).from('calendar_note_google_sync_queue')
+}
+
+function calendarNoteSyncRpc(client: unknown) {
+  return client as {
+    rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }>
+  }
+}
+
+export async function isPubOpsCalendarNoteSyncQueueAvailable(
+  supabase: SupabaseClient<any, 'public', any>
+): Promise<boolean> {
+  try {
+    const { error } = await calendarNoteSyncQueue(supabase)
+      .select('note_id')
+      .limit(1)
+    if (error) return false
+
+    const { error: claimError } = await calendarNoteSyncRpc(supabase).rpc(
+      'claim_calendar_note_google_sync',
+      {
+        p_note_id: '00000000-0000-0000-0000-000000000000',
+        p_expected_generation: null,
+        p_lease_seconds: 600,
+      }
+    )
+
+    return !claimError
+  } catch {
+    return false
+  }
+}
+
+export function generatePubOpsCalendarNoteEventId(noteId: string): string {
+  const digest = createHash('sha256').update(`anchor-calendar-note:${noteId}`).digest('hex')
+  return `acn${digest.slice(0, 48)}`
+}
+
+function addOneDay(date: string): string {
+  const [year, month, day] = date.split('-').map(Number)
+  return new Date(Date.UTC(year, month - 1, day + 1)).toISOString().slice(0, 10)
+}
+
+function normalizeTime(value: string): string {
+  const [hours = '00', minutes = '00', seconds = '00'] = value.split(':')
+  return `${hours.padStart(2, '0')}:${minutes.padStart(2, '0')}:${seconds.padStart(2, '0')}`
+}
+
+function getTimedRange(note: PubOpsCalendarNoteRow): {
+  start: CalendarDateTime
+  end: CalendarDateTime
+} {
+  const startDate = fromZonedTime(
+    `${note.note_date}T${normalizeTime(note.start_time as string)}`,
+    CALENDAR_TIME_ZONE
+  )
+
+  let endDate = note.end_time
+    ? fromZonedTime(
+        `${note.end_date || note.note_date}T${normalizeTime(note.end_time)}`,
+        CALENDAR_TIME_ZONE
+      )
+    : addHours(startDate, 1)
+
+  if (!Number.isFinite(endDate.getTime()) || endDate.getTime() <= startDate.getTime()) {
+    endDate = addHours(startDate, 1)
+  }
+
+  return {
+    start: {
+      dateTime: startDate.toISOString(),
+      timeZone: CALENDAR_TIME_ZONE,
+    },
+    end: {
+      dateTime: endDate.toISOString(),
+      timeZone: CALENDAR_TIME_ZONE,
+    },
+  }
+}
+
+function buildDescription(note: PubOpsCalendarNoteRow, appBaseUrl: string, syncedAt: Date): string {
+  const adminBaseUrl = appBaseUrl.replace(/\/+$/, '')
+  const adminUrl = adminBaseUrl
+    ? `${adminBaseUrl}/settings/calendar-notes`
+    : '/settings/calendar-notes'
+  const sourceLabel = note.source === 'ai' ? 'AI-generated' : 'Manual'
+  const details = note.notes?.trim() || null
+
+  return [
+    details,
+    details ? '' : null,
+    `Source: ${sourceLabel} calendar note`,
+    `Manage notes: ${adminUrl}`,
+    '',
+    `Last synced: ${syncedAt.toISOString()}`,
+  ].filter((line): line is string => line !== null).join('\n')
+}
+
+export function buildPubOpsCalendarNoteEntry(input: {
+  note: PubOpsCalendarNoteRow
+  appBaseUrl?: string
+  now?: Date
+}): PubOpsCalendarNoteEntry {
+  const { note } = input
+  const googleEventId = generatePubOpsCalendarNoteEventId(note.id)
+  const now = input.now ?? new Date()
+  const appBaseUrl = input.appBaseUrl || process.env.NEXT_PUBLIC_APP_URL || ''
+  const endDate = note.end_date && note.end_date >= note.note_date
+    ? note.end_date
+    : note.note_date
+
+  const range = note.start_time
+    ? getTimedRange(note)
+    : {
+        start: { date: note.note_date },
+        // Google Calendar treats all-day end dates as exclusive. The app stores
+        // end_date as inclusive, so add one day here.
+        end: { date: addOneDay(endDate) },
+      }
+
+  return {
+    googleEventId,
+    requestBody: {
+      id: googleEventId,
+      summary: note.title.trim() || 'Calendar note',
+      description: buildDescription(note, appBaseUrl, now),
+      start: range.start,
+      end: range.end,
+      // Calendar notes are informational and should not block availability or
+      // send the Pub Ops calendar's default reminders.
+      transparency: 'transparent',
+      reminders: { useDefault: false },
+      extendedProperties: {
+        private: {
+          source: SOURCE_PROPERTY,
+          anchorCalendarNoteId: note.id,
+        },
+      },
+    },
+  }
+}
+
+function getGoogleErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const candidate = error as {
+    code?: string | number
+    status?: number
+    response?: { status?: number; data?: { error?: { code?: number } } }
+  }
+  if (typeof candidate.status === 'number') return candidate.status
+  if (typeof candidate.code === 'number') return candidate.code
+  if (typeof candidate.response?.status === 'number') return candidate.response.status
+  if (typeof candidate.response?.data?.error?.code === 'number') {
+    return candidate.response.data.error.code
+  }
+  return undefined
+}
+
+function getGoogleErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function deletePubOpsCalendarNoteEntry(
+  auth: CalendarAuth,
+  noteId: string,
+  context?: Record<string, unknown>
+): Promise<PubOpsCalendarNoteSyncResult> {
+  const googleEventId = generatePubOpsCalendarNoteEventId(noteId)
+
+  try {
+    await calendar.events.delete({
+      auth: calendarAuth(auth),
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      eventId: googleEventId,
+    })
+    return { state: 'deleted', noteId, googleEventId }
+  } catch (error) {
+    const status = getGoogleErrorStatus(error)
+    if (status === 404 || status === 410) {
+      return { state: 'skipped', noteId, googleEventId, reason: 'already_missing' }
+    }
+
+    logger.warn('Failed to delete Pub Ops calendar note', {
+      metadata: {
+        noteId,
+        googleEventId,
+        status,
+        error: getGoogleErrorMessage(error),
+        ...context,
+      },
+    })
+    return {
+      state: 'failed',
+      noteId,
+      googleEventId,
+      reason: getGoogleErrorMessage(error),
+    }
+  }
+}
+
+export async function deletePubOpsCalendarNoteEntryById(
+  noteId: string,
+  context?: Record<string, unknown>
+): Promise<PubOpsCalendarNoteSyncResult> {
+  const googleEventId = generatePubOpsCalendarNoteEventId(noteId)
+
+  if (!hasCalendarAuthConfig()) {
+    return { state: 'skipped', noteId, googleEventId, reason: 'calendar_not_configured' }
+  }
+
+  try {
+    const auth = await getOAuth2Client()
+    return deletePubOpsCalendarNoteEntry(auth, noteId, context)
+  } catch (error) {
+    logger.warn('Failed to authenticate for Pub Ops calendar note delete', {
+      metadata: {
+        noteId,
+        googleEventId,
+        error: getGoogleErrorMessage(error),
+        ...context,
+      },
+    })
+    return { state: 'failed', noteId, googleEventId, reason: getGoogleErrorMessage(error) }
+  }
+}
+
+async function upsertPubOpsCalendarNoteEntry(
+  auth: CalendarAuth,
+  noteId: string,
+  entry: PubOpsCalendarNoteEntry,
+  context?: Record<string, unknown>
+): Promise<PubOpsCalendarNoteSyncResult> {
+  try {
+    const response = await calendar.events.update({
+      auth: calendarAuth(auth),
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      eventId: entry.googleEventId,
+      requestBody: entry.requestBody,
+    })
+    return {
+      state: 'updated',
+      noteId,
+      googleEventId: response.data.id || entry.googleEventId,
+    }
+  } catch (updateError) {
+    const status = getGoogleErrorStatus(updateError)
+    if (status !== 404 && status !== 410) {
+      logger.warn('Failed to update Pub Ops calendar note', {
+        metadata: {
+          noteId,
+          googleEventId: entry.googleEventId,
+          status,
+          error: getGoogleErrorMessage(updateError),
+          ...context,
+        },
+      })
+      return {
+        state: 'failed',
+        noteId,
+        googleEventId: entry.googleEventId,
+        reason: getGoogleErrorMessage(updateError),
+      }
+    }
+  }
+
+  try {
+    const response = await calendar.events.insert({
+      auth: calendarAuth(auth),
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      requestBody: entry.requestBody,
+    })
+    return {
+      state: 'created',
+      noteId,
+      googleEventId: response.data.id || entry.googleEventId,
+    }
+  } catch (insertError) {
+    const status = getGoogleErrorStatus(insertError)
+    if (status === 409) {
+      try {
+        const response = await calendar.events.update({
+          auth: calendarAuth(auth),
+          calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+          eventId: entry.googleEventId,
+          requestBody: entry.requestBody,
+        })
+        return {
+          state: 'updated',
+          noteId,
+          googleEventId: response.data.id || entry.googleEventId,
+        }
+      } catch (retryError) {
+        logger.warn('Failed to update Pub Ops calendar note after insert conflict', {
+          metadata: {
+            noteId,
+            googleEventId: entry.googleEventId,
+            status: getGoogleErrorStatus(retryError),
+            error: getGoogleErrorMessage(retryError),
+            ...context,
+          },
+        })
+        return {
+          state: 'failed',
+          noteId,
+          googleEventId: entry.googleEventId,
+          reason: getGoogleErrorMessage(retryError),
+        }
+      }
+    }
+
+    logger.warn('Failed to create Pub Ops calendar note', {
+      metadata: {
+        noteId,
+        googleEventId: entry.googleEventId,
+        status,
+        error: getGoogleErrorMessage(insertError),
+        ...context,
+      },
+    })
+    return {
+      state: 'failed',
+      noteId,
+      googleEventId: entry.googleEventId,
+      reason: getGoogleErrorMessage(insertError),
+    }
+  }
+}
+
+export async function syncPubOpsCalendarNoteById(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string,
+  context?: Record<string, unknown>
+): Promise<PubOpsCalendarNoteSyncResult> {
+  const googleEventId = generatePubOpsCalendarNoteEventId(noteId)
+
+  if (!hasCalendarAuthConfig()) {
+    return { state: 'skipped', noteId, googleEventId, reason: 'calendar_not_configured' }
+  }
+
+  try {
+    const auth = await getOAuth2Client()
+    const { data: note, error } = await supabase
+      .from('calendar_notes')
+      .select('id, note_date, end_date, title, notes, source, start_time, end_time')
+      .eq('id', noteId)
+      .maybeSingle()
+
+    if (error) {
+      logger.warn('Failed to load calendar note for Pub Ops sync', {
+        metadata: {
+          noteId,
+          error: error.message,
+          ...context,
+        },
+      })
+      return { state: 'failed', noteId, googleEventId, reason: error.message }
+    }
+
+    if (!note) {
+      return deletePubOpsCalendarNoteEntry(auth, noteId, {
+        reason: 'note_missing',
+        ...context,
+      })
+    }
+
+    const entry = buildPubOpsCalendarNoteEntry({
+      note: note as PubOpsCalendarNoteRow,
+      appBaseUrl: process.env.NEXT_PUBLIC_APP_URL || '',
+    })
+
+    return upsertPubOpsCalendarNoteEntry(auth, noteId, entry, context)
+  } catch (error) {
+    logger.warn('Unexpected Pub Ops calendar note sync failure', {
+      metadata: {
+        noteId,
+        googleEventId,
+        error: getGoogleErrorMessage(error),
+        ...context,
+      },
+    })
+    return { state: 'failed', noteId, googleEventId, reason: getGoogleErrorMessage(error) }
+  }
+}
+
+function isCompletedSync(result: PubOpsCalendarNoteSyncResult): boolean {
+  if (result.state === 'failed') return false
+  if (result.state === 'skipped' && result.reason === 'calendar_not_configured') return false
+  return true
+}
+
+function getRetryDelayMs(attempts: number): number {
+  const safeAttempts = Math.max(0, Math.min(attempts, 8))
+  return Math.min(2 ** safeAttempts * 60_000, 6 * 60 * 60 * 1000)
+}
+
+async function claimPubOpsCalendarNoteQueueItem(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string,
+  expectedGeneration?: number
+): Promise<ClaimedPubOpsCalendarNoteQueueItem | null> {
+  const { data, error } = await calendarNoteSyncRpc(supabase).rpc(
+    'claim_calendar_note_google_sync',
+    {
+      p_note_id: noteId,
+      p_expected_generation: expectedGeneration ?? null,
+      p_lease_seconds: 600,
+    }
+  )
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  const rows = Array.isArray(data) ? data : []
+  return (rows[0] as ClaimedPubOpsCalendarNoteQueueItem | undefined) ?? null
+}
+
+async function loadPubOpsCalendarNoteQueueState(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string
+): Promise<{ state: PubOpsCalendarNoteQueueState | null; error: string | null }> {
+  const { data, error } = await calendarNoteSyncQueue(supabase)
+    .select('note_id, operation, status, generation, attempts, processing_token, lease_expires_at')
+    .eq('note_id', noteId)
+    .maybeSingle()
+
+  return {
+    state: data ? data as PubOpsCalendarNoteQueueState : null,
+    error: error?.message ?? null,
+  }
+}
+
+async function releasePubOpsCalendarNoteClaim(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string,
+  processingToken: string
+): Promise<void> {
+  const { error } = await calendarNoteSyncQueue(supabase)
+    .update({
+      processing_token: null,
+      lease_expires_at: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('note_id', noteId)
+    .eq('processing_token', processingToken)
+
+  if (error) {
+    logger.warn('Failed to release calendar note sync claim', {
+      metadata: { noteId, error: error.message },
+    })
+  }
+}
+
+async function requeuePubOpsCalendarNote(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string,
+  processingToken?: string
+): Promise<boolean> {
+  const { data, error } = await calendarNoteSyncRpc(supabase).rpc(
+    'requeue_calendar_note_google_sync',
+    {
+      p_note_id: noteId,
+      p_processing_token: processingToken ?? null,
+    }
+  )
+
+  if (error) {
+    logger.warn('Failed to requeue calendar note sync', {
+      metadata: { noteId, error: error.message },
+    })
+    return false
+  }
+
+  return data !== null && data !== undefined
+}
+
+/**
+ * Process one durable queue item under a per-note lease. Newer generations wait
+ * for the active Google request, then replay immediately so an older request can
+ * never be the final write left in Google Calendar.
+ */
+export async function processPubOpsCalendarNoteQueueItem(
+  supabase: SupabaseClient<any, 'public', any>,
+  noteId: string,
+  options: {
+    expectedGeneration?: number
+    operation?: 'upsert' | 'delete'
+    force?: boolean
+    context?: Record<string, unknown>
+    replayDepth?: number
+  } = {}
+): Promise<PubOpsCalendarNoteSyncResult> {
+  const googleEventId = generatePubOpsCalendarNoteEventId(noteId)
+  const replayDepth = options.replayDepth ?? 0
+
+  try {
+    if (options.force) {
+      await requeuePubOpsCalendarNote(supabase, noteId)
+    }
+
+    let claimed: ClaimedPubOpsCalendarNoteQueueItem | null
+    try {
+      claimed = await claimPubOpsCalendarNoteQueueItem(
+        supabase,
+        noteId,
+        options.expectedGeneration
+      )
+
+      // The batch may have read an older generation just before a user edit.
+      // Claim the current pending generation instead of waiting for another run.
+      if (!claimed && options.expectedGeneration !== undefined) {
+        claimed = await claimPubOpsCalendarNoteQueueItem(supabase, noteId)
+      }
+    } catch (claimError) {
+      const reason = getGoogleErrorMessage(claimError)
+      logger.warn('Failed to claim durable calendar note sync item', {
+        metadata: { noteId, error: reason, ...options.context },
+      })
+      return { state: 'failed', noteId, googleEventId, reason: 'calendar_sync_queue_unavailable' }
+    }
+
+    if (!claimed) {
+      const queueState = await loadPubOpsCalendarNoteQueueState(supabase, noteId)
+      if (queueState.error) {
+        logger.warn('Failed to inspect calendar note sync state', {
+          metadata: { noteId, error: queueState.error, ...options.context },
+        })
+        return { state: 'failed', noteId, googleEventId, reason: queueState.error }
+      }
+
+      if (!queueState.state) {
+        return {
+          state: 'failed',
+          noteId,
+          googleEventId,
+          reason: options.operation === 'delete'
+            ? 'calendar_sync_tombstone_missing'
+            : 'calendar_sync_queue_item_missing',
+        }
+      }
+
+      return {
+        state: 'skipped',
+        noteId,
+        googleEventId,
+        reason: queueState.state.status === 'synced' ? 'already_synced' : 'sync_in_progress',
+      }
+    }
+
+    const operation = claimed.operation
+    const result = operation === 'delete'
+      ? await deletePubOpsCalendarNoteEntryById(noteId, options.context)
+      : await syncPubOpsCalendarNoteById(supabase, noteId, options.context)
+
+    const completed = isCompletedSync(result)
+    const nextAttempts = completed ? 0 : claimed.attempts + 1
+    const updatePayload = completed
+      ? {
+          status: 'synced',
+          attempts: 0,
+          last_error: null,
+          processing_token: null,
+          lease_expires_at: null,
+          updated_at: new Date().toISOString(),
+      }
+      : {
+          status: 'pending',
+          attempts: nextAttempts,
+          last_error: result.reason || 'Calendar note sync failed',
+          available_at: new Date(Date.now() + getRetryDelayMs(claimed.attempts)).toISOString(),
+          processing_token: null,
+          lease_expires_at: null,
+          updated_at: new Date().toISOString(),
+        }
+
+    const { data: finalized, error: finalizeError } = await calendarNoteSyncQueue(supabase)
+      .update(updatePayload)
+      .eq('note_id', noteId)
+      .eq('generation', claimed.generation)
+      .eq('processing_token', claimed.processing_token)
+      .eq('replay_requested', false)
+      .select('note_id')
+      .maybeSingle()
+
+    if (finalizeError) {
+      logger.warn('Failed to finalize calendar note sync claim', {
+        metadata: {
+          noteId,
+          generation: claimed.generation,
+          error: finalizeError.message,
+          ...options.context,
+        },
+      })
+    }
+
+    if (finalized) {
+      return result
+    }
+
+    // A newer generation arrived, or an expired lease was reclaimed, while the
+    // Google request was running. Invalidate the current state and replay the
+    // latest note after releasing only our own token.
+    const requeued = await requeuePubOpsCalendarNote(
+      supabase,
+      noteId,
+      claimed.processing_token
+    )
+    await releasePubOpsCalendarNoteClaim(supabase, noteId, claimed.processing_token)
+
+    if (!requeued || replayDepth >= 3) {
+      return result
+    }
+
+    return processPubOpsCalendarNoteQueueItem(supabase, noteId, {
+      operation: options.operation,
+      context: options.context,
+      replayDepth: replayDepth + 1,
+    })
+  } catch (error) {
+    logger.warn('Unexpected durable calendar note sync failure', {
+      metadata: {
+        noteId,
+        googleEventId,
+        error: getGoogleErrorMessage(error),
+        ...options.context,
+      },
+    })
+    return { state: 'failed', noteId, googleEventId, reason: getGoogleErrorMessage(error) }
+  }
+}

--- a/supabase/migrations/20260730000000_calendar_note_google_sync_queue.sql
+++ b/supabase/migrations/20260730000000_calendar_note_google_sync_queue.sql
@@ -1,0 +1,279 @@
+-- Durable Pub Ops Google Calendar sync queue for calendar notes.
+--
+-- The trigger keeps queue creation in the same transaction as the note write,
+-- including hard deletes. A generation counter prevents a completed sync from
+-- clearing a newer update which arrived while Google was being called.
+
+CREATE TABLE IF NOT EXISTS public.calendar_note_google_sync_queue (
+  note_id uuid PRIMARY KEY,
+  operation text NOT NULL CHECK (operation IN ('upsert', 'delete')),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'synced')),
+  generation bigint NOT NULL DEFAULT 1 CHECK (generation > 0),
+  attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  last_error text,
+  available_at timestamptz NOT NULL DEFAULT now(),
+  processing_token uuid,
+  lease_expires_at timestamptz,
+  replay_requested boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_calendar_note_google_sync_queue_available
+  ON public.calendar_note_google_sync_queue (available_at, updated_at)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_calendar_note_google_sync_queue_reconciliation
+  ON public.calendar_note_google_sync_queue (updated_at, note_id)
+  WHERE status = 'synced' AND operation = 'upsert';
+
+ALTER TABLE public.calendar_note_google_sync_queue ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.calendar_note_google_sync_queue FROM anon, authenticated;
+GRANT ALL ON TABLE public.calendar_note_google_sync_queue TO service_role;
+
+CREATE OR REPLACE FUNCTION public.enqueue_calendar_note_google_sync()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  target_note_id uuid;
+  target_operation text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    target_note_id := OLD.id;
+    target_operation := 'delete';
+  ELSE
+    target_note_id := NEW.id;
+    target_operation := 'upsert';
+  END IF;
+
+  INSERT INTO public.calendar_note_google_sync_queue AS queue (
+    note_id,
+    operation,
+    status,
+    generation,
+    attempts,
+    last_error,
+    available_at,
+    updated_at
+  )
+  VALUES (
+    target_note_id,
+    target_operation,
+    'pending',
+    1,
+    0,
+    NULL,
+    now(),
+    now()
+  )
+  ON CONFLICT (note_id) DO UPDATE
+  SET operation = EXCLUDED.operation,
+      status = 'pending',
+      generation = queue.generation + 1,
+      attempts = 0,
+      last_error = NULL,
+      available_at = now(),
+      replay_requested = false,
+      updated_at = now();
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enqueue_calendar_note_google_sync() FROM PUBLIC;
+
+CREATE OR REPLACE FUNCTION public.claim_calendar_note_google_sync(
+  p_note_id uuid,
+  p_expected_generation bigint DEFAULT NULL,
+  p_lease_seconds integer DEFAULT 600
+)
+RETURNS TABLE (
+  note_id uuid,
+  operation text,
+  generation bigint,
+  attempts integer,
+  processing_token uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  claim_token uuid := gen_random_uuid();
+  lease_seconds integer := GREATEST(COALESCE(p_lease_seconds, 600), 60);
+BEGIN
+  RETURN QUERY
+  UPDATE public.calendar_note_google_sync_queue AS queue
+  SET processing_token = claim_token,
+      lease_expires_at = now() + make_interval(secs => lease_seconds),
+      updated_at = now()
+  WHERE queue.note_id = p_note_id
+    AND queue.status = 'pending'
+    AND queue.available_at <= now()
+    AND (p_expected_generation IS NULL OR queue.generation = p_expected_generation)
+    AND (
+      queue.processing_token IS NULL OR
+      queue.lease_expires_at IS NULL OR
+      queue.lease_expires_at <= now()
+    )
+  RETURNING
+    queue.note_id,
+    queue.operation,
+    queue.generation,
+    queue.attempts,
+    queue.processing_token;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_calendar_note_google_sync(uuid, bigint, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.claim_calendar_note_google_sync(uuid, bigint, integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.requeue_calendar_note_google_sync(
+  p_note_id uuid,
+  p_processing_token uuid DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  next_generation bigint;
+BEGIN
+  UPDATE public.calendar_note_google_sync_queue AS queue
+  SET status = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN queue.status
+        ELSE 'pending'
+      END,
+      generation = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN queue.generation
+        ELSE queue.generation + 1
+      END,
+      attempts = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN queue.attempts
+        ELSE 0
+      END,
+      last_error = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN queue.last_error
+        ELSE NULL
+      END,
+      available_at = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN queue.available_at
+        ELSE now()
+      END,
+      replay_requested = CASE
+        WHEN queue.processing_token IS NOT NULL
+          AND queue.processing_token IS DISTINCT FROM p_processing_token
+          AND queue.lease_expires_at IS NOT NULL
+          AND queue.lease_expires_at > now()
+        THEN true
+        ELSE false
+      END,
+      updated_at = now()
+  WHERE queue.note_id = p_note_id
+  RETURNING CASE
+    WHEN queue.replay_requested THEN NULL
+    ELSE queue.generation
+  END INTO next_generation;
+
+  RETURN next_generation;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.requeue_calendar_note_google_sync(uuid, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.requeue_calendar_note_google_sync(uuid, uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.requeue_stale_calendar_note_google_sync(
+  p_today date,
+  p_synced_before timestamptz,
+  p_limit integer DEFAULT 25
+)
+RETURNS TABLE (
+  note_id uuid,
+  operation text,
+  generation bigint,
+  attempts integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  reconciliation_limit integer := LEAST(GREATEST(COALESCE(p_limit, 25), 1), 25);
+BEGIN
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT queue.note_id
+    FROM public.calendar_note_google_sync_queue AS queue
+    INNER JOIN public.calendar_notes AS notes ON notes.id = queue.note_id
+    WHERE queue.status = 'synced'
+      AND queue.operation = 'upsert'
+      AND COALESCE(notes.end_date, notes.note_date) >= p_today
+      AND queue.updated_at <= p_synced_before
+    ORDER BY queue.updated_at ASC, queue.note_id ASC
+    LIMIT reconciliation_limit
+    FOR UPDATE OF queue SKIP LOCKED
+  )
+  UPDATE public.calendar_note_google_sync_queue AS queue
+  SET status = 'pending',
+      generation = queue.generation + 1,
+      attempts = 0,
+      last_error = NULL,
+      available_at = now(),
+      processing_token = NULL,
+      lease_expires_at = NULL,
+      replay_requested = false,
+      updated_at = now()
+  FROM candidates
+  WHERE queue.note_id = candidates.note_id
+  RETURNING
+    queue.note_id,
+    queue.operation,
+    queue.generation,
+    queue.attempts;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.requeue_stale_calendar_note_google_sync(date, timestamptz, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.requeue_stale_calendar_note_google_sync(date, timestamptz, integer) TO service_role;
+
+DROP TRIGGER IF EXISTS queue_calendar_note_google_sync ON public.calendar_notes;
+CREATE TRIGGER queue_calendar_note_google_sync
+  AFTER INSERT OR UPDATE OR DELETE ON public.calendar_notes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enqueue_calendar_note_google_sync();
+
+-- Backfill every existing note, including historical entries. Completed rows
+-- remain as compact sync markers so generation numbers never reset.
+INSERT INTO public.calendar_note_google_sync_queue (note_id, operation)
+SELECT id, 'upsert'
+FROM public.calendar_notes
+ON CONFLICT (note_id) DO NOTHING;

--- a/tests/actions/calendar-notes.test.ts
+++ b/tests/actions/calendar-notes.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Mock } from 'vitest'
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('@/app/actions/rbac', () => ({
+  checkUserPermission: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/openai/config', () => ({
+  getOpenAIConfig: vi.fn(),
+}))
+
+vi.mock('@/app/actions/audit', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/google-calendar-notes', () => ({
+  isPubOpsCalendarNoteSyncQueueAvailable: vi.fn().mockResolvedValue(true),
+  processPubOpsCalendarNoteQueueItem: vi.fn().mockResolvedValue({
+    state: 'failed',
+    noteId: '550e8400-e29b-41d4-a716-446655440001',
+    googleEventId: 'google-note-id',
+    reason: 'temporary Google error',
+  }),
+}))
+
+import { checkUserPermission } from '@/app/actions/rbac'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { createClient } from '@/lib/supabase/server'
+import {
+  isPubOpsCalendarNoteSyncQueueAvailable,
+  processPubOpsCalendarNoteQueueItem,
+} from '@/lib/google-calendar-notes'
+import {
+  createCalendarNote,
+  deleteCalendarNote,
+  updateCalendarNote,
+} from '@/app/actions/calendar-notes'
+
+const mockedPermission = checkUserPermission as unknown as Mock
+const mockedCreateAdminClient = createAdminClient as unknown as Mock
+const mockedCreateClient = createClient as unknown as Mock
+const mockedProcessSync = processPubOpsCalendarNoteQueueItem as unknown as Mock
+const mockedQueueReady = isPubOpsCalendarNoteSyncQueueAvailable as unknown as Mock
+
+const noteId = '550e8400-e29b-41d4-a716-446655440001'
+const baseRow = {
+  id: noteId,
+  note_date: '2026-06-15',
+  end_date: '2026-06-15',
+  title: 'Father’s Day planning',
+  notes: 'Check staffing and stock levels.',
+  source: 'manual',
+  start_time: null,
+  end_time: null,
+  color: '#0EA5E9',
+  created_at: '2026-06-01T09:00:00.000Z',
+  updated_at: '2026-06-01T09:00:00.000Z',
+}
+
+function selectOne(result: { data: unknown; error: unknown }) {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  }
+}
+
+describe('calendar note Google sync hooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedPermission.mockResolvedValue(true)
+    mockedQueueReady.mockResolvedValue(true)
+    mockedCreateClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'user-1', email: 'staff@example.com' } },
+          error: null,
+        }),
+      },
+    })
+    mockedProcessSync.mockResolvedValue({
+      state: 'failed',
+      noteId,
+      googleEventId: 'google-note-id',
+      reason: 'temporary Google error',
+    })
+  })
+
+  it('syncs a newly created note without failing the database write when Google fails', async () => {
+    const admin = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: baseRow, error: null }),
+          }),
+        }),
+      }),
+    }
+    mockedCreateAdminClient.mockReturnValue(admin)
+
+    const result = await createCalendarNote({
+      note_date: baseRow.note_date,
+      title: baseRow.title,
+      notes: baseRow.notes,
+    })
+
+    expect(result.data).toMatchObject({ id: noteId, title: baseRow.title })
+    expect(mockedProcessSync).toHaveBeenCalledWith(admin, noteId, {
+      operation: 'upsert',
+      context: { context: 'calendar_note_created' },
+    })
+  })
+
+  it('re-syncs a successfully updated note', async () => {
+    const updatedRow = {
+      ...baseRow,
+      title: 'Updated planning note',
+      updated_at: '2026-06-02T09:00:00.000Z',
+    }
+    const admin = {
+      from: vi.fn()
+        .mockReturnValueOnce(selectOne({ data: baseRow, error: null }))
+        .mockReturnValueOnce({
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: updatedRow, error: null }),
+              }),
+            }),
+          }),
+        }),
+    }
+    mockedCreateAdminClient.mockReturnValue(admin)
+
+    const result = await updateCalendarNote(noteId, {
+      title: updatedRow.title,
+    })
+
+    expect(result.data).toMatchObject({ id: noteId, title: updatedRow.title })
+    expect(mockedProcessSync).toHaveBeenCalledWith(admin, noteId, {
+      operation: 'upsert',
+      context: { context: 'calendar_note_updated' },
+    })
+  })
+
+  it('removes the Google event after a note is deleted', async () => {
+    const admin = {
+      from: vi.fn()
+        .mockReturnValueOnce(selectOne({ data: baseRow, error: null }))
+        .mockReturnValueOnce({
+          delete: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockResolvedValue({ data: { id: noteId }, error: null }),
+              }),
+            }),
+          }),
+        }),
+    }
+    mockedCreateAdminClient.mockReturnValue(admin)
+
+    const result = await deleteCalendarNote(noteId)
+
+    expect(result).toEqual({ success: true })
+    expect(mockedProcessSync).toHaveBeenCalledWith(admin, noteId, {
+      operation: 'delete',
+      context: { context: 'calendar_note_deleted' },
+    })
+  })
+
+  it('keeps the note when the durable delete queue is unavailable', async () => {
+    mockedQueueReady.mockResolvedValue(false)
+    const admin = {
+      from: vi.fn().mockReturnValueOnce(selectOne({ data: baseRow, error: null })),
+    }
+    mockedCreateAdminClient.mockReturnValue(admin)
+
+    const result = await deleteCalendarNote(noteId)
+
+    expect(result).toEqual({
+      error: 'Calendar sync is not ready. The note was not deleted.',
+    })
+    expect(admin.from).toHaveBeenCalledTimes(1)
+    expect(mockedProcessSync).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/pubOpsCalendarNoteSync.test.ts
+++ b/tests/api/pubOpsCalendarNoteSync.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authorizeCronRequestMock = vi.fn()
+const createAdminClientMock = vi.fn()
+const processQueueItemMock = vi.fn()
+
+vi.mock('@/lib/cron-auth', () => ({
+  authorizeCronRequest: (...args: unknown[]) => authorizeCronRequestMock(...args),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => createAdminClientMock(),
+}))
+
+vi.mock('@/lib/google-calendar-notes', () => ({
+  processPubOpsCalendarNoteQueueItem: (...args: unknown[]) => processQueueItemMock(...args),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+import { GET } from '@/app/api/cron/pub-ops-calendar-note-sync/route'
+
+function makeQueueQuery(result: { data: unknown[] | null; error: unknown }) {
+  const limit = vi.fn().mockResolvedValue(result)
+  const secondOrder = vi.fn().mockReturnValue({ limit })
+  const firstOrder = vi.fn().mockReturnValue({ order: secondOrder })
+  const lte = vi.fn().mockReturnValue({ order: firstOrder })
+  const eq = vi.fn().mockReturnValue({ lte })
+
+  return {
+    builder: { select: vi.fn().mockReturnValue({ eq }) },
+    eq,
+    lte,
+    limit,
+  }
+}
+
+describe('/api/cron/pub-ops-calendar-note-sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-10T12:00:00.000Z'))
+    authorizeCronRequestMock.mockReturnValue({ authorized: true })
+    processQueueItemMock.mockResolvedValue({
+      state: 'updated',
+      noteId: 'note-1',
+      googleEventId: 'google-note-1',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rejects unauthorized requests before opening an admin client', async () => {
+    authorizeCronRequestMock.mockReturnValue({ authorized: false, reason: 'Unauthorized' })
+
+    const response = await GET(new Request('http://localhost/api/cron/pub-ops-calendar-note-sync') as any)
+
+    expect(response.status).toBe(401)
+    expect(createAdminClientMock).not.toHaveBeenCalled()
+  })
+
+  it('processes durable queue rows and reports their outcomes', async () => {
+    const item = {
+      note_id: 'note-1',
+      operation: 'upsert',
+      generation: 3,
+      attempts: 1,
+    }
+    const query = makeQueueQuery({ data: [item], error: null })
+    const admin = {
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+      from: vi.fn((table: string) => {
+        if (table !== 'calendar_note_google_sync_queue') {
+          throw new Error(`Unexpected table: ${table}`)
+        }
+        return query.builder
+      }),
+    }
+    createAdminClientMock.mockReturnValue(admin)
+
+    const response = await GET(new Request('http://localhost/api/cron/pub-ops-calendar-note-sync') as any)
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(processQueueItemMock).toHaveBeenCalledWith(admin, 'note-1', {
+      expectedGeneration: 3,
+      context: { context: 'pub_ops_calendar_note_queue' },
+    })
+    expect(payload).toMatchObject({
+      success: true,
+      processed: 1,
+      queued: 1,
+      reconciled: 0,
+      counts: { updated: 1, failed: 0 },
+    })
+  })
+
+  it('uses spare capacity to recheck old synced future notes', async () => {
+    const reconciledItem = {
+      note_id: 'note-reconciled',
+      operation: 'upsert',
+      generation: 9,
+      attempts: 0,
+    }
+    const query = makeQueueQuery({ data: [], error: null })
+    const admin = {
+      from: vi.fn().mockReturnValue(query.builder),
+      rpc: vi.fn().mockResolvedValue({ data: [reconciledItem], error: null }),
+    }
+    createAdminClientMock.mockReturnValue(admin)
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/pub-ops-calendar-note-sync') as any
+    )
+    const payload = await response.json()
+
+    expect(admin.rpc).toHaveBeenCalledWith(
+      'requeue_stale_calendar_note_google_sync',
+      {
+        p_today: '2026-07-10',
+        p_synced_before: '2026-07-09T12:00:00.000Z',
+        p_limit: 25,
+      }
+    )
+    expect(processQueueItemMock).toHaveBeenCalledWith(
+      admin,
+      'note-reconciled',
+      {
+        expectedGeneration: 9,
+        context: { context: 'pub_ops_calendar_note_reconciliation' },
+      }
+    )
+    expect(payload).toMatchObject({
+      success: true,
+      processed: 1,
+      queued: 0,
+      reconciled: 1,
+    })
+  })
+
+  it('does not reconcile when pending work fills the requested limit', async () => {
+    const item = {
+      note_id: 'note-1',
+      operation: 'upsert',
+      generation: 3,
+      attempts: 1,
+    }
+    const query = makeQueueQuery({ data: [item], error: null })
+    const admin = {
+      from: vi.fn().mockReturnValue(query.builder),
+      rpc: vi.fn(),
+    }
+    createAdminClientMock.mockReturnValue(admin)
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/pub-ops-calendar-note-sync?limit=1') as any
+    )
+
+    expect(response.status).toBe(200)
+    expect(admin.rpc).not.toHaveBeenCalled()
+  })
+
+  it('supports an immediate targeted retry without loading the batch', async () => {
+    const admin = { from: vi.fn() }
+    createAdminClientMock.mockReturnValue(admin)
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/pub-ops-calendar-note-sync?noteId=note-42') as any
+    )
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(admin.from).not.toHaveBeenCalled()
+    expect(processQueueItemMock).toHaveBeenCalledWith(admin, 'note-42', {
+      force: true,
+      context: { context: 'pub_ops_calendar_note_single_sync' },
+    })
+    expect(payload.processed).toBe(1)
+  })
+
+  it('returns a generic failure when the queue cannot be loaded', async () => {
+    const query = makeQueueQuery({ data: null, error: new Error('database details') })
+    createAdminClientMock.mockReturnValue({ from: vi.fn().mockReturnValue(query.builder) })
+
+    const response = await GET(new Request('http://localhost/api/cron/pub-ops-calendar-note-sync') as any)
+    const payload = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(payload).toEqual({
+      success: false,
+      error: 'Failed to sync Pub Ops calendar notes',
+    })
+  })
+})

--- a/tests/lib/google-calendar-notes.test.ts
+++ b/tests/lib/google-calendar-notes.test.ts
@@ -1,0 +1,636 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('server-only', () => ({}))
+
+const {
+  eventsUpdate,
+  eventsInsert,
+  eventsDelete,
+  getOAuth2ClientMock,
+  warn,
+} = vi.hoisted(() => ({
+  eventsUpdate: vi.fn(),
+  eventsInsert: vi.fn(),
+  eventsDelete: vi.fn(),
+  getOAuth2ClientMock: vi.fn(),
+  warn: vi.fn(),
+}))
+
+vi.mock('googleapis', () => ({
+  google: {
+    calendar: vi.fn(() => ({
+      events: {
+        update: eventsUpdate,
+        insert: eventsInsert,
+        delete: eventsDelete,
+      },
+    })),
+  },
+}))
+
+vi.mock('@/lib/google-calendar', () => ({
+  getOAuth2Client: getOAuth2ClientMock,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    warn,
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+import {
+  PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+  buildPubOpsCalendarNoteEntry,
+  deletePubOpsCalendarNoteEntryById,
+  generatePubOpsCalendarNoteEventId,
+  isPubOpsCalendarNoteSyncQueueAvailable,
+  processPubOpsCalendarNoteQueueItem,
+  syncPubOpsCalendarNoteById,
+  type PubOpsCalendarNoteQueueItem,
+  type PubOpsCalendarNoteRow,
+} from '@/lib/google-calendar-notes'
+
+const originalGoogleServiceAccountKey = process.env.GOOGLE_SERVICE_ACCOUNT_KEY
+const originalGoogleClientId = process.env.GOOGLE_CLIENT_ID
+const originalGoogleClientSecret = process.env.GOOGLE_CLIENT_SECRET
+const originalGoogleRefreshToken = process.env.GOOGLE_REFRESH_TOKEN
+const originalAppUrl = process.env.NEXT_PUBLIC_APP_URL
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+const baseNote: PubOpsCalendarNoteRow = {
+  id: '550e8400-e29b-41d4-a716-446655440001',
+  note_date: '2026-06-15',
+  end_date: '2026-06-15',
+  title: 'Father’s Day planning',
+  notes: 'Check staffing and stock levels.',
+  source: 'manual',
+  start_time: null,
+  end_time: null,
+}
+
+const now = new Date('2026-06-10T12:00:00.000Z')
+
+function makeSupabaseMock(input: {
+  note?: PubOpsCalendarNoteRow | null
+  error?: { message: string } | null
+}) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table !== 'calendar_notes') {
+        throw new Error(`Unexpected table: ${table}`)
+      }
+
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: input.note ?? null,
+              error: input.error ?? null,
+            }),
+          }),
+        }),
+      }
+    }),
+  }
+}
+
+function makeQueuedSupabaseMock(input: {
+  note?: PubOpsCalendarNoteRow | null
+  queueItem: PubOpsCalendarNoteQueueItem
+  finalized?: boolean
+}) {
+  const claimedItem = {
+    ...input.queueItem,
+    processing_token: 'claim-token-1',
+  }
+  const rpc = vi.fn((fn: string) => {
+    if (fn === 'claim_calendar_note_google_sync') {
+      return Promise.resolve({ data: [claimedItem], error: null })
+    }
+    if (fn === 'requeue_calendar_note_google_sync') {
+      claimedItem.generation += 1
+      claimedItem.attempts = 0
+      return Promise.resolve({ data: claimedItem.generation, error: null })
+    }
+    throw new Error(`Unexpected RPC: ${fn}`)
+  })
+
+  const finalizeMaybeSingle = vi.fn().mockResolvedValue({
+    data: input.finalized === false ? null : { note_id: input.queueItem.note_id },
+    error: null,
+  })
+  const finalizeSelect = vi.fn().mockReturnValue({ maybeSingle: finalizeMaybeSingle })
+  const finalizeReplay = vi.fn().mockReturnValue({ select: finalizeSelect })
+  const finalizeToken = vi.fn().mockReturnValue({ eq: finalizeReplay })
+  const finalizeGeneration = vi.fn().mockReturnValue({ eq: finalizeToken })
+  const finalizeNoteId = vi.fn().mockReturnValue({ eq: finalizeGeneration })
+
+  const releaseToken = vi.fn().mockResolvedValue({ error: null })
+  const releaseNoteId = vi.fn().mockReturnValue({ eq: releaseToken })
+
+  const queueUpdate = vi.fn((payload: Record<string, unknown>) => {
+    if ('status' in payload) {
+      return { eq: finalizeNoteId }
+    }
+    return { eq: releaseNoteId }
+  })
+
+  const supabase = {
+    rpc,
+    from: vi.fn((table: string) => {
+      if (table === 'calendar_notes') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: input.note ?? null,
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'calendar_note_google_sync_queue') {
+        return {
+          update: queueUpdate,
+        }
+      }
+
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+  }
+
+  return {
+    supabase,
+    rpc,
+    queueUpdate,
+    finalizeGeneration,
+    finalizeNoteId,
+    finalizeToken,
+    finalizeReplay,
+    releaseToken,
+  }
+}
+
+describe('Pub Ops calendar note sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = '{"type":"service_account"}'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.the-anchor.pub'
+    getOAuth2ClientMock.mockResolvedValue({ auth: true })
+    eventsUpdate.mockResolvedValue({ data: { id: 'updated-note-id' } })
+    eventsInsert.mockResolvedValue({ data: { id: 'created-note-id' } })
+    eventsDelete.mockResolvedValue({ data: {} })
+  })
+
+  afterEach(() => {
+    restoreEnv('GOOGLE_SERVICE_ACCOUNT_KEY', originalGoogleServiceAccountKey)
+    restoreEnv('GOOGLE_CLIENT_ID', originalGoogleClientId)
+    restoreEnv('GOOGLE_CLIENT_SECRET', originalGoogleClientSecret)
+    restoreEnv('GOOGLE_REFRESH_TOKEN', originalGoogleRefreshToken)
+    restoreEnv('NEXT_PUBLIC_APP_URL', originalAppUrl)
+  })
+
+  it('generates a stable Google-safe event id for each note', () => {
+    const first = generatePubOpsCalendarNoteEventId(baseNote.id)
+    const second = generatePubOpsCalendarNoteEventId(baseNote.id)
+    const other = generatePubOpsCalendarNoteEventId('550e8400-e29b-41d4-a716-446655440002')
+
+    expect(first).toBe(second)
+    expect(first).not.toBe(other)
+    expect(first).toMatch(/^[a-v0-9]{5,1024}$/)
+  })
+
+  it('requires both the durable queue table and claim function before allowing deletes', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+        }),
+      }),
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+
+    await expect(isPubOpsCalendarNoteSyncQueueAvailable(supabase as any)).resolves.toBe(true)
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_calendar_note_google_sync', {
+      p_note_id: '00000000-0000-0000-0000-000000000000',
+      p_expected_generation: null,
+      p_lease_seconds: 600,
+    })
+  })
+
+  it('maps the inclusive app date range to an exclusive Google all-day end date', () => {
+    const entry = buildPubOpsCalendarNoteEntry({
+      note: { ...baseNote, end_date: '2026-06-17', source: 'ai' },
+      appBaseUrl: 'https://app.the-anchor.pub',
+      now,
+    })
+
+    expect(entry.requestBody).toMatchObject({
+      id: generatePubOpsCalendarNoteEventId(baseNote.id),
+      summary: 'Father’s Day planning',
+      start: { date: '2026-06-15' },
+      end: { date: '2026-06-18' },
+      transparency: 'transparent',
+      reminders: { useDefault: false },
+    })
+    expect(entry.requestBody.description).toContain('Check staffing and stock levels.')
+    expect(entry.requestBody.description).toContain('Source: AI-generated calendar note')
+    expect(entry.requestBody.description).toContain('Manage notes: https://app.the-anchor.pub/settings/calendar-notes')
+    expect(entry.requestBody.extendedProperties.private).toEqual({
+      source: 'anchor_calendar_note',
+      anchorCalendarNoteId: baseNote.id,
+    })
+    expect(entry.requestBody).not.toHaveProperty('colorId')
+  })
+
+  it('keeps all-day end dates correct across the UK daylight-saving change', () => {
+    const entry = buildPubOpsCalendarNoteEntry({
+      note: {
+        ...baseNote,
+        note_date: '2026-03-29',
+        end_date: '2026-03-29',
+      },
+      now,
+    })
+
+    expect(entry.requestBody.start).toEqual({ date: '2026-03-29' })
+    expect(entry.requestBody.end).toEqual({ date: '2026-03-30' })
+  })
+
+  it('uses Europe/London time and the supplied end time for a timed note', () => {
+    const entry = buildPubOpsCalendarNoteEntry({
+      note: {
+        ...baseNote,
+        start_time: '19:00',
+        end_time: '21:30',
+      },
+      now,
+    })
+
+    expect(entry.requestBody.start).toEqual({
+      dateTime: '2026-06-15T18:00:00.000Z',
+      timeZone: 'Europe/London',
+    })
+    expect(entry.requestBody.end).toEqual({
+      dateTime: '2026-06-15T20:30:00.000Z',
+      timeZone: 'Europe/London',
+    })
+  })
+
+  it('defaults a timed note to one hour when its end is missing or invalid', () => {
+    const missingEnd = buildPubOpsCalendarNoteEntry({
+      note: { ...baseNote, start_time: '19:00' },
+      now,
+    })
+    const invalidEnd = buildPubOpsCalendarNoteEntry({
+      note: { ...baseNote, start_time: '19:00', end_time: '18:00' },
+      now,
+    })
+
+    expect(missingEnd.requestBody.end).toEqual({
+      dateTime: '2026-06-15T19:00:00.000Z',
+      timeZone: 'Europe/London',
+    })
+    expect(invalidEnd.requestBody.end).toEqual(missingEnd.requestBody.end)
+  })
+
+  it('updates an existing note on the shared Pub Ops calendar', async () => {
+    const supabase = makeSupabaseMock({ note: baseNote })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result.state).toBe('updated')
+    expect(eventsUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      eventId: generatePubOpsCalendarNoteEventId(baseNote.id),
+      requestBody: expect.objectContaining({ summary: baseNote.title }),
+    }))
+    expect(eventsInsert).not.toHaveBeenCalled()
+  })
+
+  it('creates the deterministic event when update returns not found', async () => {
+    eventsUpdate.mockRejectedValueOnce(Object.assign(new Error('not found'), { status: 404 }))
+    const supabase = makeSupabaseMock({ note: baseNote })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result.state).toBe('created')
+    expect(eventsInsert).toHaveBeenCalledWith(expect.objectContaining({
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      requestBody: expect.objectContaining({
+        id: generatePubOpsCalendarNoteEventId(baseNote.id),
+      }),
+    }))
+  })
+
+  it('retries update when a create races with another sync', async () => {
+    eventsUpdate
+      .mockRejectedValueOnce(Object.assign(new Error('not found'), { status: 404 }))
+      .mockResolvedValueOnce({ data: { id: 'raced-note-id' } })
+    eventsInsert.mockRejectedValueOnce(Object.assign(new Error('conflict'), { status: 409 }))
+    const supabase = makeSupabaseMock({ note: baseNote })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result).toMatchObject({ state: 'updated', googleEventId: 'raced-note-id' })
+    expect(eventsUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('deletes the deterministic Google event when the database note is missing', async () => {
+    const supabase = makeSupabaseMock({ note: null })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result.state).toBe('deleted')
+    expect(eventsDelete).toHaveBeenCalledWith(expect.objectContaining({
+      calendarId: PUB_OPS_EVENT_BOOKINGS_CALENDAR_ID,
+      eventId: generatePubOpsCalendarNoteEventId(baseNote.id),
+    }))
+  })
+
+  it('treats an already missing Google event as a successful delete', async () => {
+    eventsDelete.mockRejectedValueOnce(Object.assign(new Error('gone'), { status: 410 }))
+
+    const result = await deletePubOpsCalendarNoteEntryById(baseNote.id)
+
+    expect(result).toMatchObject({ state: 'skipped', reason: 'already_missing' })
+  })
+
+  it('skips without calling Google when calendar auth is not configured', async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY
+    delete process.env.GOOGLE_CLIENT_ID
+    delete process.env.GOOGLE_CLIENT_SECRET
+    delete process.env.GOOGLE_REFRESH_TOKEN
+    const supabase = makeSupabaseMock({ note: baseNote })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result).toMatchObject({
+      state: 'skipped',
+      reason: 'calendar_not_configured',
+    })
+    expect(getOAuth2ClientMock).not.toHaveBeenCalled()
+    expect(eventsUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns a failure instead of throwing when Google auth fails', async () => {
+    getOAuth2ClientMock.mockRejectedValueOnce(new Error('auth failed'))
+    const supabase = makeSupabaseMock({ note: baseNote })
+
+    const result = await syncPubOpsCalendarNoteById(supabase as any, baseNote.id)
+
+    expect(result).toMatchObject({ state: 'failed', reason: 'auth failed' })
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('acknowledges only the durable queue generation which was synced', async () => {
+    const queueItem: PubOpsCalendarNoteQueueItem = {
+      note_id: baseNote.id,
+      operation: 'upsert',
+      generation: 7,
+      attempts: 0,
+    }
+    const queued = makeQueuedSupabaseMock({ note: baseNote, queueItem })
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      queued.supabase as any,
+      baseNote.id,
+      { expectedGeneration: queueItem.generation }
+    )
+
+    expect(result.state).toBe('updated')
+    expect(queued.queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'synced',
+      attempts: 0,
+      last_error: null,
+    }))
+    expect(queued.finalizeNoteId).toHaveBeenCalledWith('note_id', baseNote.id)
+    expect(queued.finalizeGeneration).toHaveBeenCalledWith('generation', 7)
+    expect(queued.finalizeToken).toHaveBeenCalledWith('processing_token', 'claim-token-1')
+    expect(queued.finalizeReplay).toHaveBeenCalledWith('replay_requested', false)
+  })
+
+  it('keeps failed work queued with backoff so later items are not starved', async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY
+    delete process.env.GOOGLE_CLIENT_ID
+    delete process.env.GOOGLE_CLIENT_SECRET
+    delete process.env.GOOGLE_REFRESH_TOKEN
+    const queueItem: PubOpsCalendarNoteQueueItem = {
+      note_id: baseNote.id,
+      operation: 'upsert',
+      generation: 4,
+      attempts: 2,
+    }
+    const queued = makeQueuedSupabaseMock({ note: baseNote, queueItem })
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      queued.supabase as any,
+      baseNote.id,
+      { expectedGeneration: queueItem.generation }
+    )
+
+    expect(result).toMatchObject({ state: 'skipped', reason: 'calendar_not_configured' })
+    expect(queued.queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'pending',
+      attempts: 3,
+      last_error: 'calendar_not_configured',
+      available_at: expect.any(String),
+    }))
+    expect(queued.finalizeNoteId).toHaveBeenCalledWith('note_id', baseNote.id)
+    expect(queued.finalizeGeneration).toHaveBeenCalledWith('generation', 4)
+    expect(queued.finalizeToken).toHaveBeenCalledWith('processing_token', 'claim-token-1')
+  })
+
+  it('returns a failed targeted retry to pending status for the cron to recover', async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY
+    delete process.env.GOOGLE_CLIENT_ID
+    delete process.env.GOOGLE_CLIENT_SECRET
+    delete process.env.GOOGLE_REFRESH_TOKEN
+    const queueItem: PubOpsCalendarNoteQueueItem = {
+      note_id: baseNote.id,
+      operation: 'upsert',
+      generation: 10,
+      attempts: 4,
+    }
+    const queued = makeQueuedSupabaseMock({ note: baseNote, queueItem })
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      queued.supabase as any,
+      baseNote.id,
+      { force: true }
+    )
+
+    expect(result).toMatchObject({ state: 'skipped', reason: 'calendar_not_configured' })
+    expect(queued.rpc).toHaveBeenCalledWith('requeue_calendar_note_google_sync', {
+      p_note_id: baseNote.id,
+      p_processing_token: null,
+    })
+    expect(queued.queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'pending',
+      attempts: 1,
+      last_error: 'calendar_not_configured',
+    }))
+    expect(queued.finalizeGeneration).toHaveBeenCalledWith('generation', 11)
+  })
+
+  it('processes a durable delete tombstone after the note row is gone', async () => {
+    const queueItem: PubOpsCalendarNoteQueueItem = {
+      note_id: baseNote.id,
+      operation: 'delete',
+      generation: 9,
+      attempts: 0,
+    }
+    const queued = makeQueuedSupabaseMock({ note: null, queueItem })
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      queued.supabase as any,
+      baseNote.id,
+      { expectedGeneration: queueItem.generation }
+    )
+
+    expect(result.state).toBe('deleted')
+    expect(eventsDelete).toHaveBeenCalledWith(expect.objectContaining({
+      eventId: generatePubOpsCalendarNoteEventId(baseNote.id),
+    }))
+    expect(queued.queueUpdate).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'synced',
+    }))
+    expect(queued.finalizeGeneration).toHaveBeenCalledWith('generation', 9)
+  })
+
+  it('replays the newest generation after an edit arrives during a Google update', async () => {
+    const oldNote = { ...baseNote, title: 'Old planning title' }
+    const latestNote = { ...baseNote, title: 'Latest planning title' }
+    const claims = [
+      {
+        note_id: baseNote.id,
+        operation: 'upsert',
+        generation: 1,
+        attempts: 0,
+        processing_token: 'claim-token-old',
+      },
+      {
+        note_id: baseNote.id,
+        operation: 'upsert',
+        generation: 3,
+        attempts: 0,
+        processing_token: 'claim-token-latest',
+      },
+    ]
+    const rpc = vi.fn((fn: string) => {
+      if (fn === 'claim_calendar_note_google_sync') {
+        return Promise.resolve({ data: claims.length > 0 ? [claims.shift()] : [], error: null })
+      }
+      if (fn === 'requeue_calendar_note_google_sync') {
+        return Promise.resolve({ data: 3, error: null })
+      }
+      throw new Error(`Unexpected RPC: ${fn}`)
+    })
+    const noteMaybeSingle = vi.fn()
+      .mockResolvedValueOnce({ data: oldNote, error: null })
+      .mockResolvedValueOnce({ data: latestNote, error: null })
+
+    const finalizeMaybeSingle = vi.fn()
+      .mockResolvedValueOnce({ data: null, error: null })
+      .mockResolvedValueOnce({ data: { note_id: baseNote.id }, error: null })
+    const finalizeSelect = vi.fn().mockReturnValue({ maybeSingle: finalizeMaybeSingle })
+    const finalizeReplay = vi.fn().mockReturnValue({ select: finalizeSelect })
+    const finalizeToken = vi.fn().mockReturnValue({ eq: finalizeReplay })
+    const finalizeGeneration = vi.fn().mockReturnValue({ eq: finalizeToken })
+    const finalizeNoteId = vi.fn().mockReturnValue({ eq: finalizeGeneration })
+    const releaseToken = vi.fn().mockResolvedValue({ error: null })
+    const releaseNoteId = vi.fn().mockReturnValue({ eq: releaseToken })
+    const queueUpdate = vi.fn((payload: Record<string, unknown>) =>
+      'status' in payload ? { eq: finalizeNoteId } : { eq: releaseNoteId }
+    )
+
+    const supabase = {
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'calendar_notes') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({ maybeSingle: noteMaybeSingle }),
+            }),
+          }
+        }
+        if (table === 'calendar_note_google_sync_queue') {
+          return { update: queueUpdate }
+        }
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    }
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      supabase as any,
+      baseNote.id,
+      { expectedGeneration: 1 }
+    )
+
+    expect(result.state).toBe('updated')
+    expect(eventsUpdate).toHaveBeenCalledTimes(2)
+    expect(eventsUpdate.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      requestBody: expect.objectContaining({ summary: 'Old planning title' }),
+    }))
+    expect(eventsUpdate.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      requestBody: expect.objectContaining({ summary: 'Latest planning title' }),
+    }))
+    expect(rpc).toHaveBeenCalledWith('requeue_calendar_note_google_sync', {
+      p_note_id: baseNote.id,
+      p_processing_token: 'claim-token-old',
+    })
+    expect(finalizeToken).toHaveBeenLastCalledWith('processing_token', 'claim-token-latest')
+    expect(finalizeReplay).toHaveBeenLastCalledWith('replay_requested', false)
+  })
+
+  it('does not overlap a note sync while another generation holds the lease', async () => {
+    const supabase = {
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+      from: vi.fn((table: string) => {
+        if (table !== 'calendar_note_google_sync_queue') {
+          throw new Error(`Unexpected table: ${table}`)
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  note_id: baseNote.id,
+                  operation: 'upsert',
+                  status: 'pending',
+                  generation: 2,
+                  attempts: 0,
+                  processing_token: 'active-token',
+                  lease_expires_at: '2026-06-10T12:10:00.000Z',
+                },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }),
+    }
+
+    const result = await processPubOpsCalendarNoteQueueItem(
+      supabase as any,
+      baseNote.id,
+      { expectedGeneration: 1 }
+    )
+
+    expect(result).toMatchObject({ state: 'skipped', reason: 'sync_in_progress' })
+    expect(eventsUpdate).not.toHaveBeenCalled()
+    expect(eventsInsert).not.toHaveBeenCalled()
+    expect(eventsDelete).not.toHaveBeenCalled()
+  })
+})

--- a/tests/migrations/calendarNoteGoogleSyncQueue.test.ts
+++ b/tests/migrations/calendarNoteGoogleSyncQueue.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migrationSql = readFileSync(
+  resolve(
+    process.cwd(),
+    'supabase/migrations/20260730000000_calendar_note_google_sync_queue.sql'
+  ),
+  'utf8'
+)
+
+describe('calendar note Google sync queue migration', () => {
+  it('queues every kind of calendar note change and backfills existing notes', () => {
+    expect(migrationSql).toMatch(
+      /AFTER INSERT OR UPDATE OR DELETE ON public\.calendar_notes/
+    )
+    expect(migrationSql).toMatch(
+      /SELECT id, 'upsert'\s+FROM public\.calendar_notes/
+    )
+  })
+
+  it('claims only available work with no live lease', () => {
+    expect(migrationSql).toContain('queue.available_at <= now()')
+    expect(migrationSql).toMatch(
+      /queue\.processing_token IS NULL OR\s+queue\.lease_expires_at IS NULL OR\s+queue\.lease_expires_at <= now\(\)/
+    )
+  })
+
+  it('does not let a stale worker replace a newer live claim', () => {
+    expect(migrationSql).toContain(
+      'queue.processing_token IS DISTINCT FROM p_processing_token'
+    )
+    expect(migrationSql).toContain('queue.lease_expires_at > now()')
+    expect(migrationSql).toContain('replay_requested boolean NOT NULL DEFAULT false')
+    expect(migrationSql).toContain('WHEN queue.replay_requested THEN NULL')
+  })
+
+  it('reconciles only old synced live notes in bounded non-overlapping batches', () => {
+    expect(migrationSql).toContain("queue.status = 'synced'")
+    expect(migrationSql).toContain("queue.operation = 'upsert'")
+    expect(migrationSql).toContain(
+      'COALESCE(notes.end_date, notes.note_date) >= p_today'
+    )
+    expect(migrationSql).toContain('queue.updated_at <= p_synced_before')
+    expect(migrationSql).toContain(
+      'LEAST(GREATEST(COALESCE(p_limit, 25), 1), 25)'
+    )
+    expect(migrationSql).toContain('FOR UPDATE OF queue SKIP LOCKED')
+    expect(migrationSql).toContain('generation = queue.generation + 1')
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -122,6 +122,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/pub-ops-calendar-note-sync",
+      "schedule": "*/15 * * * *"
+    },
+    {
       "path": "/api/cron/parking-notifications",
       "schedule": "*/15 * * * *"
     },


### PR DESCRIPTION
## What changed

- Sync calendar notes from the dashboard and events calendars to the shared Pub Ops Google Calendar.
- Add a durable Supabase queue, retry leases, reconciliation cron, and regression coverage.
- Update the event checklist labels and progress calculation to match the current task set.
- Make generated event SEO copy respect verified kitchen opening hours and event times.
- Add the upcoming-event menu copy maintenance script.
- Update related architecture notes, configuration, UI copy, and tests.

## Why

Calendar notes were visible in the app but did not follow events into the shared operations calendar. The event content and checklist changes align the operational workflow and stop generated copy from promising food outside verified kitchen service.

## Impact

Saved calendar notes will create, update, and delete matching entries in the Pub Ops calendar. Failed syncs retry safely, and upcoming notes are periodically reconciled. Event checklist progress and generated event copy now use the updated operational rules.

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm test` — 522 files, 3,569 tests passed
- `npm run build` — production build passed

## Deployment note

The new Supabase migration is included. The previous dry-run found remote migration `20260709094302` missing locally, so migration history must be reconciled before the new queue migration can be pushed.