### PR TITLE
fix(api): make offers.validFrom stable instead of stamping it per request

### DIFF
--- a/src/lib/api/schema.test.ts
+++ b/src/lib/api/schema.test.ts
@@ -37,3 +37,46 @@ describe('eventToSchema', () => {
     expect(schema.startDate).toBe('2026-07-17T18:00:00.000Z')
   })
 })
+
+describe('eventToSchema offers.validFrom', () => {
+  const baseEvent = {
+    id: 'event-3',
+    name: 'Music Bingo',
+    slug: 'music-bingo-2026-07-17',
+    date: '2026-07-17',
+    time: '19:00',
+    start_datetime: '2026-07-17T18:00:00+00:00',
+    event_status: 'scheduled',
+    price: 5,
+    is_free: false,
+  }
+
+  it('uses the event creation time, so it is stable across requests', () => {
+    const schema = eventToSchema({ ...baseEvent, created_at: '2026-05-02T09:15:00+00:00' })
+    expect(schema.offers?.validFrom).toBe('2026-05-02T09:15:00.000Z')
+  })
+
+  it('returns the same value on repeated calls', () => {
+    // Regression guard. validFrom used to be new Date().toISOString(), so the
+    // website served a different value on every crawl of the same event and
+    // the field told search engines nothing.
+    const a = eventToSchema({ ...baseEvent, created_at: '2026-05-02T09:15:00+00:00' })
+    const b = eventToSchema({ ...baseEvent, created_at: '2026-05-02T09:15:00+00:00' })
+    expect(a.offers?.validFrom).toBe(b.offers?.validFrom)
+  })
+
+  it('omits validFrom rather than guessing when created_at is missing', () => {
+    const schema = eventToSchema(baseEvent)
+    expect(schema.offers?.validFrom).toBeUndefined()
+  })
+
+  it('omits validFrom when created_at is unparseable', () => {
+    const schema = eventToSchema({ ...baseEvent, created_at: 'not-a-date' })
+    expect(schema.offers?.validFrom).toBeUndefined()
+  })
+
+  it('never emits a validFrom at or after the current moment for a past event', () => {
+    const schema = eventToSchema({ ...baseEvent, created_at: '2026-05-02T09:15:00+00:00' })
+    expect(new Date(schema.offers!.validFrom!).getTime()).toBeLessThan(Date.now())
+  })
+})

--- a/src/lib/api/schema.ts
+++ b/src/lib/api/schema.ts
@@ -193,6 +193,18 @@ function createOrganizer(): SchemaOrganization {
   };
 }
 
+/**
+ * Normalise a stored timestamp to an ISO string, or undefined when it is
+ * missing or unparseable. Used for schema fields that must be stable across
+ * requests: emitting nothing beats emitting a value that changes on every
+ * crawl or a date that is simply wrong.
+ */
+function toIsoOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== 'string' && !(value instanceof Date)) return undefined;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}
+
 // Convert database event to Schema.org format
 export function eventToSchema(event: any, faqs?: any[]): SchemaEvent {
   const storedStart = event.start_datetime ? new Date(event.start_datetime) : null;
@@ -252,7 +264,13 @@ export function eventToSchema(event: any, faqs?: any[]): SchemaEvent {
       price: offerPrice.toString(),
       priceCurrency: 'GBP',
       availability,
-      validFrom: new Date().toISOString(),
+      // When the offer became available, which for us is when the event was
+      // created. This used to be new Date(), so every crawl of the same event
+      // saw a different validFrom and the field carried no information at all.
+      // Omitted rather than guessed when created_at is missing: Google treats
+      // validFrom as recommended, not required, and a wrong date is worse than
+      // an absent one.
+      validFrom: toIsoOrUndefined(event.created_at),
     },
     organizer: createOrganizer(),
     isAccessibleForFree: event.is_free === true,


### PR DESCRIPTION
## What changed

`eventToSchema` set `validFrom: new Date().toISOString()` on every `Offer`, so the same event returned a different `validFrom` on every request. It now uses the event's `created_at`, and omits the field entirely when that is missing or unparseable.

## Why

Google treats `offers.validFrom` as the date and time tickets go on sale. A value regenerated on every read carries no information, and it made every crawl of an unchanged event look like a change.

This surfaced while fixing the paired website repo. `/events/music-bingo-2026-07-17` was telling visitors "This event has ended" while its markup advertised `availability: InStock` with a `validFrom` stamped at the moment of the crawl. The website side now omits offers on past events entirely, which hides the symptom, but the churning timestamp was still wrong on upcoming events, which are the ones that matter.

`created_at` is when the offer actually came into existence and is stable for the life of the event. Where it is absent the field is dropped rather than guessed: `validFrom` is recommended, not required, and a wrong date is worse than an absent one.

## Testing done

- [x] Automated tests: 5 new cases in `src/lib/api/schema.test.ts` covering the created_at mapping, stability across repeated calls, omission when `created_at` is missing, omission when unparseable, and that a past event never emits a future `validFrom`. 7 passing in that file.
- [x] `npx tsc --noEmit` clean for the changed files.
- [x] Traced the three consumers: `/api/events`, `/api/events/[id]` and `/api/events/today`. All select `*`, so `created_at` is present.

## Assumptions

- `created_at` is a reasonable proxy for "tickets went on sale". There is no dedicated on-sale column on `events`. If one is added later, this is the single place to change.

## Complexity score

XS

## Breaking changes

None. `validFrom` is now absent on events with no `created_at`, where it previously carried a meaningless timestamp.

## Migration risk

None. No schema or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)