### PR TITLE
Clarify payroll rates and timeclock deletion

### DIFF
--- a/src/app/(authenticated)/rota/payroll/PayrollClient.tsx
+++ b/src/app/(authenticated)/rota/payroll/PayrollClient.tsx
@@ -115,6 +115,25 @@ function diffLabel(diff: number) {
   return `${diff > 0 ? '+' : ''}${diff.toFixed(1)}h`;
 }
 
+function PayRateDisplay({ row }: { row: PayrollRow }) {
+  if (row.hourlyRate == null) {
+    return <span className="font-medium text-amber-700">Not set</span>;
+  }
+
+  const premiumRate = (row.premiumHours ?? 0) > 0 ? row.effectiveRate : null;
+
+  return (
+    <div className="whitespace-nowrap">
+      <span className="font-semibold text-gray-900">£{row.hourlyRate.toFixed(2)}/hr</span>
+      {premiumRate != null && (
+        <span className="block text-[10px] font-medium text-purple-700">
+          Premium £{premiumRate.toFixed(2)}/hr
+        </span>
+      )}
+    </div>
+  );
+}
+
 function FlagChips({ flags, couldntWorkReason }: { flags: string; couldntWorkReason?: string | null }) {
   const parts = parsePayrollFlags(flags);
   if (!parts.length) return null;
@@ -437,6 +456,7 @@ export default function PayrollClient({
                   <th scope="col" className="text-right px-3 py-2 text-xs font-medium text-gray-500">Planned</th>
                   <th scope="col" className="text-right px-3 py-2 text-xs font-medium text-gray-500">Worked</th>
                   <th scope="col" className="text-right px-3 py-2 text-xs font-medium text-gray-500">Diff</th>
+                  <th scope="col" className="text-right px-3 py-2 text-xs font-medium text-gray-500">Pay rate</th>
                   <th scope="col" className="px-3 py-2 text-xs font-medium text-gray-500">Flags</th>
                   <th scope="col" className="px-3 py-2 w-16" />
                 </tr>
@@ -470,6 +490,7 @@ export default function PayrollClient({
                       <td className="px-3 py-2 text-right text-gray-700 font-medium">{dayPlanned.toFixed(1)}h</td>
                       <td className="px-3 py-2 text-right text-gray-700 font-medium">{dayActual > 0 ? `${dayActual.toFixed(1)}h` : '—'}</td>
                       <td className={`px-3 py-2 text-right text-xs ${diffColour(dayDiff)}`}>{dayActual > 0 ? diffLabel(dayDiff) : '—'}</td>
+                      <td className="px-3 py-2 text-right text-xs text-gray-300">—</td>
                       <td className="px-3 py-2">
                         {dayHasFlags && <span className="text-[10px] text-amber-600 font-medium">⚑ flagged</span>}
                       </td>
@@ -507,6 +528,9 @@ export default function PayrollClient({
                           </td>
                           <td className={`px-3 py-2 text-right text-xs ${row.actualHours != null ? diffColour(empDiff) : 'text-gray-300'}`}>
                             {row.actualHours != null ? diffLabel(empDiff) : '—'}
+                          </td>
+                          <td className="px-3 py-2 text-right text-xs">
+                            <PayRateDisplay row={row} />
                           </td>
                           <td className="px-3 py-2">
                             <FlagChips flags={row.flags} couldntWorkReason={row.sickReason} />
@@ -602,6 +626,9 @@ export default function PayrollClient({
                               />
                             </div>
                           </td>
+                          <td className="px-3 py-2 text-right text-xs">
+                            <PayRateDisplay row={row} />
+                          </td>
                           <td className="px-3 py-2" />
                           <td className="px-3 py-2">
                             <div className="flex items-center gap-1">
@@ -628,7 +655,7 @@ export default function PayrollClient({
                       const noteEditRow = editingNoteKey === rowKey && row.shiftId ? (
                         <tr key={`note-${rowKey}`} className="border-t border-amber-100 bg-amber-50">
                           <td className="px-3 py-2" />
-                          <td className="px-3 py-2 pl-8 text-xs text-gray-500" colSpan={4}>
+                          <td className="px-3 py-2 pl-8 text-xs text-gray-500" colSpan={5}>
                             <div className="flex items-center gap-2">
                               <span className="text-gray-500 shrink-0">Payroll note for <span className="font-medium text-gray-700">{row.employeeName}</span>:</span>
                               <input
@@ -679,6 +706,7 @@ export default function PayrollClient({
                   <td className={`px-3 py-2 text-right font-semibold text-sm ${diffColour(totalActual - totalPlanned)}`}>
                     {diffLabel(totalActual - totalPlanned)}
                   </td>
+                  <td className="px-3 py-2 text-right text-xs font-medium text-gray-500">Varies</td>
                   <td className="px-3 py-2" />
                   <td className="px-3 py-2" />
                 </tr>
@@ -699,9 +727,18 @@ export default function PayrollClient({
                 className="bg-white border border-gray-200 rounded-lg p-3 text-sm"
               >
                 <p className="font-semibold text-gray-900 truncate">{card.employeeName}</p>
-                {card.hourlyRate != null && (
-                  <p className="text-xs text-gray-400 mb-2">£{card.hourlyRate.toFixed(2)}/hr</p>
-                )}
+                <div className={`my-2 rounded-md border px-2.5 py-2 ${
+                  card.hourlyRate != null
+                    ? 'border-green-100 bg-green-50'
+                    : 'border-amber-100 bg-amber-50'
+                }`}>
+                  <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">Pay rate</p>
+                  <p className={`text-base font-bold ${
+                    card.hourlyRate != null ? 'text-green-800' : 'text-amber-700'
+                  }`}>
+                    {card.hourlyRate != null ? `£${card.hourlyRate.toFixed(2)} per hour` : 'Not set'}
+                  </p>
+                </div>
                 <div className="space-y-1 text-xs text-gray-600">
                   <div className="flex justify-between">
                     <span>Planned</span>

--- a/src/app/(authenticated)/rota/timeclock/TimeclockManager.tsx
+++ b/src/app/(authenticated)/rota/timeclock/TimeclockManager.tsx
@@ -14,8 +14,7 @@ import {
 import { createTimeclockSession, updateTimeclockSession, deleteTimeclockSession, approveTimeclockSession } from '@/app/actions/timeclock';
 import type { SessionPremiumInput, TimeclockSessionWithEmployee } from '@/app/actions/timeclock';
 import type { RotaEmployee } from '@/app/actions/rota';
-import { Badge } from '@/ds';
-import { Button } from '@/ds';
+import { Badge, Button, ConfirmDialog } from '@/ds';
 import { formatTime12Hour, parseLondonDateTimeLocalToIso } from '@/lib/dateUtils';
 
 // Premium rate presets offered in the review UI. 'custom' captures a bespoke
@@ -147,19 +146,16 @@ export default function TimeclockManager({
 
   // Delete state
   const [deletingId, setDeletingId] = useState<string | null>(null);
-  const [deletePending, startDeleteTransition] = useTransition();
+  const deletingSession = sessions.find(s => s.id === deletingId) ?? null;
 
-  const confirmDelete = (id: string) => setDeletingId(id);
-  const cancelDelete = () => setDeletingId(null);
+  const handleDelete = async () => {
+    if (!deletingId) return;
 
-  const handleDelete = (id: string) => {
-    startDeleteTransition(async () => {
-      const result = await deleteTimeclockSession(id, { allowPayrollApprove });
-      if (!result.success) { toast.error(result.error); return; }
-      toast.success('Session deleted');
-      setDeletingId(null);
-      setSessions(prev => prev.filter(s => s.id !== id));
-    });
+    const result = await deleteTimeclockSession(deletingId, { allowPayrollApprove });
+    if (!result.success) throw new Error(result.error);
+
+    toast.success('Session deleted');
+    setSessions(prev => prev.filter(s => s.id !== deletingId));
   };
 
   // Add entry state
@@ -648,28 +644,7 @@ export default function TimeclockManager({
 
                           {/* Actions */}
                           <td className="px-3 py-2">
-                            {deletingId === s.id ? (
-                              <div className="flex items-center gap-1.5">
-                                <span className="text-xs text-red-600 font-medium">Delete?</span>
-                                <button
-                                  type="button"
-                                  onClick={() => handleDelete(s.id)}
-                                  disabled={deletePending}
-                                  className="p-1 rounded text-red-600 hover:bg-red-50"
-                                  title="Confirm delete"
-                                >
-                                  <CheckIcon className="h-4 w-4" />
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={cancelDelete}
-                                  className="p-1 rounded text-gray-400 hover:bg-gray-100"
-                                  title="Cancel"
-                                >
-                                  <XMarkIcon className="h-4 w-4" />
-                                </button>
-                              </div>
-                            ) : isEditing ? (
+                            {isEditing ? (
                               <div className="flex gap-1">
                                 <button
                                   type="button"
@@ -712,7 +687,7 @@ export default function TimeclockManager({
                                 )}
                                 <button
                                   type="button"
-                                  onClick={() => confirmDelete(s.id)}
+                                  onClick={() => setDeletingId(s.id)}
                                   className="p-1 rounded text-gray-400 hover:text-red-600 hover:bg-red-50"
                                   title="Delete"
                                 >
@@ -731,6 +706,20 @@ export default function TimeclockManager({
           </table>
         </div>
       )}
+
+      <ConfirmDialog
+        open={deletingSession !== null}
+        onClose={() => setDeletingId(null)}
+        onConfirm={handleDelete}
+        title="Delete timeclock entry?"
+        message={
+          deletingSession
+            ? `Delete ${deletingSession.employee_name}'s timeclock entry for ${formatDayHeader(deletingSession.work_date)}? This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        tone="danger"
+      />
 
       <p className="text-xs text-gray-400">All times shown in Europe/London local time. Editing a session marks it as reviewed and clears the auto-close flag.</p>
     </div>

--- a/tests/components/PayrollClientPayRate.test.tsx
+++ b/tests/components/PayrollClientPayRate.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import PayrollClient from '@/app/(authenticated)/rota/payroll/PayrollClient'
+import type { PayrollRow } from '@/lib/rota/excel-export'
+
+vi.mock('@/app/actions/payroll', () => ({
+  approvePayrollMonth: vi.fn(),
+  sendPayrollEmail: vi.fn(),
+  updatePayrollPeriod: vi.fn(),
+  upsertShiftNote: vi.fn(),
+  updatePayrollRowTimes: vi.fn(),
+  deletePayrollRow: vi.fn(),
+}))
+
+const row: PayrollRow = {
+  employeeName: 'Amanda Jones',
+  employeeId: 'employee-1',
+  date: '2026-07-05',
+  department: 'bar',
+  plannedHours: 6,
+  actualHours: 6,
+  hourlyRate: 12.71,
+  totalPay: 85.79,
+  flags: '',
+  plannedStart: '16:00',
+  plannedEnd: '22:00',
+  actualStart: '16:00',
+  actualEnd: '22:00',
+  shiftId: 'shift-1',
+  sessionId: 'session-1',
+  note: null,
+  sessionNote: null,
+  standardHours: 5,
+  premiumHours: 1,
+  multiplier: 1.5,
+  effectiveRate: 19.07,
+  premiumReason: 'Late close',
+  premiumPay: 19.07,
+}
+
+describe('PayrollClient pay rates', () => {
+  it('shows base and premium rates clearly in the daily breakdown and summary', () => {
+    render(
+      <PayrollClient
+        year={2026}
+        month={7}
+        rows={[row]}
+        employees={[{
+          name: 'Amanda Jones',
+          plannedHours: 6,
+          actualHours: 6,
+          hourlyRate: 12.71,
+          totalPay: 85.79,
+        }]}
+        approval={null}
+        period={{
+          id: 'period-1',
+          year: 2026,
+          month: 7,
+          period_start: '2026-06-25',
+          period_end: '2026-07-24',
+        }}
+        canApprove={false}
+        canSend={false}
+        canExport={false}
+        monthOptions={[{ label: 'July 2026', value: '?year=2026&month=7' }]}
+      />,
+    )
+
+    expect(screen.getByRole('columnheader', { name: 'Pay rate' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+
+    const table = screen.getByRole('table')
+    expect(within(table).getByText('£12.71/hr')).toBeInTheDocument()
+    expect(within(table).getByText('Premium £19.07/hr')).toBeInTheDocument()
+    expect(screen.getByText('£12.71 per hour')).toBeInTheDocument()
+  })
+})

--- a/tests/components/TimeclockManager.test.tsx
+++ b/tests/components/TimeclockManager.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TimeclockManager from '@/app/(authenticated)/rota/timeclock/TimeclockManager'
+import type { TimeclockSessionWithEmployee } from '@/app/actions/timeclock'
+
+const actionMocks = vi.hoisted(() => ({
+  createTimeclockSession: vi.fn(),
+  updateTimeclockSession: vi.fn(),
+  deleteTimeclockSession: vi.fn(),
+  approveTimeclockSession: vi.fn(),
+}))
+
+vi.mock('@/app/actions/timeclock', () => actionMocks)
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const session: TimeclockSessionWithEmployee = {
+  id: 'session-1',
+  employee_id: 'employee-1',
+  employee_name: 'Amanda Jones',
+  work_date: '2026-07-27',
+  clock_in_at: '2026-07-27T14:52:00.000Z',
+  clock_out_at: null,
+  clock_in_local: '15:52',
+  clock_out_local: null,
+  linked_shift_id: null,
+  planned_start: '16:00',
+  planned_end: '22:00',
+  is_unscheduled: false,
+  is_auto_close: false,
+  auto_close_reason: null,
+  is_reviewed: false,
+  notes: null,
+  manager_note: null,
+  rate_multiplier: null,
+  rate_override: null,
+  premium_reason: null,
+  premium_start_at: null,
+  premium_end_at: null,
+  premium_start_local: null,
+  premium_end_local: null,
+  shift_rate_multiplier: null,
+  shift_rate_override: null,
+  shift_premium_reason: null,
+  shift_premium_start_time: null,
+  shift_premium_end_time: null,
+  created_at: '2026-07-27T14:52:00.000Z',
+  updated_at: '2026-07-27T14:52:00.000Z',
+}
+
+describe('TimeclockManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    actionMocks.deleteTimeclockSession.mockResolvedValue({ success: true })
+  })
+
+  it('asks for confirmation before deleting a session', async () => {
+    render(
+      <TimeclockManager
+        sessions={[session]}
+        employees={[]}
+        periodStart="2026-07-25"
+        periodEnd="2026-08-24"
+        year={2026}
+        month={8}
+        monthOptions={[{ label: 'August 2026', value: '?year=2026&month=8' }]}
+        allowPayrollApprove={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByTitle('Delete'))
+
+    expect(actionMocks.deleteTimeclockSession).not.toHaveBeenCalled()
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText("Delete Amanda Jones's timeclock entry for Monday 27 July? This cannot be undone.")).toBeInTheDocument()
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(actionMocks.deleteTimeclockSession).toHaveBeenCalledWith('session-1', {
+        allowPayrollApprove: false,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## What changed

- Replace the small inline timeclock delete prompt with a clear confirmation dialog.
- Add a dedicated pay-rate column to the payroll daily breakdown.
- Highlight each employee's pay rate in the payroll summary.
- Show premium rates alongside base rates where relevant.

## Why

Managers need a clear safeguard before deleting timeclock entries and an easy way to verify pay rates during payroll review.

## Checks

- Production build
- Focused component tests
- ESLint
- TypeScript
