### PR TITLE
Improve checklist staff defaults and breach alerts

### DIFF
--- a/src/app/(authenticated)/checklists/_components/ChecklistScreen.test.tsx
+++ b/src/app/(authenticated)/checklists/_components/ChecklistScreen.test.tsx
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { TodayChecklistResult } from '@/app/actions/checklists'
+import { ChecklistScreen } from './ChecklistScreen'
+
+const { getAttributionCandidatesMock } = vi.hoisted(() => ({
+  getAttributionCandidatesMock: vi.fn(),
+}))
+
+vi.mock('@/app/actions/checklists', () => ({
+  getAttributionCandidates: getAttributionCandidatesMock,
+  completeChecklistInstance: vi.fn(),
+  undoChecklistInstance: vi.fn(),
+}))
+
+const initial: TodayChecklistResult = {
+  businessDate: '2026-07-22',
+  moduleEnabled: true,
+  generationStatus: 'complete',
+  groups: [
+    {
+      checklistId: 'checklist-1',
+      checklistName: 'Opening',
+      department: 'bar',
+      sortOrder: 0,
+      tasks: [
+        {
+          id: 'task-1',
+          title: 'Open the till',
+          instruction: null,
+          slot: 'open',
+          department: 'bar',
+          requiresValue: false,
+          valueUnit: null,
+          valueMin: null,
+          valueMax: null,
+          dueAt: '2026-07-22T09:00:00.000Z',
+          graceUntil: '2026-07-22T09:30:00.000Z',
+          state: 'pending',
+          locked: false,
+          completedByEmployeeId: null,
+          completedByName: null,
+          completedAt: null,
+          wasLate: false,
+          valueRecorded: null,
+          valueBreach: false,
+          notes: null,
+        },
+      ],
+    },
+  ],
+}
+
+describe('ChecklistScreen attribution', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    getAttributionCandidatesMock.mockReset()
+  })
+
+  it('defaults to the most recent clock-in and still allows a manual change', async () => {
+    const user = userEvent.setup()
+    sessionStorage.setItem(
+      'checklist-identity',
+      JSON.stringify({ employeeId: 'previous', name: 'Previous Person' }),
+    )
+    getAttributionCandidatesMock.mockResolvedValue({
+      data: [
+        {
+          employeeId: 'older',
+          name: 'Older Clock-in',
+          clockedIn: true,
+          clockedInAt: '2026-07-22T08:00:00.000Z',
+          rostered: true,
+        },
+        {
+          employeeId: 'latest',
+          name: 'Latest Clock-in',
+          clockedIn: true,
+          clockedInAt: '2026-07-22T09:00:00.000Z',
+          rostered: true,
+        },
+      ],
+    })
+
+    render(<ChecklistScreen initial={initial} />)
+
+    expect(await screen.findByText('Latest Clock-in')).toBeInTheDocument()
+    expect(JSON.parse(sessionStorage.getItem('checklist-identity') ?? '{}')).toEqual({
+      employeeId: 'latest',
+      name: 'Latest Clock-in',
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Change' }))
+    await user.click(screen.getByRole('button', { name: /Older Clock-in/ }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Older Clock-in')).toBeInTheDocument()
+    })
+    expect(JSON.parse(sessionStorage.getItem('checklist-identity') ?? '{}')).toEqual({
+      employeeId: 'older',
+      name: 'Older Clock-in',
+    })
+  })
+})

--- a/src/app/(authenticated)/checklists/_components/ChecklistScreen.tsx
+++ b/src/app/(authenticated)/checklists/_components/ChecklistScreen.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Alert, Card, CardHeader, CardBody } from '@/ds'
 import { getAttributionCandidates } from '@/app/actions/checklists'
