### PR TITLE
Add recruitment slot edit and delete controls

### DIFF
--- a/src/app/(authenticated)/recruitment/_components/RecruitmentDashboardClient.tsx
+++ b/src/app/(authenticated)/recruitment/_components/RecruitmentDashboardClient.tsx
@@ -42,7 +42,6 @@ import {
   addRecruitmentCandidateNoteAction,
   archiveRecruitmentApplicationAction,
   archiveRecruitmentAppointmentAction,
-  archiveRecruitmentSlotAction,
   bulkRecruitmentApplicationsAction,
   cancelRecruitmentAppointmentAction,
   cancelRecruitmentSlotAction,
@@ -1373,7 +1372,6 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
   const archiveApplicationFormAction = archiveRecruitmentApplicationAction as unknown as (formData: FormData) => Promise<void>
   const restoreApplicationFormAction = restoreRecruitmentApplicationAction as unknown as (formData: FormData) => Promise<void>
   const cancelSlotFormAction = cancelRecruitmentSlotAction as unknown as (formData: FormData) => Promise<void>
-  const archiveSlotFormAction = archiveRecruitmentSlotAction as unknown as (formData: FormData) => Promise<void>
   const restoreSlotFormAction = restoreRecruitmentSlotAction as unknown as (formData: FormData) => Promise<void>
   const cancelAppointmentFormAction = cancelRecruitmentAppointmentAction as unknown as (formData: FormData) => Promise<void>
   const rescheduleAppointmentFormAction = rescheduleRecruitmentAppointmentAction as unknown as (formData: FormData) => Promise<void>
@@ -1403,6 +1401,9 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
   const selectedPosting = postings.find((posting: any) => posting.id === selectedPostingId) ?? null
   const selectedApplication = applications.find((application: any) => application.id === selectedApplicationId) ?? null
   const selectedSlot = slots.find((slot: any) => slot.id === selectedSlotId) ?? null
+  const selectedSlotAppointment = appointments.find((appointment: any) => (
+    appointment.slot_id === selectedSlot?.id && appointment.status === 'scheduled'
+  )) ?? null
   const selectedAppointment = appointments.find((appointment: any) => appointment.id === selectedAppointmentId) ?? null
   const selectedCommunication = communications.find((communication: any) => communication.id === selectedCommunicationId) ?? null
   const selectedTalentCandidate = talentCandidates.find((candidate: any) => candidate.id === selectedTalentCandidateId)
@@ -1774,6 +1775,17 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
   function openSlotDetail(slot: any) {
     setSelectedSlotId(slot.id)
     setSlotDrawerOpen(true)
+  }
+
+  function openBookedSlotAppointment(slot: any) {
+    const appointment = appointments.find((candidateAppointment: any) => (
+      candidateAppointment.slot_id === slot.id && candidateAppointment.status === 'scheduled'
+    ))
+    if (appointment) {
+      openAppointmentDetail(appointment)
+      return
+    }
+    openSlotDetail(slot)
   }
 
   function openAppointmentDetail(appointment: any) {
@@ -3177,6 +3189,7 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
                       <TableHead>Closes</TableHead>
                       <TableHead>Location</TableHead>
                       <TableHead>Status</TableHead>
+                      {permissions.canEdit && <TableHead>Actions</TableHead>}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -3191,6 +3204,46 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
                         <TableCell>{formatSlotDateTime(slot.ends_at)}</TableCell>
                         <TableCell>{slot.location}</TableCell>
                         <TableCell>{slot.archived_at ? 'archived' : slot.status}</TableCell>
+                        {permissions.canEdit && (
+                          <TableCell>
+                            <div className="flex flex-wrap items-center gap-2">
+                              {!slot.archived_at && slot.status === 'open' && (
+                                <>
+                                  <Button type="button" size="sm" variant="secondary" onClick={() => openSlotDetail(slot)}>
+                                    Edit
+                                  </Button>
+                                  <ActionFeedbackForm
+                                    action={cancelSlotFormAction}
+                                    confirmTitle="Delete slot"
+                                    confirmMessage="Delete this slot? It will no longer be available for booking."
+                                    successMessage="Slot deleted."
+                                    onSuccess={() => router.refresh()}
+                                  >
+                                    <input type="hidden" name="slot_id" value={slot.id} />
+                                    <SubmitButton variant="danger">Delete</SubmitButton>
+                                  </ActionFeedbackForm>
+                                </>
+                              )}
+                              {!slot.archived_at && slot.status === 'booked' && (
+                                <Button type="button" size="sm" variant="secondary" onClick={() => openBookedSlotAppointment(slot)}>
+                                  Manage booking
+                                </Button>
+                              )}
+                              {slot.archived_at && (
+                                <ActionFeedbackForm
+                                  action={restoreSlotFormAction}
+                                  confirmTitle="Restore slot"
+                                  confirmMessage="Restore this slot?"
+                                  successMessage="Slot restored."
+                                  onSuccess={() => router.refresh()}
+                                >
+                                  <input type="hidden" name="slot_id" value={slot.id} />
+                                  <SubmitButton variant="secondary">Restore</SubmitButton>
+                                </ActionFeedbackForm>
+                              )}
+                            </div>
+                          </TableCell>
+                        )}
                       </TableRow>
                     ))}
                   </TableBody>
