### PR TITLE
Improve vendor spend movement reporting

### DIFF
--- a/src/app/(authenticated)/receipts/vendors/_components/VendorSummaryGrid.tsx
+++ b/src/app/(authenticated)/receipts/vendors/_components/VendorSummaryGrid.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect, useMemo, useState, useTransition } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   getReceiptVendorAiSummary,
   getReceiptVendorDetail,
   getReceiptVendorMovements,
-  getReceiptVendorMonthTransactions,
+  setReceiptVendorReviewStatus,
   setReceiptVendorWatched,
   type ReceiptVendorAiReview,
   type ReceiptVendorCostSignal,
@@ -14,32 +14,31 @@ import {
   type ReceiptVendorMovementRange,
   type ReceiptVendorMovementSignal,
   type ReceiptVendorMovementSummary,
+  type ReceiptVendorReviewItem,
+  type ReceiptVendorReviewStatus,
   type ReceiptVendorMonthTransaction,
   type ReceiptVendorSummary,
   type ReceiptVendorWatchlistItem,
 } from '@/app/actions/receipts'
 import { Alert, Button, Card, Drawer, Spinner } from '@/ds'
 import {
-  ChevronDownIcon,
-  ChevronUpDownIcon,
-  MagnifyingGlassIcon,
+  ArrowTrendingDownIcon,
+  ArrowTrendingUpIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
   SparklesIcon,
   StarIcon,
 } from '@heroicons/react/20/solid'
 
 const MONTH_WINDOW = 12
 const DEFAULT_MOVEMENT_RANGE: ReceiptVendorMovementRange = '36m'
-const DEFAULT_MOVEMENT_COMPARISON: ReceiptVendorMovementComparison = 'yoy'
+const DEFAULT_MOVEMENT_COMPARISON: ReceiptVendorMovementComparison = 'rolling_3m'
 
 type MovementState = {
   movements: ReceiptVendorMovementSummary[]
   signals: ReceiptVendorMovementSignal[]
   error?: string
 }
