### PR TITLE
Fix: show all calendar notes on dashboard

### DIFF
--- a/src/app/(authenticated)/dashboard/dashboard-data.ts
+++ b/src/app/(authenticated)/dashboard/dashboard-data.ts
@@ -878,8 +878,10 @@ async function fetchDashboardSnapshotImpl(userId: string): Promise<DashboardSnap
             supabase
               .from('calendar_notes')
               .select('id, note_date, end_date, title, notes, source, start_time, end_time, color')
-              .lte('note_date', calendarNotesHorizonIso)
-              .or(`end_date.gte.${eventsLookbackIso},end_date.is.null`)
+              // Calendar notes are long-range reminders. Load the complete
+              // note set so future dates remain visible when users navigate
+              // the calendar; rolling horizons still apply to other dashboard
+              // datasets below.
               .order('note_date', { ascending: true })
               .order('end_date', { ascending: true })
               .order('start_time', { ascending: true, nullsFirst: true })


### PR DESCRIPTION
## What changed

Removed the dashboard calendar-note date window. The dashboard now loads the complete calendar-note set, so users can navigate to any 2026 or 2027 note without waiting for it to enter a rolling horizon.

Other dashboard datasets keep their existing operational horizons.

## Validation

- Targeted ESLint passed
- TypeScript check passed
- Production build passed
- GitHub diff contains only the dashboard calendar-note query change