@@ -3298,7 +3351,7 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
                   <p>{selectedSlot.archived_at ? 'archived' : selectedSlot.status}</p>
                 </div>
               </div>
-              {permissions.canEdit && (
+              {permissions.canEdit && !selectedSlot.archived_at && selectedSlot.status === 'open' && (
                 <form action={slotUpdateAction} className="space-y-3">
                   <input type="hidden" name="slot_id" value={selectedSlot.id} />
                   <Field label="Type">
@@ -3318,25 +3371,53 @@ export default function RecruitmentDashboardClient({ initialData, permissions }:
                   </div>
                 </form>
               )}
-              {permissions.canEdit && (
+              {!selectedSlot.archived_at && selectedSlot.status === 'booked' && (
+                <div className="rounded-lg border border-border bg-surface-2 p-3 text-sm">
+                  <p>This slot is booked. Reschedule or cancel the appointment before changing the slot.</p>
+                  {selectedSlotAppointment && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      className="mt-3"
+                      onClick={() => {
+                        setSlotDrawerOpen(false)
+                        openAppointmentDetail(selectedSlotAppointment)
+                      }}
+                    >
+                      Manage booking
+                    </Button>
+                  )}
+                </div>
+              )}
+              {permissions.canEdit && !selectedSlot.archived_at && selectedSlot.status === 'open' && (
                 <div className="flex flex-wrap gap-2 border-t border-border pt-3">
                   <ActionFeedbackForm
                     action={cancelSlotFormAction}
-                    confirmTitle="Cancel slot"
-                    confirmMessage="Cancel this recruitment slot?"
-                    successMessage="Slot cancelled."
+                    confirmTitle="Delete slot"
+                    confirmMessage="Delete this slot? It will no longer be available for booking."
+                    successMessage="Slot deleted."
+                    onSuccess={() => {
+                      setSlotDrawerOpen(false)
+                      router.refresh()
+                    }}
                   >
                     <input type="hidden" name="slot_id" value={selectedSlot.id} />
-                    <SubmitButton variant="secondary">Cancel slot</SubmitButton>
+                    <SubmitButton variant="danger">Delete slot</SubmitButton>
                   </ActionFeedbackForm>
+                </div>
+              )}
+              {permissions.canEdit && selectedSlot.archived_at && (
+                <div className="flex flex-wrap gap-2 border-t border-border pt-3">
                   <ActionFeedbackForm
-                    action={selectedSlot.archived_at ? restoreSlotFormAction : archiveSlotFormAction}
-                    confirmTitle={selectedSlot.archived_at ? 'Restore slot' : 'Archive slot'}
-                    confirmMessage={selectedSlot.archived_at ? 'Restore this slot?' : 'Archive this slot?'}
-                    successMessage={selectedSlot.archived_at ? 'Slot restored.' : 'Slot archived.'}
+                    action={restoreSlotFormAction}
+                    confirmTitle="Restore slot"
+                    confirmMessage="Restore this slot?"
+                    successMessage="Slot restored."
+                    onSuccess={() => router.refresh()}
                   >
                     <input type="hidden" name="slot_id" value={selectedSlot.id} />
-                    <SubmitButton variant="secondary">{selectedSlot.archived_at ? 'Restore slot' : 'Archive slot'}</SubmitButton>
+                    <SubmitButton variant="secondary">Restore slot</SubmitButton>
                   </ActionFeedbackForm>
                 </div>
               )}

--- a/src/app/actions/recruitment.ts
+++ b/src/app/actions/recruitment.ts
@@ -37,6 +37,7 @@ import {
   recordRecruitmentAppointmentOutcome,
   rescheduleRecruitmentAppointmentByStaff,
   rescoreRecruitmentApplication,
+  restoreRecruitmentAppointmentSlot,
   runRecruitmentRetentionCleanup,
   saveRecruitmentEmailTemplate,
   scheduleRecruitmentAppointmentByStaff,
@@ -908,9 +909,9 @@ export async function cancelRecruitmentSlotAction(formData: FormData): Promise<A
       newValues: { status: (slot as any).status ?? 'cancelled' },
     })
     revalidatePath('/recruitment')
-    return { success: true, data: slot, message: 'Slot cancelled.' }
+    return { success: true, data: slot, message: 'Slot deleted.' }
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : 'Failed to cancel slot.' }
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to delete slot.' }
   }
 }
 
