### PR TITLE
Fix duplicate checklist alert emails

### DIFF
--- a/src/lib/checklists/__tests__/outbox.test.ts
+++ b/src/lib/checklists/__tests__/outbox.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runOutboxProcess } from '@/lib/checklists/jobs/outbox'
+
+type OutboxRow = Record<string, unknown> & {
+  id: string
+  status: string
+  next_attempt_at: string | null
+}
+
+type Filter = {
+  field: string
+  value: unknown
+}
+
+class FakeQuery {
+  private operation: 'select' | 'update' | 'upsert' | null = null
+  private patch: Record<string, unknown> | null = null
+  private filters: Filter[] = []
+  private maxRows: number | null = null
+
+  constructor(private readonly db: FakeOutboxDb) {}
+
+  select() {
+    if (!this.operation) this.operation = 'select'
+    return this
+  }
+
+  update(patch: Record<string, unknown>) {
+    this.operation = 'update'
+    this.patch = patch
+    return this
+  }
+
+  upsert() {
+    this.operation = 'upsert'
+    return this
+  }
+
+  eq(field: string, value: unknown) {
+    this.filters.push({ field, value })
+    return this
+  }
+
+  is(field: string, value: unknown) {
+    this.filters.push({ field, value })
+    return this
+  }
+
+  or() {
+    return this
+  }
+
+  order() {
+    return this
+  }
+
+  limit(value: number) {
+    this.maxRows = value
+    return this
+  }
+
+  maybeSingle() {
+    return this.execute().then(({ data, error }) => ({
+      data: Array.isArray(data) ? data[0] ?? null : data,
+      error,
+    }))
+  }
+
+  then<TResult1 = unknown, TResult2 = never>(
+    onfulfilled?: ((value: unknown) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ) {
+    return this.execute().then(onfulfilled, onrejected)
+  }
+
+  private matches(row: OutboxRow) {
+    return this.filters.every(({ field, value }) => row[field] === value)
+  }
+
+  private async execute(): Promise<{ data: OutboxRow[] | null; error: null }> {
+    if (this.operation === 'select') {
+      const rows = this.db.rows.filter((row) => this.matches(row))
+      const selected = this.maxRows == null ? rows : rows.slice(0, this.maxRows)
+      return this.db.releaseSelectTogether(selected.map((row) => ({ ...row })))
+    }
+
+    if (this.operation === 'update' && this.patch) {
+      const updated: OutboxRow[] = []
+      for (const row of this.db.rows) {
+        if (!this.matches(row)) continue
+        Object.assign(row, this.patch)
+        updated.push({ ...row })
+      }
+      return { data: updated, error: null }
+    }
+
+    return { data: null, error: null }
+  }
+}
+
+class FakeOutboxDb {
+  readonly rows: OutboxRow[]
+  private selectWaiters: Array<() => void> = []
+
+  constructor(row: OutboxRow) {
+    this.rows = [row]
+  }
+
+  from(table: string) {
+    if (table !== 'checklist_email_outbox') throw new Error(`Unexpected table: ${table}`)
+    return new FakeQuery(this)
+  }
+
+  async releaseSelectTogether(rows: OutboxRow[]): Promise<{ data: OutboxRow[]; error: null }> {
+    await new Promise<void>((resolve) => {
+      this.selectWaiters.push(resolve)
+      if (this.selectWaiters.length === 2) {
+        const waiters = this.selectWaiters.splice(0)
+        waiters.forEach((release) => release())
+      }
+    })
+    return { data: rows, error: null }
+  }
+}
+
+describe('runOutboxProcess', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends a pending row once when two outbox jobs process it concurrently', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-26T10:58:35.000Z'))
+
+    const db = new FakeOutboxDb({
+      id: 'outbox-1',
+      email_type: 'value_breach',
+      source_type: 'instance',
+      source_id: 'instance-1',
+      idempotency_key: 'value_breach:instance-1',
+      to_addresses: ['manager@example.com'],
+      subject: 'Checklist alert: Cellar Cooler is above the limit (15 degC)',
+      body_html: '<p>Alert</p>',
+      status: 'pending',
+      attempts: 0,
+      next_attempt_at: '2026-07-26T10:58:03.000Z',
+      created_at: '2026-07-26T10:58:03.000Z',
+    })
+    const send = vi.fn().mockResolvedValue({ success: true, messageId: 'message-1' })
+
+    const results = await Promise.all([
+      runOutboxProcess({ db: db as never, send }),
+      runOutboxProcess({ db: db as never, send }),
+    ])
+
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({
+      idempotencyKey: 'checklist:outbox-1',
+      commType: 'checklist_alert',
+    }))
+    expect(db.rows[0]).toMatchObject({ status: 'sent', message_id: 'message-1' })
+    expect(results.map((result) => result.sent).sort()).toEqual([0, 1])
+  })
+})