-
-type MovementSortKey = 'vendor' | 'latestMonth' | 'spend' | 'baseline' | 'delta' | 'change' | 'transactions' | 'signal'
-
-type MovementSortDirection = 'asc' | 'desc'
 
 type DetailAiState = {
   review?: ReceiptVendorAiReview
@@ -56,12 +55,6 @@ function formatCurrency(value: number | null | undefined) {
 function formatMonth(isoDate: string) {
   const date = new Date(isoDate)
   return date.toLocaleDateString('en-GB', { month: 'short', year: 'numeric', timeZone: 'UTC' })
-}
-
-function formatChange(value: number) {
-  if (!Number.isFinite(value) || value === 0) return '0%'
-  const prefix = value > 0 ? '+' : ''
-  return `${prefix}${value.toFixed(1)}%`
 }
 
 function formatSignedCurrency(value: number | null | undefined) {
@@ -111,13 +104,18 @@ const statusTone: Record<ReceiptVendorMonthTransaction['status'], string> = {
 type VendorSummaryGridProps = {
   vendors: ReceiptVendorSummary[]
   initialWatchlist: ReceiptVendorWatchlistItem[]
+  initialReviews?: ReceiptVendorReviewItem[]
 }
 
 function normalizeVendorKey(value: string): string {
   return value.trim().replace(/\s+/g, ' ').toLowerCase()
 }
 
-export default function VendorSummaryGrid({ vendors, initialWatchlist }: VendorSummaryGridProps) {
+function reviewKey(vendorLabel: string, comparison: ReceiptVendorMovementComparison, monthStart: string) {
+  return `${normalizeVendorKey(vendorLabel)}|${comparison}|${monthStart}`
+}
+
+export default function VendorSummaryGrid({ vendors, initialWatchlist, initialReviews = [] }: VendorSummaryGridProps) {
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [selectedVendor, setSelectedVendor] = useState<string | null>(null)
   const [detail, setDetail] = useState<ReceiptVendorDetail | null>(null)
@@ -131,14 +129,16 @@ export default function VendorSummaryGrid({ vendors, initialWatchlist }: VendorS
       return acc
     }, {})
   })
-  const [showWatchedOnly, setShowWatchedOnly] = useState(false)
   const [watchlistError, setWatchlistError] = useState<string | null>(null)
   const [updatingWatchVendor, setUpdatingWatchVendor] = useState<string | null>(null)
-
-  const watchedCount = Object.keys(watchedVendors).length
-  const displayedVendors = showWatchedOnly
-    ? vendors.filter((vendor) => Boolean(watchedVendors[normalizeVendorKey(vendor.vendorLabel)]))
-    : vendors
+  const [reviews, setReviews] = useState<Record<string, ReceiptVendorReviewStatus>>(() => {
+    return initialReviews.reduce<Record<string, ReceiptVendorReviewStatus>>((acc, item) => {
+      acc[reviewKey(item.vendorLabel, item.comparison, item.monthStart)] = item.status
+      return acc
+    }, {})
+  })
+  const [updatingReview, setUpdatingReview] = useState<string | null>(null)
+  const [reviewError, setReviewError] = useState<string | null>(null)
 
   if (!vendors.length) return null
 
@@ -222,6 +222,47 @@ export default function VendorSummaryGrid({ vendors, initialWatchlist }: VendorS
     }
   }
 
+  async function updateVendorReview(
+    movement: ReceiptVendorMovementSummary,
+    status: ReceiptVendorReviewStatus,
+  ) {
+    if (!movement.latestMonthStart) return
+    const key = reviewKey(movement.vendorLabel, movement.comparison, movement.latestMonthStart)
+    const previous = reviews[key]
+    setReviewError(null)
+    setUpdatingReview(key)
+    setReviews((current) => ({ ...current, [key]: status }))
+
+    try {
+      const result = await setReceiptVendorReviewStatus({
+        vendorLabel: movement.vendorLabel,
+        comparison: movement.comparison,
+        monthStart: movement.latestMonthStart,
+        status,
+      })
+      if (!result.success || result.error) {
+        setReviews((current) => {
+          const next = { ...current }
+          if (previous) next[key] = previous
+          else delete next[key]
+          return next
+        })
+        setReviewError(result.error ?? 'Unable to update review status.')
+      }
+    } catch (error) {
+      console.error('Failed to update vendor review status', error)
+      setReviews((current) => {
+        const next = { ...current }
+        if (previous) next[key] = previous
+        else delete next[key]
+        return next
+      })
+      setReviewError('Something went wrong updating the review status.')
+    } finally {
+      setUpdatingReview(null)
+    }
+  }
+
   const activeVendorLabel = detail?.vendorLabel ?? selectedVendor
   const activeVendorWatched = activeVendorLabel
     ? Boolean(watchedVendors[normalizeVendorKey(activeVendorLabel)])
@@ -233,37 +274,16 @@ export default function VendorSummaryGrid({ vendors, initialWatchlist }: VendorS
   return (
     <>
       <div className="space-y-4">
-        <VendorMovementPanel onViewDetails={openVendorDetail} />
-
-        <WatchedVendorToolbar
-          watchedCount={watchedCount}
-          showWatchedOnly={showWatchedOnly}
-          error={watchlistError}
-          onShowAll={() => setShowWatchedOnly(false)}
-          onShowWatched={() => setShowWatchedOnly(true)}
+        <VendorMovementPanel
+          watchedVendors={watchedVendors}
+          reviews={reviews}
+          updatingWatchVendor={updatingWatchVendor}
+          updatingReview={updatingReview}
+          error={watchlistError ?? reviewError}
+          onViewDetails={openVendorDetail}
+          onToggleWatched={toggleVendorWatched}
+          onUpdateReview={updateVendorReview}
         />
-
-        {displayedVendors.length > 0 ? (
-          <div className="grid gap-4 xl:grid-cols-2">
-            {displayedVendors.map((vendor) => {
-              const watched = Boolean(watchedVendors[normalizeVendorKey(vendor.vendorLabel)])
-              return (
-                <VendorCard
-                  key={vendor.vendorLabel}
-                  vendor={vendor}
-                  watched={watched}
-                  watchLoading={updatingWatchVendor === vendor.vendorLabel}
-                  onViewDetails={() => openVendorDetail(vendor.vendorLabel)}
-                  onToggleWatched={() => toggleVendorWatched(vendor.vendorLabel, !watched)}
-                />
-              )
-            })}
-          </div>
-        ) : (
-          <Card>
-            <p className="text-sm text-gray-500">No watched vendors yet.</p>
-          </Card>
-        )}
       </div>
 
       <VendorDetailDrawer
@@ -312,123 +332,123 @@ function SegmentedControl({
   )
 }
 
-function defaultMovementSortDirection(key: MovementSortKey): MovementSortDirection {
-  return key === 'vendor' ? 'asc' : 'desc'
+type MovementView = 'attention' | 'increases' | 'decreases' | 'new' | 'watched' | 'all'
+
+const reviewStatusLabels: Record<ReceiptVendorReviewStatus, string> = {
+  needs_review: 'Needs review',
+  expected: 'Expected',
+  action_required: 'Action required',
+  reviewed: 'Reviewed',
 }
 
-function compareNullableNumber(
-  left: number | null | undefined,
-  right: number | null | undefined,
-  direction: MovementSortDirection,
-): number {
-  const leftMissing = left === null || left === undefined || !Number.isFinite(left)
-  const rightMissing = right === null || right === undefined || !Number.isFinite(right)
-  if (leftMissing && rightMissing) return 0
-  if (leftMissing) return 1
-  if (rightMissing) return -1
-  return direction === 'asc' ? left - right : right - left
+function movementReviewStatus(
+  movement: ReceiptVendorMovementSummary,
+  reviews: Record<string, ReceiptVendorReviewStatus>,
+): ReceiptVendorReviewStatus {
+  if (!movement.latestMonthStart) return 'reviewed'
+  return reviews[reviewKey(movement.vendorLabel, movement.comparison, movement.latestMonthStart)]
+    ?? (movement.signal ? 'needs_review' : 'reviewed')
 }
 
-function compareNullableText(
-  left: string | null | undefined,
-  right: string | null | undefined,
-  direction: MovementSortDirection,
-): number {
-  const leftMissing = !left
-  const rightMissing = !right
-  if (leftMissing && rightMissing) return 0
-  if (leftMissing) return 1
-  if (rightMissing) return -1
-  const result = left.localeCompare(right)
-  return direction === 'asc' ? result : -result
-}
-
-function compareMovementSignals(
-  left: ReceiptVendorMovementSummary,
-  right: ReceiptVendorMovementSummary,
-  direction: MovementSortDirection,
-): number {
-  const severityRank = (movement: ReceiptVendorMovementSummary) => {
-    if (movement.signal?.severity === 'high') return 2
-    if (movement.signal?.severity === 'medium') return 1
-    return null
-  }
-  const severityCompare = compareNullableNumber(severityRank(left), severityRank(right), direction)
-  if (severityCompare !== 0) return severityCompare
-
-  const deltaCompare = compareNullableNumber(left.signal?.absoluteDelta, right.signal?.absoluteDelta, direction)
-  if (deltaCompare !== 0) return deltaCompare
-
-  return compareNullableText(left.signal?.direction, right.signal?.direction, direction)
-}
-
-function compareVendorMovements(
-  left: ReceiptVendorMovementSummary,
-  right: ReceiptVendorMovementSummary,
-  key: MovementSortKey,
-  direction: MovementSortDirection,
-): number {
-  if (key === 'vendor') return compareNullableText(left.vendorLabel, right.vendorLabel, direction)
-  if (key === 'latestMonth') return compareNullableText(left.latestMonthStart, right.latestMonthStart, direction)
-  if (key === 'spend') return compareNullableNumber(left.latestOutgoing, right.latestOutgoing, direction)
-  if (key === 'baseline') return compareNullableNumber(left.baselineOutgoing, right.baselineOutgoing, direction)
-  if (key === 'delta') return compareNullableNumber(left.delta, right.delta, direction)
-  if (key === 'change') return compareNullableNumber(left.percentageChange, right.percentageChange, direction)
-  if (key === 'transactions') return compareNullableNumber(left.latestTransactionCount, right.latestTransactionCount, direction)
-  return compareMovementSignals(left, right, direction)
-}
-
-function SortableHeader({
+function MovementMetric({
   label,
-  sortKey,
-  activeKey,
-  direction,
-  align = 'left',
-  onSort,
+  value,
+  detail,
+  tone = 'neutral',
 }: {
   label: string
-  sortKey: MovementSortKey
-  activeKey: MovementSortKey
-  direction: MovementSortDirection
-  align?: 'left' | 'right'
-  onSort: (key: MovementSortKey) => void
+  value: string
+  detail: string
+  tone?: 'neutral' | 'up' | 'down' | 'attention'
 }) {
-  const isActive = activeKey === sortKey
+  const toneClass = tone === 'up'
+    ? 'border-rose-100 bg-rose-50 text-rose-800'
+    : tone === 'down'
+      ? 'border-emerald-100 bg-emerald-50 text-emerald-800'
+      : tone === 'attention'
+        ? 'border-amber-100 bg-amber-50 text-amber-800'
+        : 'border-gray-200 bg-white text-gray-900'
 
   return (
-    <th scope="col" className={`px-2 py-2 ${align === 'right' ? 'text-right' : 'text-left'}`} aria-sort={isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'}>
-      <button
-        type="button"
-        className={`inline-flex items-center gap-1 font-semibold uppercase tracking-wide hover:text-gray-800 ${align === 'right' ? 'justify-end' : 'justify-start'}`}
-        onClick={() => onSort(sortKey)}
-      >
-        <span>{label}</span>
-        {isActive ? (
-          <ChevronDownIcon className={`h-3.5 w-3.5 transition-transform ${direction === 'asc' ? 'rotate-180' : ''}`} />
-        ) : (
-          <ChevronUpDownIcon className="h-3.5 w-3.5 text-gray-400" />
-        )}
-      </button>
-    </th>
+    <div className={`rounded-lg border p-4 ${toneClass}`}>
+      <p className="text-xs font-semibold uppercase tracking-wide opacity-70">{label}</p>
+      <p className="mt-2 text-2xl font-semibold tabular-nums">{value}</p>
+      <p className="mt-1 text-xs opacity-75">{detail}</p>
+    </div>
   )
 }
 
-function VendorMovementPanel({ onViewDetails }: { onViewDetails: (vendorLabel: string) => void }) {
-  const [range, setRange] = useState<ReceiptVendorMovementRange>(DEFAULT_MOVEMENT_RANGE)
+function DivergingMovementChart({ movements }: { movements: ReceiptVendorMovementSummary[] }) {
+  const rows = [...movements]
+    .filter((movement) => movement.delta !== null && movement.delta !== 0)
+    .sort((left, right) => Math.abs(right.delta ?? 0) - Math.abs(left.delta ?? 0))
+    .slice(0, 10)
+  const maxDelta = rows.reduce((max, movement) => Math.max(max, Math.abs(movement.delta ?? 0)), 0)
+
+  if (!rows.length) {
+    return <p className="text-sm text-gray-500">No movement is available for this comparison.</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-[minmax(7rem,11rem)_1fr_5rem] items-center gap-3 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+        <span>Vendor</span>
+        <div className="grid grid-cols-2 text-center"><span>Down</span><span>Up</span></div>
+        <span className="text-right">Movement</span>
+      </div>
+      {rows.map((movement) => {
+        const delta = movement.delta ?? 0
+        const width = maxDelta > 0 ? Math.max((Math.abs(delta) / maxDelta) * 50, 2) : 0
+        return (
+          <div key={movement.vendorLabel} className="grid grid-cols-[minmax(7rem,11rem)_1fr_5rem] items-center gap-3">
+            <span className="truncate text-xs font-medium text-gray-700" title={movement.vendorLabel}>{movement.vendorLabel}</span>
+            <div className="relative h-5 rounded bg-gray-50">
+              <div className="absolute inset-y-0 left-1/2 w-px bg-gray-300" />
+              <div
+                className={`absolute inset-y-1 rounded ${delta > 0 ? 'left-1/2 bg-rose-500' : 'right-1/2 bg-emerald-500'}`}
+                style={{ width: `${width}%` }}
+              />
+            </div>
+            <span className={`text-right text-xs font-semibold tabular-nums ${delta > 0 ? 'text-rose-700' : 'text-emerald-700'}`}>
+              {formatSignedCurrency(delta)}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function VendorMovementPanel({
+  watchedVendors,
+  reviews,
+  updatingWatchVendor,
+  updatingReview,
+  error,
+  onViewDetails,
+  onToggleWatched,
+  onUpdateReview,
+}: {
+  watchedVendors: Record<string, string>
+  reviews: Record<string, ReceiptVendorReviewStatus>
+  updatingWatchVendor: string | null
+  updatingReview: string | null
+  error: string | null
+  onViewDetails: (vendorLabel: string) => void
+  onToggleWatched: (vendorLabel: string, watched: boolean) => void
+  onUpdateReview: (movement: ReceiptVendorMovementSummary, status: ReceiptVendorReviewStatus) => void
+}) {
+  const range: ReceiptVendorMovementRange = DEFAULT_MOVEMENT_RANGE
   const [comparison, setComparison] = useState<ReceiptVendorMovementComparison>(DEFAULT_MOVEMENT_COMPARISON)
-  const [watchedOnly, setWatchedOnly] = useState(false)
+  const [view, setView] = useState<MovementView>('attention')
   const [state, setState] = useState<MovementState>({ movements: [], signals: [] })
   const [isLoading, setIsLoading] = useState(true)
-  const [sort, setSort] = useState<{ key: MovementSortKey; direction: MovementSortDirection }>({
-    key: 'signal',
-    direction: 'desc',
-  })
 
   useEffect(() => {
     let cancelled = false
     setIsLoading(true)
 
-    getReceiptVendorMovements({ range, comparison, watchedOnly })
+    getReceiptVendorMovements({ range, comparison })
       .then((result) => {
         if (cancelled) return
         if (!result.success || result.error) {
@@ -453,68 +473,79 @@ function VendorMovementPanel({ onViewDetails }: { onViewDetails: (vendorLabel: s
     return () => {
       cancelled = true
     }
-  }, [range, comparison, watchedOnly])
+  }, [range, comparison])
 
-  const baselineLabel = comparison === 'mom' ? 'Prior month' : 'Prior year'
-  const sortedMovements = useMemo(() => {
-    return [...state.movements].sort((left, right) => {
-      const result = compareVendorMovements(left, right, sort.key, sort.direction)
-      return result === 0
-        ? left.vendorLabel.localeCompare(right.vendorLabel)
-        : result
-    })
-  }, [sort.direction, sort.key, state.movements])
+  const baselineLabel = comparison === 'mom' ? 'Prior month' : comparison === 'yoy' ? 'Prior year' : 'Prior 3m avg'
+  const currentLabel = comparison === 'rolling_3m' ? 'Latest 3m avg' : 'Spend'
+  const latestMonth = state.movements.find((movement) => movement.latestMonthStart)?.latestMonthStart ?? null
+  const periodLabel = latestMonth
+    ? comparison === 'rolling_3m'
+      ? `Three-month average ending ${formatMonth(latestMonth)}`
+      : comparison === 'mom'
+        ? `${formatMonth(latestMonth)} against the prior month`
+        : `${formatMonth(latestMonth)} against the same month last year`
+    : 'Latest completed period'
 
-  function handleSort(key: MovementSortKey) {
-    setSort((current) => {
-      if (current.key === key) {
-        return {
-          key,
-          direction: current.direction === 'asc' ? 'desc' : 'asc',
-        }
-      }
-      return {
-        key,
-        direction: defaultMovementSortDirection(key),
-      }
-    })
-  }
+  const summary = useMemo(() => {
+    const comparable = state.movements.filter((movement) => movement.delta !== null)
+    const increases = comparable.filter((movement) => (movement.delta ?? 0) > 0)
+    const decreases = comparable.filter((movement) => (movement.delta ?? 0) < 0)
+    const increaseTotal = increases.reduce((sum, movement) => sum + (movement.delta ?? 0), 0)
+    const decreaseTotal = decreases.reduce((sum, movement) => sum + Math.abs(movement.delta ?? 0), 0)
+    const attentionCount = state.movements.filter((movement) => {
+      const status = movementReviewStatus(movement, reviews)
+      return status === 'action_required' || (Boolean(movement.signal) && status === 'needs_review')
+    }).length
+    return {
+      currentSpend: comparable.reduce((sum, movement) => sum + movement.latestOutgoing, 0),
+      increaseTotal,
+      decreaseTotal,
+      netChange: increaseTotal - decreaseTotal,
+      attentionCount,
+    }
+  }, [reviews, state.movements])
+
+  const displayedMovements = useMemo(() => {
+    return state.movements
+      .filter((movement) => {
+        const delta = movement.delta ?? 0
+        const status = movementReviewStatus(movement, reviews)
+        if (view === 'attention') return status === 'action_required' || (Boolean(movement.signal) && status === 'needs_review')
+        if (view === 'increases') return delta > 0
+        if (view === 'decreases') return delta < 0
+        if (view === 'new') return movement.signal?.direction === 'new' || movement.signal?.direction === 'resumed'
+        if (view === 'watched') return Boolean(watchedVendors[normalizeVendorKey(movement.vendorLabel)])
+        return true
+      })
+      .sort((left, right) => Math.abs(right.delta ?? 0) - Math.abs(left.delta ?? 0))
+  }, [reviews, state.movements, view, watchedVendors])
+
+  const views: Array<{ value: MovementView; label: string }> = [
+    { value: 'attention', label: `Needs attention (${summary.attentionCount})` },
+    { value: 'increases', label: 'Biggest increases' },
+    { value: 'decreases', label: 'Biggest decreases' },
+    { value: 'new', label: 'New / resumed' },
+    { value: 'watched', label: `Watched (${Object.keys(watchedVendors).length})` },
+    { value: 'all', label: 'All vendors' },
+  ]
 
   return (
-    <Card>
-      <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="space-y-4">
+      <Card>
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0">
-          <h3 className="text-base font-semibold text-gray-900">Vendor movement</h3>
-          <p className="mt-1 text-xs text-gray-500">
-            {state.movements.length.toLocaleString('en-GB')} vendors ranked by {comparison === 'mom' ? 'month-on-month' : 'year-on-year'} change
-          </p>
+          <h3 className="text-lg font-semibold text-gray-900">Spend movement overview</h3>
+          <p className="mt-1 text-sm text-gray-500">{periodLabel}. Uses complete months only.</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <SegmentedControl
-            value={range}
-            options={[
-              { value: '12m', label: '12m' },
-              { value: '24m', label: '24m' },
-              { value: '36m', label: '36m' },
-              { value: 'all', label: 'All' },
-            ]}
-            onChange={(value) => setRange(value as ReceiptVendorMovementRange)}
-          />
-          <SegmentedControl
             value={comparison}
             options={[
-              { value: 'yoy', label: 'YoY' },
-              { value: 'mom', label: 'MoM' },
+              { value: 'rolling_3m', label: '3m trend' },
+              { value: 'yoy', label: 'Year on year' },
+              { value: 'mom', label: 'Month on month' },
             ]}
             onChange={(value) => setComparison(value as ReceiptVendorMovementComparison)}
-          />
-          <SegmentedControl
-            value={watchedOnly ? 'watched' : 'all'}
-            options={[
-              { value: 'all', label: 'All' },
-              { value: 'watched', label: 'Watched' },
-            ]}
-            onChange={(value) => setWatchedOnly(value === 'watched')}
           />
         </div>
       </div>
@@ -529,280 +560,161 @@ function VendorMovementPanel({ onViewDetails }: { onViewDetails: (vendorLabel: s
           {state.error}
         </Alert>
       ) : state.movements.length ? (
-        <div className="mt-4 overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200 text-xs">
-            <thead className="bg-gray-100 text-left font-semibold uppercase tracking-wide text-gray-500">
-              <tr>
-                <SortableHeader label="Vendor" sortKey="vendor" activeKey={sort.key} direction={sort.direction} onSort={handleSort} />
-                <SortableHeader label="Latest month" sortKey="latestMonth" activeKey={sort.key} direction={sort.direction} onSort={handleSort} />
-                <SortableHeader label="Spend" sortKey="spend" activeKey={sort.key} direction={sort.direction} align="right" onSort={handleSort} />
-                <SortableHeader label={baselineLabel} sortKey="baseline" activeKey={sort.key} direction={sort.direction} align="right" onSort={handleSort} />
-                <SortableHeader label="Delta" sortKey="delta" activeKey={sort.key} direction={sort.direction} align="right" onSort={handleSort} />
-                <SortableHeader label="Change" sortKey="change" activeKey={sort.key} direction={sort.direction} align="right" onSort={handleSort} />
-                <SortableHeader label="Txns" sortKey="transactions" activeKey={sort.key} direction={sort.direction} align="right" onSort={handleSort} />
-                <SortableHeader label="Signal" sortKey="signal" activeKey={sort.key} direction={sort.direction} onSort={handleSort} />
-                <th scope="col" className="px-2 py-2 text-right"> </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100 text-gray-700">
-              {sortedMovements.map((movement) => (
-                <tr key={`${movement.vendorLabel}-${movement.range}-${movement.comparison}`}>
-                  <td className="max-w-[14rem] truncate px-2 py-2 font-medium text-gray-900" title={movement.vendorLabel}>
-                    {movement.vendorLabel}
-                  </td>
-                  <td className="whitespace-nowrap px-2 py-2 text-gray-600">
-                    {movement.latestMonthStart ? formatMonth(movement.latestMonthStart) : '-'}
-                  </td>
-                  <td className="px-2 py-2 text-right tabular-nums text-gray-900">{formatCurrency(movement.latestOutgoing)}</td>
-                  <td className="px-2 py-2 text-right tabular-nums text-gray-700">
-                    {movement.baselineOutgoing === null ? `No ${comparison === 'mom' ? 'prior month' : 'prior year'}` : formatCurrency(movement.baselineOutgoing)}
-                  </td>
-                  <td className="px-2 py-2 text-right tabular-nums text-gray-900">{formatSignedCurrency(movement.delta)}</td>
-                  <td className="px-2 py-2 text-right tabular-nums text-gray-900">{formatSignedPercent(movement.percentageChange)}</td>
-                  <td className="px-2 py-2 text-right tabular-nums text-gray-700">{movement.latestTransactionCount.toLocaleString('en-GB')}</td>
-                  <td className="px-2 py-2">
-                    {movement.signal ? (
-                      <span className={`inline-flex items-center rounded-full border px-2 py-0.5 font-medium capitalize ${signalTone(movement.signal)}`}>
-                        {movement.signal.direction}
-                      </span>
-                    ) : (
-                      <span className="text-gray-400">-</span>
-                    )}
-                  </td>
-                  <td className="px-2 py-2 text-right">
-                    <button
-                      type="button"
-                      className="font-semibold text-blue-700 hover:text-blue-900"
-                      onClick={() => onViewDetails(movement.vendorLabel)}
-                    >
-                      View details
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+          <MovementMetric label={comparison === 'rolling_3m' ? 'Average monthly spend' : 'Total spend'} value={formatCurrency(summary.currentSpend)} detail={periodLabel} />
+          <MovementMetric label="Spend increases" value={`+${formatCurrency(summary.increaseTotal)}`} detail="Across vendors that increased" tone="up" />
+          <MovementMetric label="Spend decreases" value={`-${formatCurrency(summary.decreaseTotal)}`} detail="Across vendors that decreased" tone="down" />
+          <MovementMetric label="Net movement" value={formatSignedCurrency(summary.netChange)} detail="Increases less decreases" tone={summary.netChange > 0 ? 'up' : summary.netChange < 0 ? 'down' : 'neutral'} />
+          <MovementMetric label="Needs attention" value={summary.attentionCount.toLocaleString('en-GB')} detail="Material movements not closed" tone="attention" />
         </div>
       ) : (
         <p className="mt-4 text-sm text-gray-500">No vendor movement found for this view.</p>
       )}
-    </Card>
-  )
-}
+      </Card>
 
-function WatchedVendorToolbar({
-  watchedCount,
-  showWatchedOnly,
-  error,
-  onShowAll,
-  onShowWatched,
-}: {
-  watchedCount: number
-  showWatchedOnly: boolean
-  error: string | null
-  onShowAll: () => void
-  onShowWatched: () => void
-}) {
-  return (
-    <Card>
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <StarIcon className="h-5 w-5 text-amber-500" />
-            <h3 className="text-base font-semibold text-gray-900">Watched vendors</h3>
-          </div>
-          <p className="mt-1 text-xs text-gray-500">{watchedCount} watched</p>
-        </div>
-        <div className="inline-flex rounded-md border border-gray-200 bg-white p-1">
-          <button
-            type="button"
-            onClick={onShowAll}
-            className={`rounded px-3 py-1.5 text-xs font-semibold transition ${!showWatchedOnly ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={onShowWatched}
-            className={`rounded px-3 py-1.5 text-xs font-semibold transition ${showWatchedOnly ? 'bg-gray-900 text-white' : 'text-gray-600 hover:bg-gray-100'}`}
-          >
-            Watched
-          </button>
-        </div>
-      </div>
-      {error && (
-        <Alert tone="danger" title="Watchlist unavailable" className="mt-4">
-          {error}
-        </Alert>
-      )}
-    </Card>
-  )
-}
+      {!isLoading && !state.error && state.movements.length > 0 && (
+        <>
+          <Card>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h3 className="text-base font-semibold text-gray-900">Biggest movements</h3>
+                <p className="mt-1 text-xs text-gray-500">Top vendors ranked by absolute pound movement.</p>
+              </div>
+              <div className="hidden items-center gap-4 text-xs sm:flex">
+                <span className="inline-flex items-center gap-1 text-emerald-700"><ArrowTrendingDownIcon className="h-4 w-4" /> Spend down</span>
+                <span className="inline-flex items-center gap-1 text-rose-700"><ArrowTrendingUpIcon className="h-4 w-4" /> Spend up</span>
+              </div>
+            </div>
+            <div className="mt-5"><DivergingMovementChart movements={state.movements} /></div>
+          </Card>
 
-function VendorCard({
-  vendor,
-  watched,
-  watchLoading,
-  onViewDetails,
-  onToggleWatched,
-}: {
-  vendor: ReceiptVendorSummary
-  watched: boolean
-  watchLoading: boolean
-  onViewDetails: () => void
-  onToggleWatched: () => void
-}) {
-  const totalTransactions = useMemo(
-    () => vendor.months.reduce((sum, month) => sum + month.transactionCount, 0),
-    [vendor.months],
-  )
-  const maxMonthlySpend = useMemo(
-    () => vendor.months.reduce((max, month) => Math.max(max, month.totalOutgoing), 0),
-    [vendor.months],
-  )
-  const recentMonths = useMemo(() => vendor.months.slice(-6), [vendor.months])
+          <Card>
+            <div className="flex gap-2 overflow-x-auto pb-2">
+              {views.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setView(option.value)}
+                  className={`whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition ${view === option.value ? 'bg-gray-900 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
 
-  const changeTone = vendor.changePercentage > 5
-    ? 'bg-rose-50 text-rose-700'
-    : vendor.changePercentage < -5
-      ? 'bg-emerald-50 text-emerald-700'
-      : 'bg-gray-100 text-gray-600'
+            {error && <Alert tone="danger" title="Unable to save changes" className="mt-3">{error}</Alert>}
 
-  const [expandedMonth, setExpandedMonth] = useState<string | null>(null)
-  const [loadingMonth, setLoadingMonth] = useState<string | null>(null)
-  const [monthTransactions, setMonthTransactions] = useState<Record<string, ReceiptVendorMonthTransaction[]>>({})
-  const [monthErrors, setMonthErrors] = useState<Record<string, string | undefined>>({})
-  const [isPending, startTransition] = useTransition()
-
-  function toggleMonth(monthStart: string) {
-    if (expandedMonth === monthStart) {
-      setExpandedMonth(null)
-      return
-    }
-
-    setExpandedMonth(monthStart)
-
-    if (monthTransactions[monthStart] || loadingMonth === monthStart) {
-      return
-    }
-
-    setLoadingMonth(monthStart)
-    setMonthErrors((prev) => ({ ...prev, [monthStart]: undefined }))
-
-    startTransition(async () => {
-      try {
-        const result = await getReceiptVendorMonthTransactions({
-          vendorLabel: vendor.vendorLabel,
-          monthStart,
-        })
-        if (result.error) {
-          setMonthErrors((prev) => ({ ...prev, [monthStart]: result.error }))
-        } else {
-          setMonthTransactions((prev) => ({ ...prev, [monthStart]: result.transactions }))
-          setMonthErrors((prev) => ({ ...prev, [monthStart]: undefined }))
-        }
-      } catch (error) {
-        console.error('Failed to load vendor month details', error)
-        setMonthErrors((prev) => ({ ...prev, [monthStart]: 'Something went wrong loading transactions.' }))
-      } finally {
-        setLoadingMonth(null)
-      }
-    })
-  }
-
-  return (
-    <Card>
-      <div className="space-y-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
-            <h3 className="truncate text-lg font-semibold text-gray-900">{vendor.vendorLabel}</h3>
-            <p className="text-xs text-gray-500">{totalTransactions} transactions across {vendor.months.length} months</p>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${changeTone}`}>
-              {formatChange(vendor.changePercentage)} vs prior 3 months
-            </span>
-            <Button
-              type="button"
-              size="sm"
-              variant={watched ? 'primary' : 'secondary'}
-              icon={<StarIcon className="h-4 w-4" />}
-              loading={watchLoading}
-              onClick={onToggleWatched}
-            >
-              {watched ? 'Watching' : 'Watch'}
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              icon={<MagnifyingGlassIcon className="h-4 w-4" />}
-              onClick={onViewDetails}
-            >
-              View details
-            </Button>
-          </div>
-        </div>
-
-        <div className="grid gap-3 sm:grid-cols-3">
-          <Metric label="Total spend" value={formatCurrency(vendor.totalOutgoing)} tone="spend" />
-          <Metric label="Avg (last 3m)" value={formatCurrency(vendor.recentAverageOutgoing)} tone="neutral" />
-          <Metric label="Prev avg" value={formatCurrency(vendor.previousAverageOutgoing)} tone="neutral" subtle />
-        </div>
-
-        <div className="space-y-2">
-          <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500">Recent six months</h4>
-          <div className="space-y-2">
-            {recentMonths.map((month) => {
-              const width = maxMonthlySpend
-                ? Math.max(Math.min((month.totalOutgoing / maxMonthlySpend) * 100, 100), 4)
-                : 0
-              const isActive = expandedMonth === month.monthStart
-              const hasError = monthErrors[month.monthStart]
-              const transactions = monthTransactions[month.monthStart] ?? []
-
-              return (
-                <div key={month.monthStart}>
-                  <button
-                    type="button"
-                    onClick={() => toggleMonth(month.monthStart)}
-                    className={`flex w-full items-center gap-3 rounded-md border border-transparent px-2 py-2 text-left text-xs text-gray-600 transition hover:border-emerald-200 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-300 ${isActive ? 'border-emerald-300 bg-emerald-50' : ''}`}
-                    aria-expanded={isActive}
-                  >
-                    <ChevronDownIcon
-                      className={`h-4 w-4 shrink-0 transition-transform ${isActive ? 'rotate-180 text-emerald-600' : 'text-gray-400'}`}
-                    />
-                    <span className="w-20 text-gray-500">{formatMonth(month.monthStart)}</span>
-                    <div className="relative h-2 flex-1 rounded bg-gray-100" title={formatCurrency(month.totalOutgoing)}>
-                      <div
-                        className="absolute left-0 top-0 h-2 rounded bg-emerald-500"
-                        style={{ width: `${width}%` }}
-                      />
-                    </div>
-                    <span className="w-20 text-right text-gray-700 tabular-nums">{formatCurrency(month.totalOutgoing)}</span>
-                  </button>
-
-                  {isActive && (
-                    <div className="mt-2 rounded-md border border-gray-100 bg-gray-50 p-3">
-                      {loadingMonth === month.monthStart || isPending ? (
-                        <div className="flex items-center gap-2 text-sm text-gray-500">
-                          <Spinner className="h-4 w-4" />
-                          Loading transactions...
-                        </div>
-                      ) : hasError ? (
-                        <p className="text-sm text-rose-600">{hasError}</p>
-                      ) : (
-                        <TransactionTable transactions={transactions} />
-                      )}
-                    </div>
-                  )}
+            {displayedMovements.length ? (
+              <>
+                <div className="mt-4 hidden overflow-x-auto md:block">
+                  <table className="min-w-full divide-y divide-gray-200 text-xs">
+                    <thead className="bg-gray-100 text-left font-semibold uppercase tracking-wide text-gray-500">
+                      <tr>
+                        <th scope="col" className="px-3 py-2">Vendor</th>
+                        <th scope="col" className="px-3 py-2 text-right">{currentLabel}</th>
+                        <th scope="col" className="px-3 py-2 text-right">{baselineLabel}</th>
+                        <th scope="col" className="px-3 py-2 text-right">Movement</th>
+                        <th scope="col" className="px-3 py-2">Review status</th>
+                        <th scope="col" className="px-3 py-2 text-right">Actions</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-100 text-gray-700">
+                      {displayedMovements.map((movement) => {
+                        const watched = Boolean(watchedVendors[normalizeVendorKey(movement.vendorLabel)])
+                        const status = movementReviewStatus(movement, reviews)
+                        const key = movement.latestMonthStart ? reviewKey(movement.vendorLabel, movement.comparison, movement.latestMonthStart) : ''
+                        return (
+                          <tr key={`${movement.vendorLabel}-${movement.comparison}`}>
+                            <td className="max-w-[15rem] px-3 py-3">
+                              <div className="truncate font-semibold text-gray-900" title={movement.vendorLabel}>{movement.vendorLabel}</div>
+                              <div className="mt-1 flex items-center gap-2">
+                                {movement.signal && <span className={`inline-flex rounded-full border px-2 py-0.5 font-medium capitalize ${signalTone(movement.signal)}`}>{movement.signal.direction}</span>}
+                                <span className="text-gray-400">{movement.latestTransactionCount.toLocaleString('en-GB')} transactions</span>
+                              </div>
+                            </td>
+                            <td className="px-3 py-3 text-right font-medium tabular-nums text-gray-900">{formatCurrency(movement.latestOutgoing)}</td>
+                            <td className="px-3 py-3 text-right tabular-nums text-gray-600">{movement.baselineOutgoing === null ? 'No baseline' : formatCurrency(movement.baselineOutgoing)}</td>
+                            <td className={`px-3 py-3 text-right font-semibold tabular-nums ${(movement.delta ?? 0) > 0 ? 'text-rose-700' : (movement.delta ?? 0) < 0 ? 'text-emerald-700' : 'text-gray-600'}`}>
+                              <div>{formatSignedCurrency(movement.delta)}</div>
+                              <div className="mt-1 text-[11px] font-medium opacity-75">{movement.baselineOutgoing === 0 && movement.latestOutgoing > 0 ? 'New' : formatSignedPercent(movement.percentageChange)}</div>
+                            </td>
+                            <td className="px-3 py-3">
+                              <select
+                                value={status}
+                                disabled={!movement.latestMonthStart || updatingReview === key}
+                                onChange={(event) => onUpdateReview(movement, event.target.value as ReceiptVendorReviewStatus)}
+                                className="rounded-md border border-gray-200 bg-white px-2 py-1.5 text-xs font-medium text-gray-700"
+                                aria-label={`Review status for ${movement.vendorLabel}`}
+                              >
+                                {Object.entries(reviewStatusLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                              </select>
+                            </td>
+                            <td className="px-3 py-3 text-right">
+                              <div className="inline-flex items-center gap-2">
+                                <button
+                                  type="button"
+                                  disabled={updatingWatchVendor === movement.vendorLabel}
+                                  onClick={() => onToggleWatched(movement.vendorLabel, !watched)}
+                                  className={`rounded p-1.5 ${watched ? 'bg-amber-100 text-amber-700' : 'text-gray-400 hover:bg-gray-100 hover:text-amber-600'}`}
+                                  aria-label={`${watched ? 'Stop watching' : 'Watch'} ${movement.vendorLabel}`}
+                                >
+                                  <StarIcon className="h-4 w-4" />
+                                </button>
+                                <button type="button" className="font-semibold text-blue-700 hover:text-blue-900" onClick={() => onViewDetails(movement.vendorLabel)}>View details</button>
+                              </div>
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
                 </div>
-              )
-            })}
-          </div>
-        </div>
-      </div>
-    </Card>
+
+                <div className="mt-4 space-y-3 md:hidden">
+                  {displayedMovements.map((movement) => {
+                    const watched = Boolean(watchedVendors[normalizeVendorKey(movement.vendorLabel)])
+                    const status = movementReviewStatus(movement, reviews)
+                    const key = movement.latestMonthStart ? reviewKey(movement.vendorLabel, movement.comparison, movement.latestMonthStart) : ''
+                    return (
+                      <div key={`${movement.vendorLabel}-${movement.comparison}-mobile`} className="rounded-lg border border-gray-200 p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate font-semibold text-gray-900">{movement.vendorLabel}</p>
+                            <p className="mt-1 text-xs text-gray-500">{formatCurrency(movement.latestOutgoing)} vs {movement.baselineOutgoing === null ? 'no baseline' : formatCurrency(movement.baselineOutgoing)}</p>
+                          </div>
+                          <div className={`text-right font-semibold tabular-nums ${(movement.delta ?? 0) > 0 ? 'text-rose-700' : 'text-emerald-700'}`}>
+                            <p>{formatSignedCurrency(movement.delta)}</p>
+                            <p className="text-xs">{movement.baselineOutgoing === 0 && movement.latestOutgoing > 0 ? 'New' : formatSignedPercent(movement.percentageChange)}</p>
+                          </div>
+                        </div>
+                        <div className="mt-3 flex items-center gap-2">
+                          <select
+                            value={status}
+                            disabled={!movement.latestMonthStart || updatingReview === key}
+                            onChange={(event) => onUpdateReview(movement, event.target.value as ReceiptVendorReviewStatus)}
+                            className="min-w-0 flex-1 rounded-md border border-gray-200 bg-white px-2 py-2 text-xs font-medium text-gray-700"
+                            aria-label={`Review status for ${movement.vendorLabel}`}
+                          >
+                            {Object.entries(reviewStatusLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                          </select>
+                          <button type="button" onClick={() => onToggleWatched(movement.vendorLabel, !watched)} className={`rounded-md p-2 ${watched ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-500'}`} aria-label={`${watched ? 'Stop watching' : 'Watch'} ${movement.vendorLabel}`}><StarIcon className="h-4 w-4" /></button>
+                          <button type="button" onClick={() => onViewDetails(movement.vendorLabel)} className="rounded-md bg-gray-900 px-3 py-2 text-xs font-semibold text-white">Details</button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </>
+            ) : (
+              <div className="mt-6 rounded-lg bg-gray-50 p-6 text-center">
+                {view === 'attention' ? <CheckCircleIcon className="mx-auto h-8 w-8 text-emerald-500" /> : <ExclamationTriangleIcon className="mx-auto h-8 w-8 text-gray-400" />}
+                <p className="mt-2 text-sm font-medium text-gray-700">No vendors in this view.</p>
+              </div>
+            )}
+          </Card>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/src/app/(authenticated)/receipts/vendors/page.tsx
+++ b/src/app/(authenticated)/receipts/vendors/page.tsx
@@ -1,4 +1,4 @@
-import { getReceiptVendorSummary, getReceiptVendorWatchlist } from '@/app/actions/receipts'
+import { getReceiptVendorReviews, getReceiptVendorSummary, getReceiptVendorWatchlist } from '@/app/actions/receipts'
 import { Card } from '@/ds'
 import VendorSummaryGrid from './_components/VendorSummaryGrid'
 import { redirect } from 'next/navigation'
@@ -13,9 +13,10 @@ export default async function ReceiptsVendorsPage() {
     redirect('/unauthorized')
   }
 
-  const [vendors, watchlist] = await Promise.all([
+  const [vendors, watchlist, reviews] = await Promise.all([
     getReceiptVendorSummary(12),
     getReceiptVendorWatchlist(),
+    getReceiptVendorReviews(),
   ])
 
   return (
@@ -29,7 +30,7 @@ export default async function ReceiptsVendorsPage() {
           <p className="text-sm text-gray-500">No vendor data available yet. Import statements to see trends.</p>
         </Card>
       ) : (
-        <VendorSummaryGrid vendors={vendors} initialWatchlist={watchlist} />
+        <VendorSummaryGrid vendors={vendors} initialWatchlist={watchlist} initialReviews={reviews} />
       )}
     </ReceiptsPageChrome>
   )

--- a/src/app/actions/receipts.ts
+++ b/src/app/actions/receipts.ts
@@ -39,6 +39,8 @@ export type {
   
   ReceiptVendorDetail,
   ReceiptVendorWatchlistItem,
+  ReceiptVendorReviewItem,
+  ReceiptVendorReviewStatus,
   
   
   ReceiptBulkReviewData,
@@ -64,6 +66,7 @@ import {
   queryReceiptVendorCostReview,
   queryReceiptVendorAiSummary,
   queryReceiptVendorWatchlist,
+  queryReceiptVendorReviews,
   queryReceiptMissingExpenseSummary,
   queryAIUsageBreakdown,
   queryPreviewReceiptRule,
@@ -83,6 +86,7 @@ import {
   performApplyReceiptGroupClassification,
   performRequeueUnclassifiedTransactions,
   performSetReceiptVendorWatched,
+  performSetReceiptVendorReviewStatus,
   performApproveReceiptRuleSuggestion,
   performApproveReceiptRuleSuggestions,
   performDeclineReceiptRuleSuggestion,
@@ -115,6 +119,8 @@ import type {
   ReceiptVendorMovementSignal,
   ReceiptVendorMovementSummary,
   ReceiptVendorWatchlistItem,
+  ReceiptVendorReviewItem,
+  ReceiptVendorReviewStatus,
   ReceiptMissingExpenseSummaryItem,
   AIUsageBreakdown,
   RulePreviewResult,
@@ -377,6 +383,36 @@ export async function setReceiptVendorWatched(input: {
 
   const { user_id } = await requireCurrentUser()
   const result = await performSetReceiptVendorWatched(user_id, input)
+
+  if (result.success) {
+    revalidatePath('/receipts/vendors')
+  }
+
+  return result
+}
+
+export async function getReceiptVendorReviews(): Promise<ReceiptVendorReviewItem[]> {
+  const canView = await checkUserPermission('receipts', 'view')
+  if (!canView) {
+    throw new Error('Insufficient permissions')
+  }
+  const { user_id } = await requireCurrentUser()
+  return queryReceiptVendorReviews(user_id)
+}
+
+export async function setReceiptVendorReviewStatus(input: {
+  vendorLabel: string
+  comparison: ReceiptVendorMovementComparison
+  monthStart: string
+  status: ReceiptVendorReviewStatus
+}): Promise<{ success?: boolean; item?: ReceiptVendorReviewItem; error?: string }> {
+  const canView = await checkUserPermission('receipts', 'view')
+  if (!canView) {
+    return { error: 'Insufficient permissions' }
+  }
+
+  const { user_id } = await requireCurrentUser()
+  const result = await performSetReceiptVendorReviewStatus(user_id, input)
 
   if (result.success) {
     revalidatePath('/receipts/vendors')

--- a/src/services/receipts/receiptMutations.ts
+++ b/src/services/receipts/receiptMutations.ts
@@ -32,6 +32,9 @@ import type {
   RuleMutationResult,
   BulkStatus,
   ReceiptVendorWatchlistItem,
+  ReceiptVendorReviewItem,
+  ReceiptVendorReviewStatus,
+  ReceiptVendorMovementComparison,
 } from './types'
 import {
   RECEIPT_BUCKET,
@@ -147,6 +150,63 @@ export async function performSetReceiptVendorWatched(
       userId: data.user_id,
       vendorKey: data.vendor_key,
       vendorLabel: data.vendor_label,
+      createdAt: data.created_at,
+      updatedAt: data.updated_at,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// performSetReceiptVendorReviewStatus
+// ---------------------------------------------------------------------------
+
+export async function performSetReceiptVendorReviewStatus(
+  userId: string,
+  input: {
+    vendorLabel: string
+    comparison: ReceiptVendorMovementComparison
+    monthStart: string
+    status: ReceiptVendorReviewStatus
+  },
+): Promise<{ success?: boolean; item?: ReceiptVendorReviewItem; error?: string }> {
+  const vendorLabel = normalizeVendorInput(input.vendorLabel)
+  const vendorKey = normalizeReceiptVendorKey(vendorLabel)
+  const validStatuses: ReceiptVendorReviewStatus[] = ['needs_review', 'expected', 'action_required', 'reviewed']
+  const validComparisons: ReceiptVendorMovementComparison[] = ['mom', 'yoy', 'rolling_3m']
+  const monthStart = /^\d{4}-\d{2}-01$/.test(input.monthStart) ? input.monthStart : null
+
+  if (!vendorLabel || !vendorKey || !monthStart || !validStatuses.includes(input.status) || !validComparisons.includes(input.comparison)) {
+    return { error: 'Invalid vendor review provided' }
+  }
+
+  const supabase = createAdminClient()
+  const { data, error } = await supabase
+    .from('receipt_vendor_reviews')
+    .upsert({
+      user_id: userId,
+      vendor_key: vendorKey,
+      vendor_label: vendorLabel,
+      comparison: input.comparison,
+      month_start: monthStart,
+      status: input.status,
+    }, { onConflict: 'user_id,vendor_key,comparison,month_start' })
+    .select('user_id, vendor_key, vendor_label, comparison, month_start, status, created_at, updated_at')
+    .single()
+
+  if (error || !data) {
+    console.error('Failed to update vendor review status', error)
+    return { error: 'Failed to update vendor review status.' }
+  }
+
+  return {
+    success: true,
+    item: {
+      userId: data.user_id,
+      vendorKey: data.vendor_key,
+      vendorLabel: data.vendor_label,
+      comparison: data.comparison as ReceiptVendorMovementComparison,
+      monthStart: String(data.month_start).slice(0, 10),
+      status: data.status as ReceiptVendorReviewStatus,
       createdAt: data.created_at,
       updatedAt: data.updated_at,
     },

--- a/src/services/receipts/receiptQueries.ts
+++ b/src/services/receipts/receiptQueries.ts
@@ -37,6 +37,8 @@ import type {
   ReceiptVendorMovementSignal,
   ReceiptVendorMovementSummary,
   ReceiptVendorWatchlistItem,
+  ReceiptVendorReviewItem,
+  ReceiptVendorReviewStatus,
   ReceiptMissingExpenseSummaryItem,
   AIUsageBreakdown,
   RpcDetailGroupRow,
@@ -1459,6 +1461,44 @@ export async function queryReceiptVendorWatchlist(userId: string): Promise<Recei
     userId: row.user_id,
     vendorKey: row.vendor_key,
     vendorLabel: row.vendor_label,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }))
+}
+
+export async function queryReceiptVendorReviews(userId: string): Promise<ReceiptVendorReviewItem[]> {
+  const supabase = createAdminClient()
+  const { data, error } = await supabase
+    .from('receipt_vendor_reviews')
+    .select('user_id, vendor_key, vendor_label, comparison, month_start, status, created_at, updated_at')
+    .eq('user_id', userId)
+    .order('month_start', { ascending: false })
+
+  if (error) {
+    if ((error as { code?: string }).code === '42P01') {
+      console.warn('Receipt vendor reviews table is not available yet; returning no review states.')
+      return []
+    }
+    console.error('Failed to load receipt vendor reviews', error)
+    throw error
+  }
+
+  return ((data ?? []) as Array<{
+    user_id: string
+    vendor_key: string
+    vendor_label: string
+    comparison: ReceiptVendorMovementComparison
+    month_start: string
+    status: ReceiptVendorReviewStatus
+    created_at: string
+    updated_at: string
+  }>).map((row) => ({
+    userId: row.user_id,
+    vendorKey: row.vendor_key,
+    vendorLabel: row.vendor_label,
+    comparison: row.comparison,
+    monthStart: String(row.month_start).slice(0, 10),
+    status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }))

--- a/src/services/receipts/types.ts
+++ b/src/services/receipts/types.ts
@@ -225,7 +225,7 @@ export type ReceiptVendorCostSignal = {
 
 export type ReceiptVendorMovementRange = '12m' | '24m' | '36m' | 'all'
 
-export type ReceiptVendorMovementComparison = 'mom' | 'yoy'
+export type ReceiptVendorMovementComparison = 'mom' | 'yoy' | 'rolling_3m'
 
 type ReceiptVendorMovementDirection = 'spike' | 'drop' | 'new' | 'resumed'
 
@@ -337,6 +337,19 @@ export type ReceiptVendorWatchlistItem = {
   userId: string
   vendorKey: string
   vendorLabel: string
+  createdAt: string
+  updatedAt: string
+}
+
+export type ReceiptVendorReviewStatus = 'needs_review' | 'expected' | 'action_required' | 'reviewed'
+
+export type ReceiptVendorReviewItem = {
+  userId: string
+  vendorKey: string
+  vendorLabel: string
+  comparison: ReceiptVendorMovementComparison
+  monthStart: string
+  status: ReceiptVendorReviewStatus
   createdAt: string
   updatedAt: string
 }

--- a/src/services/receipts/vendorInsights.test.ts
+++ b/src/services/receipts/vendorInsights.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildReceiptVendorMovementSummaries } from './vendorInsights'
+import type { ReceiptVendorTrendMonth } from './types'
+
+function month(monthStart: string, totalOutgoing: number, transactionCount = 1): ReceiptVendorTrendMonth {
+  return { monthStart, totalOutgoing, totalIncome: 0, transactionCount }
+}
+
+describe('buildReceiptVendorMovementSummaries', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the latest completed month instead of a partial current month', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-11T12:00:00Z'))
+
+    const [summary] = buildReceiptVendorMovementSummaries([
+      {
+        vendorLabel: 'Supplier A',
+        months: [
+          month('2025-06-01', 500),
+          month('2026-06-01', 750),
+          month('2026-07-01', 20),
+        ],
+      },
+    ], { comparison: 'yoy', range: '12m' })
+
+    expect(summary.latestMonthStart).toBe('2026-06-01')
+    expect(summary.latestOutgoing).toBe(750)
+    expect(summary.baselineOutgoing).toBe(500)
+    expect(summary.delta).toBe(250)
+  })
+
+  it('calculates the latest three-month average against the previous three months', () => {
+    const [summary] = buildReceiptVendorMovementSummaries([
+      {
+        vendorLabel: 'Supplier A',
+        months: [
+          month('2026-01-01', 100),
+          month('2026-02-01', 200),
+          month('2026-03-01', 300),
+          month('2026-04-01', 300),
+          month('2026-05-01', 450),
+          month('2026-06-01', 600),
+        ],
+      },
+    ], {
+      comparison: 'rolling_3m',
+      range: '12m',
+      referenceMonthStart: '2026-06-01',
+    })
+
+    expect(summary.latestOutgoing).toBe(450)
+    expect(summary.baselineOutgoing).toBe(200)
+    expect(summary.delta).toBe(250)
+    expect(summary.percentageChange).toBe(125)
+    expect(summary.latestTransactionCount).toBe(3)
+  })
+
+  it('ranks all vendors by absolute pound movement', () => {
+    const summaries = buildReceiptVendorMovementSummaries([
+      {
+        vendorLabel: 'Small increase',
+        months: [month('2025-06-01', 100), month('2026-06-01', 200)],
+      },
+      {
+        vendorLabel: 'Large decrease',
+        months: [month('2025-06-01', 1_000), month('2026-06-01', 400)],
+      },
+    ], {
+      comparison: 'yoy',
+      range: '12m',
+      referenceMonthStart: '2026-06-01',
+    })
+
+    expect(summaries.map((summary) => summary.vendorLabel)).toEqual(['Large decrease', 'Small increase'])
+  })
+})

--- a/src/services/receipts/vendorInsights.ts
+++ b/src/services/receipts/vendorInsights.ts
@@ -44,7 +44,9 @@ export function normalizeReceiptVendorMovementRange(value: unknown): ReceiptVend
 }
 
 export function normalizeReceiptVendorMovementComparison(value: unknown): ReceiptVendorMovementComparison {
-  return value === 'mom' || value === 'yoy' ? value : DEFAULT_MOVEMENT_COMPARISON
+  return value === 'mom' || value === 'yoy' || value === 'rolling_3m'
+    ? value
+    : DEFAULT_MOVEMENT_COMPARISON
 }
 
 export function receiptVendorMovementRangeMonths(range: ReceiptVendorMovementRange): number | null {
@@ -309,7 +311,9 @@ function hasPriorSpendBefore(monthMap: Map<string, ReceiptVendorTrendMonth>, mon
 }
 
 function comparisonLabel(comparison: ReceiptVendorMovementComparison): string {
-  return comparison === 'mom' ? 'MoM' : 'YoY'
+  if (comparison === 'mom') return 'MoM'
+  if (comparison === 'rolling_3m') return 'rolling three-month'
+  return 'YoY'
 }
 
 function buildMovementSignal(input: {
@@ -481,9 +485,13 @@ export function buildReceiptVendorMovementSummaries(
 ): ReceiptVendorMovementSummary[] {
   const range = normalizeReceiptVendorMovementRange(options.range)
   const comparison = normalizeReceiptVendorMovementComparison(options.comparison)
-  const latestMonth =
-    (options.referenceMonthStart ? toMonthStart(options.referenceMonthStart) : null) ??
-    latestMovementMonth(vendors)
+  const latestDataMonth = latestMovementMonth(vendors)
+  const completedMonthCutoff = addUtcMonths(toMonthStart(new Date())!, -1)
+  const latestMonth = options.referenceMonthStart
+    ? toMonthStart(options.referenceMonthStart)
+    : latestDataMonth && latestDataMonth < completedMonthCutoff
+      ? latestDataMonth
+      : completedMonthCutoff
   const earliestMonth = earliestMovementMonth(vendors)
 
   if (!latestMonth || !earliestMonth) {
@@ -505,21 +513,51 @@ export function buildReceiptVendorMovementSummaries(
         analysisStartMonth,
       })
       const latest = months[months.length - 1] ?? null
-      const signal = latest
-        ? (comparison === 'mom' ? latest.momSignal : latest.yoySignal)
-        : null
-      const baselineOutgoing = latest
+      let latestOutgoing = latest?.totalOutgoing ?? 0
+      let latestTransactionCount = latest?.transactionCount ?? 0
+      let baselineOutgoing = latest
         ? (comparison === 'mom' ? latest.momBaselineOutgoing : latest.yoyBaselineOutgoing)
         : null
-      const baselineMonthStart = latest
+      let baselineMonthStart = latest
         ? (comparison === 'mom' ? latest.momBaselineMonthStart : latest.yoyBaselineMonthStart)
         : null
-      const delta = latest
+      let delta = latest
         ? (comparison === 'mom' ? latest.momDelta : latest.yoyDelta)
         : null
-      const percentageChange = latest
+      let percentageChange = latest
         ? (comparison === 'mom' ? latest.momPercentageChange : latest.yoyPercentageChange)
         : null
+      let signal = latest
+        ? (comparison === 'mom' ? latest.momSignal : latest.yoySignal)
+        : null
+
+      if (comparison === 'rolling_3m' && latest) {
+        const recentMonths = months.slice(-3)
+        const previousMonths = months.slice(-6, -3)
+        const hasBaseline = previousMonths.length === 3 && addUtcMonths(latest.monthStart, -5) >= analysisStartMonth
+        const average = (items: ReceiptVendorMovementMonth[]) =>
+          items.reduce((sum, month) => sum + month.totalOutgoing, 0) / Math.max(items.length, 1)
+
+        latestOutgoing = roundMovementValue(average(recentMonths))
+        latestTransactionCount = recentMonths.reduce((sum, month) => sum + month.transactionCount, 0)
+        baselineOutgoing = hasBaseline ? roundMovementValue(average(previousMonths)) : null
+        baselineMonthStart = hasBaseline ? addUtcMonths(latest.monthStart, -5) : null
+        delta = baselineOutgoing === null ? null : roundMovementValue(latestOutgoing - baselineOutgoing)
+        percentageChange = baselineOutgoing === null
+          ? null
+          : roundMovementValue(movementPercentage(latestOutgoing, baselineOutgoing))
+        signal = baselineOutgoing === null
+          ? null
+          : buildMovementSignal({
+            vendorLabel: vendor.vendorLabel,
+            comparison,
+            monthStart: latest.monthStart,
+            currentOutgoing: latestOutgoing,
+            baselineOutgoing,
+            baselineMonthStart,
+            hadPriorSpendBeforeCurrent: hasPriorSpendBefore(monthMapForMovement(vendor.months), addUtcMonths(latest.monthStart, -2)),
+          })
+      }
       const totalOutgoing = roundMovementValue(months.reduce((sum, month) => sum + month.totalOutgoing, 0))
       const transactionCount = months.reduce((sum, month) => sum + month.transactionCount, 0)
 
@@ -533,8 +571,8 @@ export function buildReceiptVendorMovementSummaries(
         comparison,
         months,
         latestMonthStart: latest?.monthStart ?? null,
-        latestOutgoing: latest?.totalOutgoing ?? 0,
-        latestTransactionCount: latest?.transactionCount ?? 0,
+        latestOutgoing,
+        latestTransactionCount,
         baselineMonthStart,
         baselineOutgoing,
         delta,
@@ -546,14 +584,9 @@ export function buildReceiptVendorMovementSummaries(
     })
     .filter((summary): summary is ReceiptVendorMovementSummary => Boolean(summary))
     .sort((a, b) => {
-      if (a.signal?.severity !== b.signal?.severity) {
-        if (a.signal?.severity === 'high') return -1
-        if (b.signal?.severity === 'high') return 1
-      }
-
-      const aSignalDelta = a.signal?.absoluteDelta ?? Math.abs(a.delta ?? 0)
-      const bSignalDelta = b.signal?.absoluteDelta ?? Math.abs(b.delta ?? 0)
-      if (aSignalDelta !== bSignalDelta) return bSignalDelta - aSignalDelta
+      const aAbsoluteDelta = Math.abs(a.delta ?? 0)
+      const bAbsoluteDelta = Math.abs(b.delta ?? 0)
+      if (aAbsoluteDelta !== bAbsoluteDelta) return bAbsoluteDelta - aAbsoluteDelta
 
       return b.latestOutgoing - a.latestOutgoing
     })

--- a/supabase/migrations/20260730000001_receipt_vendor_reviews.sql
+++ b/supabase/migrations/20260730000001_receipt_vendor_reviews.sql
@@ -1,0 +1,48 @@
+-- Per-user review state for a vendor movement in a specific reporting period.
+
+CREATE TABLE IF NOT EXISTS public.receipt_vendor_reviews (
+  user_id UUID NOT NULL,
+  vendor_key TEXT NOT NULL,
+  vendor_label TEXT NOT NULL,
+  comparison TEXT NOT NULL,
+  month_start DATE NOT NULL,
+  status TEXT NOT NULL DEFAULT 'needs_review',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT receipt_vendor_reviews_pk PRIMARY KEY (user_id, vendor_key, comparison, month_start),
+  CONSTRAINT receipt_vendor_reviews_vendor_key_not_empty CHECK (btrim(vendor_key) <> ''),
+  CONSTRAINT receipt_vendor_reviews_vendor_label_not_empty CHECK (btrim(vendor_label) <> ''),
+  CONSTRAINT receipt_vendor_reviews_comparison_valid CHECK (comparison IN ('mom', 'yoy', 'rolling_3m')),
+  CONSTRAINT receipt_vendor_reviews_status_valid CHECK (status IN ('needs_review', 'expected', 'action_required', 'reviewed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_receipt_vendor_reviews_user_period
+  ON public.receipt_vendor_reviews (user_id, month_start DESC, comparison);
+
+CREATE OR REPLACE FUNCTION public.set_receipt_vendor_reviews_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_receipt_vendor_reviews_updated_at ON public.receipt_vendor_reviews;
+CREATE TRIGGER trg_receipt_vendor_reviews_updated_at
+BEFORE UPDATE ON public.receipt_vendor_reviews
+FOR EACH ROW
+EXECUTE FUNCTION public.set_receipt_vendor_reviews_updated_at();
+
+ALTER TABLE public.receipt_vendor_reviews ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role manages receipt vendor reviews" ON public.receipt_vendor_reviews;
+CREATE POLICY "Service role manages receipt vendor reviews"
+  ON public.receipt_vendor_reviews
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+REVOKE ALL ON public.receipt_vendor_reviews FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.receipt_vendor_reviews TO service_role;

--- a/tests/components/ReceiptVendorSummaryGrid.test.tsx
+++ b/tests/components/ReceiptVendorSummaryGrid.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/app/actions/receipts', () => ({
   getReceiptVendorDetail: vi.fn(),
   getReceiptVendorMovements: vi.fn(),
   getReceiptVendorMonthTransactions: vi.fn(),
+  setReceiptVendorReviewStatus: vi.fn(),
   setReceiptVendorWatched: vi.fn(),
 }))
 
@@ -14,11 +15,13 @@ import VendorSummaryGrid from '@/app/(authenticated)/receipts/vendors/_component
 import {
   getReceiptVendorDetail,
   getReceiptVendorMovements,
+  setReceiptVendorReviewStatus,
   setReceiptVendorWatched,
 } from '@/app/actions/receipts'
 
 const mockedGetReceiptVendorDetail = getReceiptVendorDetail as unknown as Mock
 const mockedGetReceiptVendorMovements = getReceiptVendorMovements as unknown as Mock
+const mockedSetReceiptVendorReviewStatus = setReceiptVendorReviewStatus as unknown as Mock
 const mockedSetReceiptVendorWatched = setReceiptVendorWatched as unknown as Mock
 
 const vendors = [
@@ -47,11 +50,33 @@ const vendors = [
   },
 ]
 
+const movement = (vendorLabel: string, delta: number, signal: Record<string, unknown> | null = null) => ({
+  vendorLabel,
+  range: '36m',
+  comparison: 'rolling_3m',
+  months: [],
+  latestMonthStart: '2026-06-01',
+  latestOutgoing: 300 + delta,
+  latestTransactionCount: 2,
+  baselineMonthStart: '2026-01-01',
+  baselineOutgoing: 300,
+  delta,
+  percentageChange: (delta / 300) * 100,
+  signal,
+  totalOutgoing: 1_000,
+  transactionCount: 6,
+})
+
 describe('VendorSummaryGrid', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedSetReceiptVendorWatched.mockResolvedValue({ success: true, watched: true })
-    mockedGetReceiptVendorMovements.mockResolvedValue({ success: true, movements: [], signals: [] })
+    mockedSetReceiptVendorReviewStatus.mockResolvedValue({ success: true })
+    mockedGetReceiptVendorMovements.mockResolvedValue({
+      success: true,
+      movements: [movement('Brewery A', 200), movement('Food Supplier', -250)],
+      signals: [],
+    })
   })
 
   it('opens the vendor detail drawer and displays loaded transactions', async () => {
@@ -108,9 +133,12 @@ describe('VendorSummaryGrid', () => {
       },
     })
 
-    render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} />)
+    render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} initialReviews={[]} />)
 
-    fireEvent.click(screen.getAllByRole('button', { name: /view details/i })[0])
+    fireEvent.click(await screen.findByRole('button', { name: 'All vendors' }))
+    const breweryRow = screen.getAllByRole('row').find((row) => within(row).queryByText('Brewery A'))
+    expect(breweryRow).toBeDefined()
+    fireEvent.click(within(breweryRow!).getByRole('button', { name: /view details/i }))
 
     await waitFor(() => expect(mockedGetReceiptVendorDetail).toHaveBeenCalledWith({
       vendorLabel: 'Brewery A',
@@ -124,87 +152,34 @@ describe('VendorSummaryGrid', () => {
     expect(screen.getByText('Entertainment')).toBeInTheDocument()
   })
 
-  it('updates the vendor movement table controls', async () => {
+  it('ranks movements by absolute pounds and updates the comparison', async () => {
     mockedGetReceiptVendorMovements
       .mockResolvedValueOnce({
         success: true,
         signals: [],
         movements: [
-          {
-            vendorLabel: 'Brewery A',
-            range: '36m',
-            comparison: 'yoy',
-            months: [],
-            latestMonthStart: '2026-06-01',
-            latestOutgoing: 300,
-            latestTransactionCount: 2,
-            baselineMonthStart: '2025-06-01',
-            baselineOutgoing: 100,
-            delta: 200,
-            percentageChange: 200,
-            signal: null,
-            totalOutgoing: 300,
-            transactionCount: 2,
-          },
-          {
-            vendorLabel: 'Food Supplier',
-            range: '36m',
-            comparison: 'yoy',
-            months: [],
-            latestMonthStart: '2026-06-01',
-            latestOutgoing: 500,
-            latestTransactionCount: 1,
-            baselineMonthStart: '2025-06-01',
-            baselineOutgoing: 250,
-            delta: 250,
-            percentageChange: 100,
-            signal: null,
-            totalOutgoing: 500,
-            transactionCount: 1,
-          },
+          movement('Brewery A', 200),
+          movement('Food Supplier', -250),
         ],
       })
       .mockResolvedValueOnce({
         success: true,
         signals: [],
-        movements: [{
-          vendorLabel: 'Brewery A',
-          range: '12m',
-          comparison: 'yoy',
-          months: [],
-          latestMonthStart: '2026-06-01',
-          latestOutgoing: 300,
-          latestTransactionCount: 2,
-          baselineMonthStart: '2025-06-01',
-          baselineOutgoing: 100,
-          delta: 200,
-          percentageChange: 200,
-          signal: null,
-          totalOutgoing: 300,
-          transactionCount: 2,
-        }],
+        movements: [{ ...movement('Brewery A', 200), comparison: 'yoy' }],
       })
 
-    render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} />)
+    render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} initialReviews={[]} />)
 
-    expect(await screen.findByText('Vendor movement')).toBeInTheDocument()
-    expect(await screen.findByText('+£200.00')).toBeInTheDocument()
-    expect(screen.queryByText('AI cost review')).not.toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: /spend/i }))
-    let rows = screen.getAllByRole('row')
+    expect(await screen.findByText('Spend movement overview')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'All vendors' }))
+    const rows = screen.getAllByRole('row')
     expect(within(rows[1]).getByText('Food Supplier')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /spend/i }))
-    rows = screen.getAllByRole('row')
-    expect(within(rows[1]).getByText('Brewery A')).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('button', { name: '12m' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Year on year' }))
 
     await waitFor(() => expect(mockedGetReceiptVendorMovements).toHaveBeenLastCalledWith({
-      range: '12m',
+      range: '36m',
       comparison: 'yoy',
-      watchedOnly: false,
     }))
   })
 
@@ -219,13 +194,47 @@ describe('VendorSummaryGrid', () => {
           createdAt: '2026-06-01T00:00:00.000Z',
           updatedAt: '2026-06-01T00:00:00.000Z',
         }]}
+        initialReviews={[]}
       />,
     )
 
     await waitFor(() => expect(mockedGetReceiptVendorMovements).toHaveBeenCalled())
-    fireEvent.click(screen.getAllByRole('button', { name: 'Watched' })[1])
+    fireEvent.click(screen.getByRole('button', { name: 'Watched (1)' }))
 
-    expect(screen.getByText('Brewery A')).toBeInTheDocument()
-    expect(screen.queryByText('Food Supplier')).not.toBeInTheDocument()
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows.some((row) => within(row).queryByText('Brewery A'))).toBe(true)
+    expect(rows.some((row) => within(row).queryByText('Food Supplier'))).toBe(false)
+  })
+
+  it('saves an action status for the current comparison period', async () => {
+    mockedGetReceiptVendorMovements.mockResolvedValue({
+      success: true,
+      movements: [movement('Brewery A', 200, {
+        vendorLabel: 'Brewery A',
+        severity: 'high',
+        direction: 'spike',
+        comparison: 'rolling_3m',
+        monthStart: '2026-06-01',
+        currentOutgoing: 500,
+        baselineOutgoing: 300,
+        baselineMonthStart: '2026-01-01',
+        absoluteDelta: 200,
+        percentageChange: 66.7,
+        reason: 'Spend increased.',
+      })],
+      signals: [],
+    })
+
+    render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} initialReviews={[]} />)
+
+    const statusControls = await screen.findAllByRole('combobox', { name: 'Review status for Brewery A' })
+    fireEvent.change(statusControls[0], { target: { value: 'action_required' } })
+
+    await waitFor(() => expect(mockedSetReceiptVendorReviewStatus).toHaveBeenCalledWith({
+      vendorLabel: 'Brewery A',
+      comparison: 'rolling_3m',
+      monthStart: '2026-06-01',
+      status: 'action_required',
+    }))
   })
 })


### PR DESCRIPTION
## What changed
- adds spend movement summary cards and a diverging biggest-movement chart
- adds completed-month, rolling three-month, YoY, and MoM comparisons
- adds increase, decrease, new/resumed, watched, and attention views
- adds per-user review statuses backed by a new migration
- simplifies the page and improves mobile presentation

## Why
The previous page contained the data but made it difficult to quickly see the largest increases and decreases or track follow-up action.

## Validation
- `npm run build`
- `npm run lint`
- `npx tsc --noEmit`
- targeted vendor movement and component tests (7 passing)