@@ -982,7 +983,7 @@ export async function restoreRecruitmentSlotAction(formData: FormData): Promise<
     const user = await requireRecruitmentPermission('edit')
     const slotId = formString(formData, 'slot_id')
     if (!slotId) throw new Error('Slot ID is required.')
-    const slot = await setRecruitmentArchiveState('recruitment_appointment_slots', slotId, false, user.id)
+    const slot = await restoreRecruitmentAppointmentSlot(slotId)
     await auditRecruitmentMutation({
       user,
       operation: 'restore',

--- a/src/services/__tests__/recruitmentAppointmentSlot.test.ts
+++ b/src/services/__tests__/recruitmentAppointmentSlot.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createRecruitmentAppointmentSlot, createRecruitmentAppointmentSlots } from '../recruitment'
+import {
+  createRecruitmentAppointmentSlot,
+  createRecruitmentAppointmentSlots,
+  restoreRecruitmentAppointmentSlot,
+} from '../recruitment'
 
 function createInsertMock() {
   const select = vi.fn().mockResolvedValue({ data: [], error: null })
@@ -86,5 +90,33 @@ describe('recruitment appointment slots', () => {
         ends_at: '2099-01-01T16:00:00.000Z',
       }),
     ])
+  })
+
+  it('reopens a future cancelled slot when it is restored', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: 'slot-1', status: 'cancelled', starts_at: '2099-01-01T12:00:00.000Z' },
+      error: null,
+    })
+    const existingEq = vi.fn(() => ({ maybeSingle }))
+    const existingSelect = vi.fn(() => ({ eq: existingEq }))
+    const single = vi.fn().mockResolvedValue({
+      data: { id: 'slot-1', status: 'open', archived_at: null, archived_by: null },
+      error: null,
+    })
+    const updateSelect = vi.fn(() => ({ single }))
+    const updateEq = vi.fn(() => ({ select: updateSelect }))
+    const update = vi.fn(() => ({ eq: updateEq }))
+    const from = vi.fn()
+      .mockReturnValueOnce({ select: existingSelect })
+      .mockReturnValueOnce({ update })
+
+    const slot = await restoreRecruitmentAppointmentSlot('slot-1', { from } as any)
+
+    expect(update).toHaveBeenCalledWith({
+      status: 'open',
+      archived_at: null,
+      archived_by: null,
+    })
+    expect(slot).toEqual(expect.objectContaining({ id: 'slot-1', status: 'open' }))
   })
 })

--- a/src/services/recruitment.ts
+++ b/src/services/recruitment.ts
@@ -1965,6 +1965,35 @@ export async function cancelRecruitmentAppointmentSlot(
   return data
 }
 