--- a/src/lib/checklists/jobs/outbox.ts
+++ b/src/lib/checklists/jobs/outbox.ts
@@ -10,13 +10,20 @@ import { sendEmail } from '@/lib/email/emailService'
 
 const MAX_ATTEMPTS = 5
 const BATCH_SIZE = 20
+const CLAIM_LEASE_MS = 10 * 60 * 1000
+
+type OutboxDependencies = {
+  db?: ReturnType<typeof createAdminClient>
+  send?: typeof sendEmail
+}
 
 function systemEmail(): string {
   return process.env.CHECKLIST_SYSTEM_EMAIL || 'peter@orangejelly.co.uk'
 }
 
-export async function runOutboxProcess(): Promise<Record<string, unknown>> {
-  const db = createAdminClient()
+export async function runOutboxProcess(dependencies: OutboxDependencies = {}): Promise<Record<string, unknown>> {
+  const db = dependencies.db ?? createAdminClient()
+  const send = dependencies.send ?? sendEmail
   const nowIso = new Date().toISOString()
 
   const { data: rows, error } = await db
@@ -31,18 +38,42 @@ export async function runOutboxProcess(): Promise<Record<string, unknown>> {
   let sent = 0
   let retried = 0
   let failed = 0
+  let claimed = 0
 
   for (const row of rows ?? []) {
-    const toAddresses = (row.to_addresses as string[] | null) ?? []
+    // Compare-and-swap next_attempt_at before sending. Concurrent processors can all read the
+    // same pending row, but only one can replace the exact value it read with this lease.
+    const previousNextAttemptAt = (row.next_attempt_at as string | null) ?? null
+    const claimUntil = new Date(Date.now() + CLAIM_LEASE_MS).toISOString()
+    let claimQuery = db
+      .from('checklist_email_outbox')
+      .update({ next_attempt_at: claimUntil })
+      .eq('id', row.id as string)
+      .eq('status', 'pending')
+    claimQuery = previousNextAttemptAt
+      ? claimQuery.eq('next_attempt_at', previousNextAttemptAt)
+      : claimQuery.is('next_attempt_at', null)
+    const { data: claimedRow, error: claimError } = await claimQuery.select('*').maybeSingle()
+    if (claimError) throw claimError
+    if (!claimedRow) continue
+    claimed += 1
+
+    const toAddresses = (claimedRow.to_addresses as string[] | null) ?? []
     let result: { success: boolean; error?: string; messageId?: string }
     try {
       const bodyHtml =
-        (row.body_html as string | null) ??
-        `<div style="font-family:sans-serif;max-width:600px;margin:0 auto">${row.subject}</div>`
-      result = await sendEmail({
+        (claimedRow.body_html as string | null) ??
+        `<div style="font-family:sans-serif;max-width:600px;margin:0 auto">${claimedRow.subject}</div>`
+      result = await send({
         to: toAddresses.join(', '),
-        subject: row.subject as string,
+        subject: claimedRow.subject as string,
         html: bodyHtml,
+        commType: 'checklist_alert',
+        idempotencyKey: `checklist:${claimedRow.id as string}`,
+        metadata: {
+          checklist_outbox_id: claimedRow.id as string,
+          checklist_idempotency_key: claimedRow.idempotency_key as string,
+        },
       })
     } catch (e) {
       // sendEmail is expected to return a result rather than throw, but guard defensively so a
@@ -51,37 +82,47 @@ export async function runOutboxProcess(): Promise<Record<string, unknown>> {
     }
 
     if (result.success) {
-      const { error: updErr } = await db
+      const { data: sentRow, error: updErr } = await db
         .from('checklist_email_outbox')
         .update({ status: 'sent', sent_at: new Date().toISOString(), message_id: result.messageId ?? null })
-        .eq('id', row.id as string)
+        .eq('id', claimedRow.id as string)
+        .eq('status', 'pending')
+        .eq('next_attempt_at', claimUntil)
+        .select('id')
+        .maybeSingle()
       if (updErr) throw updErr
+      if (!sentRow) throw new Error(`Checklist outbox claim lost after sending ${claimedRow.id as string}`)
       sent += 1
       continue
     }
 
-    const attempts = ((row.attempts as number | null) ?? 0) + 1
+    const attempts = ((claimedRow.attempts as number | null) ?? 0) + 1
     const errorMessage = result.error ?? 'unknown error'
 
     if (attempts >= MAX_ATTEMPTS) {
-      const { error: updErr } = await db
+      const { data: failedRow, error: updErr } = await db
         .from('checklist_email_outbox')
         .update({ status: 'failed', attempts, error_message: errorMessage })
-        .eq('id', row.id as string)
+        .eq('id', claimedRow.id as string)
+        .eq('status', 'pending')
+        .eq('next_attempt_at', claimUntil)
+        .select('id')
+        .maybeSingle()
       if (updErr) throw updErr
+      if (!failedRow) throw new Error(`Checklist outbox claim lost while failing ${claimedRow.id as string}`)
       failed += 1
 
       // Terminal-failure alert to Peter, once (distinct key). Skip when the dead row is itself
       // a dead-letter alert, so a mail outage cannot spawn an unbounded chain of alerts.
-      if (row.source_type !== 'outbox') {
+      if (claimedRow.source_type !== 'outbox') {
         const { error: alertErr } = await db.from('checklist_email_outbox').upsert(
           {
             email_type: 'system_alert',
             source_type: 'outbox',
-            source_id: row.id as string,
-            idempotency_key: `checklist_outbox_dead:${row.id as string}`,
+            source_id: claimedRow.id as string,
+            idempotency_key: `checklist_outbox_dead:${claimedRow.id as string}`,
             to_addresses: [systemEmail()],
-            subject: `Checklist email permanently failed: ${row.subject as string}`,
+            subject: `Checklist email permanently failed: ${claimedRow.subject as string}`,
             status: 'pending',
             next_attempt_at: new Date().toISOString(),
           },
@@ -95,13 +136,18 @@ export async function runOutboxProcess(): Promise<Record<string, unknown>> {
     // Exponential backoff: 2^attempts minutes until the next attempt.
     const backoffMinutes = 2 ** attempts
     const nextAttemptAt = new Date(Date.now() + backoffMinutes * 60 * 1000).toISOString()
-    const { error: updErr } = await db
+    const { data: retriedRow, error: updErr } = await db
       .from('checklist_email_outbox')
       .update({ attempts, next_attempt_at: nextAttemptAt, error_message: errorMessage })
-      .eq('id', row.id as string)
+      .eq('id', claimedRow.id as string)
+      .eq('status', 'pending')
+      .eq('next_attempt_at', claimUntil)
+      .select('id')
+      .maybeSingle()
     if (updErr) throw updErr
+    if (!retriedRow) throw new Error(`Checklist outbox claim lost while retrying ${claimedRow.id as string}`)
     retried += 1
   }
 
-  return { processed: (rows ?? []).length, sent, retried, failed }
+  return { candidates: (rows ?? []).length, processed: claimed, sent, retried, failed }
 }

--- a/src/lib/email/emailService.ts
+++ b/src/lib/email/emailService.ts
@@ -27,6 +27,7 @@ export interface EmailOptions {
   parkingBookingId?: string | null;
   invoiceId?: string | null;
   quoteId?: string | null;
+  idempotencyKey?: string;
 }
 
 export interface EmailAttachment {
@@ -182,7 +183,10 @@ async function sendEmailViaResend(options: EmailOptions): Promise<EmailSendResul
       resendPayload.text = '';
     }
 
-    const { data, error } = await client.emails.send(resendPayload as any);
+    const { data, error } = await client.emails.send(
+      resendPayload as any,
+      options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : undefined,
+    );
 
     if (error) {
       try {

--- a/src/lib/email/emailService.ts
+++ b/src/lib/email/emailService.ts
@@ -183,10 +183,9 @@ async function sendEmailViaResend(options: EmailOptions): Promise<EmailSendResul
       resendPayload.text = '';
     }
 
-    const { data, error } = await client.emails.send(
-      resendPayload as any,
-      options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : undefined,
-    );
+    const { data, error } = options.idempotencyKey
+      ? await client.emails.send(resendPayload as any, { idempotencyKey: options.idempotencyKey })
+      : await client.emails.send(resendPayload as any);
 
     if (error) {
       try {

--- a/tests/lib/emailService.resend.test.ts
+++ b/tests/lib/emailService.resend.test.ts
@@ -167,6 +167,31 @@ describe('sendEmail Resend provider', () => {
     expect(result).toEqual({ success: false, error: 'invalid from address' })
   })
 
+  it('passes an idempotency key to Resend when supplied', async () => {
+    mockAdminClient()
+    resendSend.mockResolvedValue({
+      data: { id: 'resend-email-idempotent' },
+      error: null,
+    })
+
+    const { sendEmail } = await import('@/lib/email/emailService')
+    const result = await sendEmail({
+      to: 'manager@example.com',
+      subject: 'Checklist alert',
+      text: 'Alert',
+      idempotencyKey: 'checklist:outbox-1',
+    })
+
+    expect(result).toEqual({ success: true, messageId: 'resend-email-idempotent' })
+    expect(resendSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'manager@example.com',
+        subject: 'Checklist alert',
+      }),
+      { idempotencyKey: 'checklist:outbox-1' },
+    )
+  })
+
   it('short-circuits suppressed recipients before calling Resend', async () => {
     mockAdminClient({ suppressed: true })
 


### PR DESCRIPTION
## What changed
- atomically lease each checklist outbox row before sending
- pass a stable idempotency key to Resend
- add a regression test for two concurrent outbox processors

## Why
Three checklist breach jobs could read and send the same pending rows in parallel, causing each alert to be delivered three times.

## Checks
- targeted checklist tests pass
- ESLint passes for changed files
- production Next.js build passes with an 8 GB Node heap