@@ -23,6 +23,7 @@ interface ChecklistScreenProps {
 export function ChecklistScreen({ initial, error }: ChecklistScreenProps) {
   const router = useRouter()
   const [identity, setIdentity] = useState<Identity | null>(null)
+  const identityChangedByUser = useRef(false)
   const [candidates, setCandidates] = useState<AttributionCandidate[]>([])
   const [candidatesLoading, setCandidatesLoading] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -55,7 +56,25 @@ export function ChecklistScreen({ initial, error }: ChecklistScreenProps) {
     getAttributionCandidates({ date: businessDate, department: firstDept })
       .then((res) => {
         if (!active) return
-        if (res.data) setCandidates(res.data)
+        if (res.data) {
+          setCandidates(res.data)
+
+          const latestClockIn = res.data.reduce<AttributionCandidate | null>((latest, candidate) => {
+            if (!candidate.clockedInAt) return latest
+            if (!latest?.clockedInAt || candidate.clockedInAt > latest.clockedInAt) return candidate
+            return latest
+          }, null)
+
+          if (latestClockIn && !identityChangedByUser.current) {
+            const next = { employeeId: latestClockIn.employeeId, name: latestClockIn.name }
+            setIdentity(next)
+            try {
+              sessionStorage.setItem(IDENTITY_KEY, JSON.stringify(next))
+            } catch {
+              /* sessionStorage unavailable, ignore */
+            }
+          }
+        }
         setCandidatesLoading(false)
       })
       .catch(() => {
@@ -67,6 +86,7 @@ export function ChecklistScreen({ initial, error }: ChecklistScreenProps) {
   }, [businessDate, firstDept])
 
   const chooseIdentity = useCallback((next: Identity) => {
+    identityChangedByUser.current = true
     setIdentity(next)
     try {
       sessionStorage.setItem(IDENTITY_KEY, JSON.stringify(next))

--- a/src/app/actions/checklists.ts
+++ b/src/app/actions/checklists.ts
@@ -10,6 +10,7 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { getChecklistSettings } from '@/lib/checklists/settings'
 import { getPublishedShiftsForDate } from '@/lib/checklists/rota'
 import { jobQueue } from '@/lib/unified-job-queue'
+import { buildValueBreachEmail } from '@/lib/checklists/value-breach-email'
 
 const TZ = 'Europe/London'
 
@@ -150,7 +151,9 @@ export async function completeChecklistInstance(input: {
   const db = createAdminClient()
   const { data: inst, error: fetchErr } = await db
     .from('checklist_task_instances')
-    .select('id, state, locked_at, grace_until, requires_value, value_min, value_max')
+    .select(
+      'id, state, locked_at, grace_until, requires_value, value_min, value_max, value_unit, title_snapshot, instruction_snapshot, department',
+    )
     .eq('id', input.instanceId)
     .maybeSingle()
   if (fetchErr) return { error: fetchErr.message }
@@ -203,7 +206,29 @@ export async function completeChecklistInstance(input: {
   })
 
   if (breach) {
-    const settings = await getChecklistSettings()
+    const [{ data: employee }, settings] = await Promise.all([
+      db
+        .from('employees')
+        .select('first_name, last_name')
+        .eq('employee_id', input.employeeId)
+        .maybeSingle(),
+      getChecklistSettings(),
+    ])
+    const completedByName = employee
+      ? [employee.first_name, employee.last_name].filter(Boolean).join(' ') || 'Team member'
+      : 'Team member'
+    const email = buildValueBreachEmail({
+      title: inst.title_snapshot as string,
+      instruction: (inst.instruction_snapshot as string | null) ?? null,
+      department: inst.department as string,
+      recordedValue: input.value ?? null,
+      valueUnit: (inst.value_unit as string | null) ?? null,
+      valueMin: (inst.value_min as number | string | null) ?? null,
+      valueMax: (inst.value_max as number | string | null) ?? null,
+      completedByName,
+      completedAt: now.toISOString(),
+      notes: input.notes ?? null,
+    })
     const to = process.env.CHECKLIST_MANAGER_EMAIL || 'manager@the-anchor.pub'
     const { error: outboxErr } = await db
       .from('checklist_email_outbox')
@@ -213,7 +238,8 @@ export async function completeChecklistInstance(input: {
         source_id: input.instanceId,
         idempotency_key: `value_breach:${input.instanceId}`,
         to_addresses: [to],
-        subject: 'The Anchor: a checklist reading is out of range',
+        subject: email.subject,
+        body_html: email.bodyHtml,
         status: settings.emailsEnabled ? 'pending' : 'held',
         next_attempt_at: now.toISOString(),
       })
@@ -311,6 +337,7 @@ export interface AttributionCandidate {
   employeeId: string
   name: string
   clockedIn: boolean
+  clockedInAt: string | null
   rostered: boolean
 }
 
@@ -329,7 +356,11 @@ export async function getAttributionCandidates(input: {
   if (error) return { error: error.message }
 
   const open = await getOpenSessions()
-  const clockedInIds = new Set(open.success ? open.data.map((s) => s.employee_id as string) : [])
+  const clockedInAtByEmployeeId = new Map(
+    open.success
+      ? open.data.map((session) => [session.employee_id as string, session.clock_in_at as string])
+      : [],
+  )
 
   const shifts = await getPublishedShiftsForDate(input.date)
   const rosteredIds = new Set(
@@ -339,7 +370,8 @@ export async function getAttributionCandidates(input: {
   const candidates: AttributionCandidate[] = (employees ?? []).map((e) => ({
     employeeId: e.employee_id as string,
     name: [e.first_name, e.last_name].filter(Boolean).join(' ') || 'Unknown',
-    clockedIn: clockedInIds.has(e.employee_id as string),
+    clockedIn: clockedInAtByEmployeeId.has(e.employee_id as string),
+    clockedInAt: clockedInAtByEmployeeId.get(e.employee_id as string) ?? null,
     rostered: rosteredIds.has(e.employee_id as string),
   }))
 

--- a/src/lib/checklists/__tests__/value-breach-email.test.ts
+++ b/src/lib/checklists/__tests__/value-breach-email.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { buildValueBreachEmail } from '@/lib/checklists/value-breach-email'
+
+describe('buildValueBreachEmail', () => {
+  it('explains an above-range reading in the subject and body', () => {
+    const email = buildValueBreachEmail({
+      title: 'Back bar fridge temperature',
+      instruction: 'Check the digital display',
+      department: 'bar',
+      recordedValue: 9,
+      valueUnit: '°C',
+      valueMin: 1,
+      valueMax: 5,
+      completedByName: 'Alex Smith',
+      completedAt: '2026-07-22T15:40:00.000Z',
+      notes: 'Door was left open',
+    })
+
+    expect(email.subject).toBe(
+      'Checklist alert: Back bar fridge temperature is above the limit (9°C)',
+    )
+    expect(email.bodyHtml).toContain('The recorded value of 9°C is above the maximum of 5°C.')
+    expect(email.bodyHtml).toContain('1°C to 5°C')
+    expect(email.bodyHtml).toContain('Alex Smith')
+    expect(email.bodyHtml).toContain('Wednesday, 22 July 2026 at 4:40 pm')
+    expect(email.bodyHtml).toContain('Door was left open')
+  })
+
+  it('escapes task and note text before adding it to the email HTML', () => {
+    const email = buildValueBreachEmail({
+      title: '<Freezer & cellar>',
+      instruction: null,
+      department: 'kitchen',
+      recordedValue: -5,
+      valueUnit: '°C',
+      valueMin: -2,
+      valueMax: null,
+      completedByName: 'Sam Jones',
+      completedAt: '2026-07-22T15:40:00.000Z',
+      notes: '<script>alert(1)</script>',
+    })
+
+    expect(email.bodyHtml).toContain('&lt;Freezer &amp; cellar&gt;')
+    expect(email.bodyHtml).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(email.bodyHtml).not.toContain('<script>')
+  })
+})

--- a/src/lib/checklists/value-breach-email.ts
+++ b/src/lib/checklists/value-breach-email.ts
@@ -1,0 +1,127 @@
+const LONDON_TIMEZONE = 'Europe/London'
+
+type Measurement = number | string | null
+
+export interface ValueBreachEmailInput {
+  title: string
+  instruction: string | null
+  department: string
+  recordedValue: Measurement
+  valueUnit: string | null
+  valueMin: Measurement
+  valueMax: Measurement
+  completedByName: string
+  completedAt: string
+  notes: string | null
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;',
+  })[character] as string)
+}
+
+function asNumber(value: Measurement): number | null {
+  if (value == null || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function measurementLabel(value: Measurement, unit: string | null): string {
+  const number = asNumber(value)
+  const valueLabel = number == null ? 'Not recorded' : String(number)
+  const cleanUnit = unit?.trim()
+  if (!cleanUnit) return valueLabel
+  const separator = /^[%°]/.test(cleanUnit) ? '' : ' '
+  return `${valueLabel}${separator}${cleanUnit}`
+}
+
+function rangeLabel(input: ValueBreachEmailInput): string {
+  if (input.valueMin != null && input.valueMax != null) {
+    return `${measurementLabel(input.valueMin, input.valueUnit)} to ${measurementLabel(input.valueMax, input.valueUnit)}`
+  }
+  if (input.valueMin != null) return `${measurementLabel(input.valueMin, input.valueUnit)} or above`
+  if (input.valueMax != null) return `${measurementLabel(input.valueMax, input.valueUnit)} or below`
+  return 'No range recorded'
+}
+
+function problemDetails(input: ValueBreachEmailInput): { summary: string; subjectState: string } {
+  const recorded = asNumber(input.recordedValue)
+  const min = asNumber(input.valueMin)
+  const max = asNumber(input.valueMax)
+  const recordedLabel = measurementLabel(input.recordedValue, input.valueUnit)
+
+  if (recorded != null && min != null && recorded < min) {
+    return {
+      summary: `The recorded value of ${recordedLabel} is below the minimum of ${measurementLabel(input.valueMin, input.valueUnit)}.`,
+      subjectState: 'is below the limit',
+    }
+  }
+  if (recorded != null && max != null && recorded > max) {
+    return {
+      summary: `The recorded value of ${recordedLabel} is above the maximum of ${measurementLabel(input.valueMax, input.valueUnit)}.`,
+      subjectState: 'is above the limit',
+    }
+  }
+  return {
+    summary: `The recorded value of ${recordedLabel} is outside the expected range.`,
+    subjectState: 'is out of range',
+  }
+}
+
+function completedAtLabel(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-GB', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: LONDON_TIMEZONE,
+  }).format(date)
+}
+
+export function buildValueBreachEmail(input: ValueBreachEmailInput): {
+  subject: string
+  bodyHtml: string
+} {
+  const problem = problemDetails(input)
+  const title = input.title.replace(/\s+/g, ' ').trim() || 'Checklist reading'
+  const recorded = measurementLabel(input.recordedValue, input.valueUnit)
+  const detailRows = [
+    ['Task', title],
+    ['Problem', problem.summary],
+    ['Recorded value', recorded],
+    ['Expected range', rangeLabel(input)],
+    ['Department', input.department || 'Not recorded'],
+    ['Completed by', input.completedByName],
+    ['Completed at', completedAtLabel(input.completedAt)],
+  ]
+
+  if (input.instruction) detailRows.push(['Instructions', input.instruction])
+  if (input.notes) detailRows.push(['Team note', input.notes])
+
+  const rowsHtml = detailRows
+    .map(([label, value]) => `<tr>
+      <td style="padding:8px 12px 8px 0;color:#666;vertical-align:top;white-space:nowrap">${escapeHtml(label)}</td>
+      <td style="padding:8px 0;font-weight:600;vertical-align:top">${escapeHtml(value)}</td>
+    </tr>`)
+    .join('')
+
+  return {
+    subject: `Checklist alert: ${title} ${problem.subjectState} (${recorded})`,
+    bodyHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:0 auto;color:#222">
+      <h2 style="margin-bottom:8px">Checklist reading needs attention</h2>
+      <p style="margin-top:0">${escapeHtml(problem.summary)}</p>
+      <table role="presentation" style="border-collapse:collapse;width:100%;margin:20px 0">${rowsHtml}</table>
+      <p>Please review this reading and take any needed action.</p>
+    </div>`,
+  }
+}


### PR DESCRIPTION
## What changed
- Default the checklist completer to the most recently clocked-in team member while keeping manual selection.
- Make out-of-range checklist emails explain the task, recorded value, expected range, person, time, instructions, and notes.
- Add focused regression tests.

## Why
The shared FOH checklist required unnecessary manual selection and breach emails did not explain the problem.

## Checks
- `npm run build`
- Focused Vitest tests
- ESLint
- TypeScript type check