+export async function restoreRecruitmentAppointmentSlot(
+  slotId: string,
+  supabase: GenericClient = createAdminClient()
+) {
+  const { data: slot, error: slotError } = await supabase
+    .from('recruitment_appointment_slots')
+    .select('id, status, starts_at')
+    .eq('id', slotId)
+    .maybeSingle()
+
+  if (slotError) throw slotError
+  if (!slot) throw new Error('Slot not found.')
+  if (new Date(slot.starts_at) <= new Date()) throw new Error('Past slots cannot be restored.')
+
+  const { data, error } = await supabase
+    .from('recruitment_appointment_slots')
+    .update({
+      status: slot.status === 'cancelled' ? 'open' : slot.status,
+      archived_at: null,
+      archived_by: null,
+    })
+    .eq('id', slotId)
+    .select('*')
+    .single()
+
+  if (error) throw error
+  return data
+}
+
 export async function setRecruitmentArchiveState(
   table: 'recruitment_applications' | 'recruitment_appointment_slots' | 'recruitment_candidate_appointments',
   id: string,

--- a/tests/components/RecruitmentDashboardA039.test.tsx
+++ b/tests/components/RecruitmentDashboardA039.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import RecruitmentDashboardClient from '@/app/(authenticated)/recruitment/_components/RecruitmentDashboardClient'
-import { scheduleRecruitmentInterviewForCandidateAction } from '@/app/actions/recruitment'
+import {
+  cancelRecruitmentSlotAction,
+  scheduleRecruitmentInterviewForCandidateAction,
+} from '@/app/actions/recruitment'
 
 vi.mock('@/app/actions/recruitment', () => {
   const ok = vi.fn().mockResolvedValue({ success: true, message: 'Done.' })
@@ -217,6 +220,66 @@ describe('RecruitmentDashboardClient A-039', () => {
     expect(screen.getByRole('columnheader', { name: 'Closes' })).toBeInTheDocument()
     expect(screen.getByText('Wed, 1 Jul 2026, 12:00')).toBeInTheDocument()
     expect(screen.getByText('Wed, 1 Jul 2026, 14:00')).toBeInTheDocument()
+  })
+
+  it('shows clear edit and delete controls for open slots', async () => {
+    const data = makeInitialData()
+    data.slots = [{
+      id: 'slot-1',
+      type: 'interview',
+      starts_at: '2099-07-01T11:00:00.000Z',
+      ends_at: '2099-07-01T12:00:00.000Z',
+      location: 'The Anchor',
+      status: 'open',
+      archived_at: null,
+    }]
+
+    render(<RecruitmentDashboardClient initialData={data} permissions={permissions} />)
+    fireEvent.click(screen.getByRole('tab', { name: /Schedule/i }))
+
+    expect(screen.getByRole('columnheader', { name: 'Actions' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    expect(screen.getByRole('button', { name: 'Save slot' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete', exact: true }))
+    const dialog = await screen.findByRole('dialog', { name: 'Delete slot' })
+    expect(cancelRecruitmentSlotAction).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Confirm' }))
+
+    await waitFor(() => expect(cancelRecruitmentSlotAction).toHaveBeenCalledTimes(1))
+    const formData = (cancelRecruitmentSlotAction as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as FormData
+    expect(formData.get('slot_id')).toBe('slot-1')
+  })
+
+  it('routes booked slots to the appointment instead of allowing deletion', () => {
+    const data = makeInitialData()
+    data.slots = [{
+      id: 'slot-1',
+      type: 'interview',
+      starts_at: '2099-07-01T11:00:00.000Z',
+      ends_at: '2099-07-01T12:00:00.000Z',
+      location: 'The Anchor',
+      status: 'booked',
+      archived_at: null,
+    }]
+    data.appointments = [{
+      id: 'appointment-1',
+      slot_id: 'slot-1',
+      type: 'interview',
+      status: 'scheduled',
+      scheduled_start: '2099-07-01T11:00:00.000Z',
+      calendar_sync_status: 'synced',
+      candidate: { first_name: 'Megan', last_name: 'Daily' },
+      application: { job_posting: { title: 'Kitchen Team' } },
+    }]
+
+    render(<RecruitmentDashboardClient initialData={data} permissions={permissions} />)
+    fireEvent.click(screen.getByRole('tab', { name: /Schedule/i }))
+
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete', exact: true })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Manage booking' }))
+    expect(screen.getByRole('dialog', { name: 'Megan Daily' })).toBeInTheDocument()
   })
 
   it('lets managers schedule an interview from the candidate drawer', () => {


### PR DESCRIPTION
## What changed

- added clear Edit and Delete actions to open recruitment slots
- routed booked slots to appointment management
- made deleted future slots safely restorable
- added service and UI coverage

## Why

Slot controls existed behind an unclear drawer flow and booked slots needed safer handling.

## Checks

- npm run lint
- npx tsc --noEmit
- npm test (3,643 tests)
- npm run build