### PR TITLE
Fix booking last names and drinks pacing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
+          NODE_OPTIONS: --max-old-space-size=6144
           NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
           NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
           NEXT_PUBLIC_APP_URL: https://placeholder.example.com

--- a/src/app/(authenticated)/table-bookings/foh/components/FohCreateBookingModal.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/FohCreateBookingModal.tsx
@@ -274,10 +274,9 @@ export const FohCreateBookingModal = React.memo(function FohCreateBookingModal(p
 
           {!selectedCustomer && createMode !== 'walk_in' && (
             <label className="text-xs font-medium text-gray-700">
-              Last name
+              Last name (optional)
               <input
                 type="text"
-                required={createMode !== 'management'}
                 value={createForm.last_name}
                 onChange={(event) => onSetCreateForm((current) => ({ ...current, last_name: event.target.value }))}
                 className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm"

--- a/src/app/(authenticated)/table-bookings/foh/hooks/useFohCreateBooking.ts
+++ b/src/app/(authenticated)/table-bookings/foh/hooks/useFohCreateBooking.ts
@@ -350,8 +350,8 @@ export function useFohCreateBooking(input: {
     const walkInNameParts = splitName(createForm.customer_name)
     const firstName = createForm.first_name.trim() || (isWalkIn ? walkInNameParts.firstName : undefined)
     const lastName = createForm.last_name.trim() || (isWalkIn ? walkInNameParts.lastName : undefined)
-    if (!isWalkIn && !isManagement && !selectedCustomer && (!firstName || !lastName)) {
-      setErrorMessage('Enter first name and last name for the new customer'); return
+    if (!isWalkIn && !isManagement && !selectedCustomer && !firstName) {
+      setErrorMessage('Enter a first name for the new customer'); return
     }
 
     if (createForm.purpose === 'event') {

--- a/src/app/(authenticated)/table-bookings/foh/types.ts
+++ b/src/app/(authenticated)/table-bookings/foh/types.ts
@@ -86,6 +86,7 @@ export type FohCreateBookingResponse = {
       | 'too_large_party'
       | 'customer_conflict'
       | 'in_past'
+      | 'slot_full'
       | 'blocked'
       | null
     next_step_url: string | null

--- a/src/app/(authenticated)/table-bookings/foh/utils.test.ts
+++ b/src/app/(authenticated)/table-bookings/foh/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { mapFohBlockedReason } from './utils'
+
+describe('mapFohBlockedReason', () => {
+  it('shows a clear kitchen pacing message', () => {
+    expect(mapFohBlockedReason('slot_full')).toContain('kitchen arrival window is full')
+  })
+})

--- a/src/app/(authenticated)/table-bookings/foh/utils.ts
+++ b/src/app/(authenticated)/table-bookings/foh/utils.ts
@@ -236,6 +236,8 @@ export function mapFohBlockedReason(blockedReason?: string | null, reason?: stri
       return 'This customer already has an event booking at that time.'
     case 'in_past':
       return 'Selected time has already passed. Pick the current or next available time.'
+    case 'slot_full':
+      return 'This kitchen arrival window is full. Choose another time or use the pacing override if appropriate.'
     default:
       return 'Booking could not be created for the selected details.'
   }

--- a/src/app/(event-kiosk)/events/[id]/check-in/EventCheckInClient.tsx
+++ b/src/app/(event-kiosk)/events/[id]/check-in/EventCheckInClient.tsx
@@ -208,11 +208,10 @@ export default function EventCheckInClient({ event }: { event: EventRecord }) {
           required
         />
         <Input
-          label="Last name"
+          label="Last name (optional)"
           value={newGuestDetails.lastName}
           onChange={(e) => setNewGuestDetails((current) => ({ ...current, lastName: e.target.value }))}
           autoComplete="family-name"
-          required
         />
       </div>
       <Input

--- a/src/app/actions/event-check-in.ts
+++ b/src/app/actions/event-check-in.ts
@@ -32,7 +32,7 @@ const registerNewSchema = z.object({
   eventId: z.string().uuid(),
   phone: z.string().trim().min(3),
   firstName: z.string().trim().min(1, 'First name is required').max(80),
-  lastName: z.string().trim().min(1, 'Last name is required').max(80),
+  lastName: z.string().trim().max(80).optional(),
   email: z.string().trim().email('Enter a valid email').optional().or(z.literal('')),
 })
 
@@ -1059,7 +1059,7 @@ export async function registerNewGuest(input: z.infer<typeof registerNewSchema>)
   }
 
   const firstName = cleanName(parsed.data.firstName)
-  const lastName = cleanName(parsed.data.lastName)
+  const lastName = cleanName(parsed.data.lastName ?? '')
   const email = parsed.data.email ? parsed.data.email.trim().toLowerCase() : null
   const admin = createAdminClient()
   const customerResolution = await ensureCustomerForPhone(admin, normalizedPhone, {

--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -32,7 +32,7 @@ const CreateEventBookingSchema = z.object({
   event_id: z.string().uuid(),
   phone: z.string().trim().min(7).max(32),
   first_name: z.string().trim().min(1).max(100).optional(),
-  last_name: z.string().trim().min(1).max(100).optional(),
+  last_name: z.string().trim().max(100).optional(),
   email: z.string().trim().email().max(320).optional(),
   default_country_code: z.string().regex(/^\d{1,4}$/).optional(),
   seats: z.preprocess(

--- a/src/app/api/event-waitlist/route.ts
+++ b/src/app/api/event-waitlist/route.ts
@@ -27,7 +27,7 @@ const CreateEventWaitlistSchema = z.object({
   event_id: z.string().uuid(),
   phone: z.string().trim().min(7).max(32),
   first_name: z.string().trim().min(1).max(100).optional(),
-  last_name: z.string().trim().min(1).max(100).optional(),
+  last_name: z.string().trim().max(100).optional(),
   email: z.string().trim().email().max(320).optional(),
   default_country_code: z.string().regex(/^\d{1,4}$/).optional(),
   requested_seats: z.preprocess(

--- a/src/app/api/foh/bookings/route.test.ts
+++ b/src/app/api/foh/bookings/route.test.ts
@@ -153,6 +153,46 @@ describe('POST /api/foh/bookings — kitchen pacing', () => {
     )
   })
 
+  it('bypasses kitchen pacing for a drinks booking', async () => {
+    const db = createSupabaseMock()
+    mockAuthSuccess(db)
+
+    const res = await POST(
+      makeRequest({
+        customer_id: CUSTOMER_ID,
+        date: '2026-08-01',
+        time: '18:00',
+        party_size: 4,
+        purpose: 'drinks',
+      }),
+    )
+
+    expect(res.status).toBe(201)
+    expect(db.rpc).toHaveBeenCalledWith(
+      'create_table_booking_v05',
+      expect.objectContaining({ p_bypass_pacing: true }),
+    )
+  })
+
+  it('creates a new customer booking without a last name', async () => {
+    const db = createSupabaseMock()
+    mockAuthSuccess(db)
+
+    const res = await POST(
+      makeRequest({
+        phone: '07700900000',
+        first_name: 'Sam',
+        date: '2026-08-01',
+        time: '18:00',
+        party_size: 2,
+        purpose: 'food',
+      }),
+    )
+
+    expect(res.status).toBe(201)
+    expect(db.rpc).toHaveBeenCalledTimes(1)
+  })
+
   it('returns 403 when a non-manager sets bypass_pacing and never calls the RPC', async () => {
     const db = createSupabaseMock({ roleRows: [{ roles: { name: 'staff' } }] })
     mockAuthSuccess(db)

--- a/src/app/api/foh/bookings/route.ts
+++ b/src/app/api/foh/bookings/route.ts
@@ -27,7 +27,7 @@ const CreateFohTableBookingSchema = z.object({
   phone: z.string().trim().min(7).max(32).optional(),
   email: z.string().trim().email().max(255).optional(),
   first_name: z.string().trim().min(1).max(80).optional(),
-  last_name: z.string().trim().min(1).max(80).optional(),
+  last_name: z.string().trim().max(80).optional(),
   walk_in: z.boolean().optional(),
   walk_in_guest_name: z.string().trim().max(120).optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
@@ -65,12 +65,6 @@ const CreateFohTableBookingSchema = z.object({
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Enter the customer first name'
-      })
-    }
-    if (!value.last_name?.trim()) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Enter the customer last name'
       })
     }
   }
@@ -139,7 +133,7 @@ async function createWalkInCustomer(
 ): Promise<{ customerId: string; syntheticPhone: string }> {
   const guestNameParts = splitWalkInGuestName(input.guestName)
   const firstName = input.firstName?.trim() || guestNameParts.firstName || 'Walk-in'
-  const lastName = input.lastName?.trim() || guestNameParts.lastName || 'Guest'
+  const lastName = input.lastName?.trim() || guestNameParts.lastName || ''
   const sanitizedEmail = typeof input.email === 'string' ? input.email.trim().toLowerCase() || null : null
   // Email is optional enrichment — never let a lower(email) unique-index
   // collision block walk-in creation. On such a 23505 we drop the email and
@@ -781,6 +775,7 @@ type FohCreateBookingResponseData = {
     | 'too_large_party'
     | 'customer_conflict'
     | 'in_past'
+    | 'slot_full'
     | 'blocked'
     | null
   next_step_url: string | null
@@ -1154,9 +1149,11 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  // Walk-ins are at-arrival and always bypass pacing; advance FOH bookings are
-  // subject to pacing unless a manager/super_admin explicitly overrides.
-  let bypassPacing = payload.walk_in === true
+  // Walk-ins and drinks never consume kitchen pacing. Advance food bookings
+  // are subject to pacing unless a manager/super_admin explicitly overrides.
+  // Drinks do not add kitchen covers, so they must never be blocked by the
+  // food-only kitchen pacing gate.
+  let bypassPacing = payload.walk_in === true || payload.purpose === 'drinks'
   if (payload.bypass_pacing === true && payload.walk_in !== true) {
     const { data: roleRows } = await auth.supabase
       .from('user_roles')

--- a/src/app/api/foh/event-bookings/route.ts
+++ b/src/app/api/foh/event-bookings/route.ts
@@ -18,7 +18,7 @@ const CreateFohEventBookingSchema = z.object({
   phone: z.string().trim().min(7).max(32).optional(),
   email: z.string().trim().email().max(255).optional(),
   first_name: z.string().trim().min(1).max(80).optional(),
-  last_name: z.string().trim().min(1).max(80).optional(),
+  last_name: z.string().trim().max(80).optional(),
   walk_in: z.boolean().optional(),
   walk_in_guest_name: z.string().trim().max(120).optional(),
   default_country_code: z.string().regex(/^\d{1,4}$/).optional(),
@@ -41,12 +41,6 @@ const CreateFohEventBookingSchema = z.object({
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Enter the customer first name'
-      })
-    }
-    if (!value.last_name?.trim()) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Enter the customer last name'
       })
     }
   }
@@ -111,7 +105,7 @@ async function createWalkInCustomer(
 ): Promise<{ customerId: string; syntheticPhone: string }> {
   const guestNameParts = splitWalkInGuestName(input.guestName)
   const firstName = input.firstName?.trim() || guestNameParts.firstName || 'Walk-in'
-  const lastName = input.lastName?.trim() || guestNameParts.lastName || 'Guest'
+  const lastName = input.lastName?.trim() || guestNameParts.lastName || ''
   const sanitizedEmail = typeof input.email === 'string' ? input.email.trim().toLowerCase() || null : null
   // Email is optional enrichment — never let a lower(email) unique-index
   // collision block walk-in creation. On such a 23505 we drop the email and

--- a/src/app/api/public/private-booking/route.ts
+++ b/src/app/api/public/private-booking/route.ts
@@ -36,7 +36,7 @@ const BookingItemSchema = z.object({
 
 const PublicBookingSchema = z.object({
     customer_first_name: z.string().min(1, 'First name is required').max(100),
-    customer_last_name: z.string().min(1).max(100).optional(),
+    customer_last_name: z.string().trim().max(100).optional(),
     contact_phone: z.string().min(5, 'Phone number is required'),
     contact_email: z.string().email().max(320).optional(),
     default_country_code: z.string().regex(/^\d{1,4}$/, 'default_country_code must be 1 to 4 digits').optional(),

--- a/src/app/api/table-bookings/route.ts
+++ b/src/app/api/table-bookings/route.ts
@@ -46,7 +46,7 @@ type NotificationChannelMeta = TableBookingNotificationChannel
 const CreateTableBookingSchema = z.object({
   phone: z.string().trim().min(7).max(32),
   first_name: z.string().trim().min(1).max(100).optional(),
-  last_name: z.string().trim().min(1).max(100).optional(),
+  last_name: z.string().trim().max(100).optional(),
   email: z.string().trim().email().max(320).optional(),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
   time: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/),
@@ -83,6 +83,7 @@ type TableBookingResponseData = {
     | 'too_large_party'
     | 'customer_conflict'
     | 'in_past'
+    | 'slot_full'
     | 'blocked'
     | null
   next_step_url: string | null
@@ -251,6 +252,8 @@ export async function POST(request: NextRequest) {
         // regular table-booking path.
         p_sunday_lunch: false,
         p_source: 'brand_site',
+        // Drinks do not use kitchen capacity.
+        p_bypass_pacing: payload.purpose === 'drinks',
         // High chairs are granted atomically inside the RPC (never via the
         // post-insert UPDATE below); outside bookings hold no indoor table.
         p_high_chair_count: payload.high_chair_count ?? 0,

--- a/src/lib/recruitment/communications.ts
+++ b/src/lib/recruitment/communications.ts
@@ -136,7 +136,7 @@ function formatSlotClock(value: Date, timeZone: string): string {
   const parts = new Intl.DateTimeFormat('en-GB', {
     hour: 'numeric',
     minute: '2-digit',
-    hour12: true,
+    hourCycle: 'h12',
     timeZone,
   }).formatToParts(value)
   const hour = parts.find(part => part.type === 'hour')?.value ?? ''

--- a/src/lib/sms/customers.ts
+++ b/src/lib/sms/customers.ts
@@ -274,11 +274,11 @@ export async function ensureCustomerForPhone(
       ? providedFirstName
       : 'Unknown'
 
-    // Keep fallbacks compatible with customer validation rules (letters/spaces/-/').
-    // Numeric placeholders (e.g. last 4 digits) break `/customers` updates.
+    // The database column is non-null, but an empty string correctly records
+    // that the customer chose not to provide a last name.
     const fallbackLastName = providedLastName
       ? providedLastName
-      : 'Guest'
+      : ''
 
     const insertPayload = {
       first_name: fallbackFirstName,

--- a/src/lib/table-bookings/bookings.ts
+++ b/src/lib/table-bookings/bookings.ts
@@ -184,6 +184,7 @@ export function mapTableBookingBlockedReason(reason?: string | null):
   | 'too_large_party'
   | 'customer_conflict'
   | 'in_past'
+  | 'slot_full'
   | 'blocked' {
   switch (reason) {
     case 'too_large_party':
@@ -198,6 +199,8 @@ export function mapTableBookingBlockedReason(reason?: string | null):
       return 'customer_conflict'
     case 'in_past':
       return 'in_past'
+    case 'slot_full':
+      return 'slot_full'
     case 'outside_hours':
     case 'hours_not_configured':
     case 'outside_service_window':

--- a/supabase/migrations/20260726000001_kitchen_pacing_gate_v06.sql
+++ b/supabase/migrations/20260726000001_kitchen_pacing_gate_v06.sql
@@ -431,8 +431,8 @@ BEGIN
   -- ===== KITCHEN PACING GATE (new) =====
   -- Seam: immediately after the no_table guard, before the deposit/status decision.
   -- Mirrors src/lib/table-bookings/kitchen-pacing.ts. Skips entirely when the caller
-  -- bypasses (walk-ins / manager override) or when the feature is disabled.
-  IF NOT COALESCE(p_bypass_pacing, false) THEN
+  -- is for drinks, bypasses (walk-ins / manager override), or the feature is disabled.
+  IF v_purpose = 'food' AND NOT COALESCE(p_bypass_pacing, false) THEN
     SELECT COALESCE((value ->> 'value')::boolean, false)
       INTO v_pacing_enabled
       FROM public.system_settings WHERE key = 'kitchen_pacing_enabled';

--- a/supabase/migrations/20260728000000_highchair_outside.sql
+++ b/supabase/migrations/20260728000000_highchair_outside.sql
@@ -514,8 +514,8 @@ BEGIN
   -- ===== KITCHEN PACING GATE =====
   -- Runs for inside AND outside bookings (outside food still paces the kitchen).
   -- Mirrors src/lib/table-bookings/kitchen-pacing.ts. Skips entirely when the caller
-  -- bypasses (walk-ins / manager override) or when the feature is disabled.
-  IF NOT COALESCE(p_bypass_pacing, false) THEN
+  -- is for drinks, bypasses (walk-ins / manager override), or the feature is disabled.
+  IF v_purpose = 'food' AND NOT COALESCE(p_bypass_pacing, false) THEN
     SELECT COALESCE((value ->> 'value')::boolean, false)
       INTO v_pacing_enabled
       FROM public.system_settings WHERE key = 'kitchen_pacing_enabled';

--- a/supabase/migrations/20260730000002_fix_drinks_kitchen_pacing.sql
+++ b/supabase/migrations/20260730000002_fix_drinks_kitchen_pacing.sql
@@ -1,0 +1,28 @@
+-- Kitchen pacing is food-only. Patch the existing function in place so this
+-- also fixes databases where the original pacing migration already ran.
+DO $migration$
+DECLARE
+  v_function oid := to_regprocedure(
+    'public.create_table_booking_v05(uuid,date,time without time zone,integer,text,text,boolean,text,boolean,boolean,boolean,integer,boolean)'
+  )::oid;
+  v_definition text;
+  v_old_guard constant text := 'IF NOT COALESCE(p_bypass_pacing, false) THEN';
+  v_new_guard constant text := 'IF v_purpose = ''food'' AND NOT COALESCE(p_bypass_pacing, false) THEN';
+BEGIN
+  IF v_function IS NULL THEN
+    RAISE EXCEPTION 'create_table_booking_v05 runtime function was not found';
+  END IF;
+
+  v_definition := pg_get_functiondef(v_function);
+
+  IF position(v_new_guard IN v_definition) > 0 THEN
+    RETURN;
+  END IF;
+
+  IF position(v_old_guard IN v_definition) = 0 THEN
+    RAISE EXCEPTION 'create_table_booking_v05 pacing guard was not found';
+  END IF;
+
+  EXECUTE replace(v_definition, v_old_guard, v_new_guard);
+END
+$migration$;

--- a/tests/api/tableBookingStructuredPersistence.test.ts
+++ b/tests/api/tableBookingStructuredPersistence.test.ts
@@ -187,6 +187,27 @@ describe('POST /api/table-bookings — structured persistence', () => {
     expect(supabase._tableBookingsUpdateEq).toHaveBeenCalledWith('id', BOOKING_ID)
   })
 
+  it('accepts an empty last name and bypasses kitchen pacing for drinks', async () => {
+    const supabase = buildSupabase()
+    ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
+
+    const response = await POST(buildRequest({
+      phone: '+447000000000',
+      first_name: 'Sam',
+      last_name: '',
+      date: '2026-04-24',
+      time: '19:00',
+      party_size: 4,
+      purpose: 'drinks',
+    }) as any)
+
+    expect(response.status).toBeLessThan(500)
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'create_table_booking_v05',
+      expect.objectContaining({ p_bypass_pacing: true }),
+    )
+  })
+
   // Sunday pre-order fields are now legacy input. The public POST path no
   // longer persists or validates those line items, regardless of flag value.
   it('does NOT call saveSundayPreorderByBookingId from the public POST path even with sunday_lunch=true', async () => {

--- a/tests/lib/smsCustomers.test.ts
+++ b/tests/lib/smsCustomers.test.ts
@@ -264,7 +264,7 @@ describe('ensureCustomerForPhone', () => {
     })
   })
 
-  it("uses a non-numeric placeholder last name when lastName is missing", async () => {
+  it('stores an empty last name when the customer does not provide one', async () => {
     const { client, inserts } = createSupabaseMock()
 
     await ensureCustomerForPhone(client, '07700900180', {
@@ -274,7 +274,7 @@ describe('ensureCustomerForPhone', () => {
     expect(inserts).toHaveLength(1)
     expect(inserts[0]).toMatchObject({
       first_name: 'Jane',
-      last_name: 'Guest'
+      last_name: ''
     })
   })
 

--- a/tests/lib/tableBookingKitchenPacingSql.test.ts
+++ b/tests/lib/tableBookingKitchenPacingSql.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('table booking kitchen pacing SQL', () => {
+  it('only applies the kitchen gate to food bookings', () => {
+    const latestRuntime = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260728000000_highchair_outside.sql'),
+      'utf8',
+    )
+    const livePatch = readFileSync(
+      join(process.cwd(), 'supabase/migrations/20260730000002_fix_drinks_kitchen_pacing.sql'),
+      'utf8',
+    )
+
+    expect(latestRuntime).toContain(
+      "IF v_purpose = 'food' AND NOT COALESCE(p_bypass_pacing, false) THEN",
+    )
+    expect(livePatch).toContain("v_new_guard constant text := 'IF v_purpose = ''food''")
+  })
+})

--- a/tests/lib/tableBookingRules.test.ts
+++ b/tests/lib/tableBookingRules.test.ts
@@ -6,6 +6,7 @@ describe('mapTableBookingBlockedReason', () => {
     expect(mapTableBookingBlockedReason('too_large_party')).toBe('too_large_party')
     expect(mapTableBookingBlockedReason('no_table')).toBe('no_table')
     expect(mapTableBookingBlockedReason('cut_off')).toBe('cut_off')
+    expect(mapTableBookingBlockedReason('slot_full')).toBe('slot_full')
   })
 
   it('maps hours-related reasons', () => {


### PR DESCRIPTION
## Summary

- make last name optional across booking, waitlist, and check-in flows
- stop drinks bookings being blocked by food-only kitchen pacing
- show a clear message when a food slot is full
- add a forward database migration and regression tests

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm test` (3,641 tests)
- `npm run build`
- `npx supabase db push --dry-run --include-all`
