### PR TITLE
Fix event revenue estimate per cover

### DIFF
--- a/src/lib/events/stats.test.ts
+++ b/src/lib/events/stats.test.ts
@@ -20,7 +20,7 @@ describe('event stats', () => {
       totalSeats: 6,
       capacity: 20,
       capacityPct: 30,
-      estimatedRevenue: 18,
+      estimatedRevenue: 150,
       totalLinkClicks: 5,
     })
   })
@@ -44,27 +44,25 @@ describe('event stats', () => {
     expect(stats.capacityPct).toBe(50)
   })
 
-  it('estimates revenue from booking charge totals when supplied, with event-price fallback', () => {
+  it('estimates venue revenue at £25 per booked seat', () => {
     const stats = buildEventBookingStats(
       { capacity: 20, price: 15, payment_mode: 'prepaid' },
       [
-        // Multi-type booking: charge comes from its booking_items sum
         { seats: 2, status: 'confirmed', is_reminder_only: false, charge_total: 23 },
-        // Legacy booking without items: event price × seats
         { seats: 2, status: 'confirmed', is_reminder_only: false },
       ]
     )
 
-    expect(stats.estimatedRevenue).toBe(53)
+    expect(stats.estimatedRevenue).toBe(100)
   })
 
-  it('estimates £0 revenue for free events', () => {
+  it('still estimates venue revenue for free events', () => {
     const stats = buildEventBookingStats(
       { capacity: 20, price: 0, is_free: true, payment_mode: 'free' },
       [{ seats: 4, status: 'confirmed', is_reminder_only: false }]
     )
 
-    expect(stats.estimatedRevenue).toBe(0)
+    expect(stats.estimatedRevenue).toBe(100)
   })
 
   it('uses split communal capacity before static capacity', () => {

--- a/src/lib/events/stats.ts
+++ b/src/lib/events/stats.ts
@@ -1,4 +1,4 @@
-import { resolveEventPriceAmount } from './pricing'
+const ESTIMATED_REVENUE_PER_BOOKED_SEAT = 25
 
 type EventLike = {
   capacity?: number | null
@@ -83,24 +83,13 @@ export function buildEventBookingStats(
   const capacity = resolveEventCapacity(event)
   const totalLinkClicks = links.reduce((sum, link) => sum + Math.max(0, Number(link.clickCount ?? 0)), 0)
 
-  // Estimated revenue: per-booking charge (sum of its booking_items) when the
-  // caller supplies it, otherwise the event's online price × seats. Free events
-  // are always £0 — no more hardcoded per-seat fiction.
-  const unitPrice = resolveEventPriceAmount(event)
-  const estimatedRevenue = activeBookings.reduce((sum, booking) => {
-    const chargeTotal = Number(booking.charge_total)
-    if (Number.isFinite(chargeTotal) && chargeTotal >= 0 && booking.charge_total !== null && booking.charge_total !== undefined) {
-      return sum + chargeTotal
-    }
-    return sum + unitPrice * Math.max(0, Number(booking.seats ?? 0))
-  }, 0)
-
   return {
     activeBookings: activeBookings.length,
     totalSeats,
     capacity,
     capacityPct: capacity && capacity > 0 ? Math.round((totalSeats / capacity) * 100) : null,
-    estimatedRevenue: Number(estimatedRevenue.toFixed(2)),
+    // Estimated total venue revenue per booked cover, not event ticket income.
+    estimatedRevenue: ESTIMATED_REVENUE_PER_BOOKED_SEAT * totalSeats,
     totalLinkClicks,
   }
 }


### PR DESCRIPTION
## What changed

- Estimate event revenue at £25 per active booked seat.
- Ignore ticket price, discounts, payment method, and free entry.
- Update event stats tests for paid and free events.

## Why

Estimated revenue represents expected total venue spend per person, not ticket income.

## Checks

- `npm test -- src/lib/events/stats.test.ts`
- ESLint on the changed files
- `npm run build` (with an 8 GB Node heap)
