### PR TITLE
fix(api): stop every endpoint returning the same ETag

### DIFF
--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -203,11 +203,23 @@ export function createApiResponse(
     ...headers,
   }
 
-  // Only include ETag for cacheable responses
+  // Only include ETag for cacheable responses.
+  //
+  // This used to base64 the payload and keep the first 27 characters. 27 base64
+  // characters cover about 20 bytes, and the payload is normalised just above
+  // to `{ success: true, data }`, so those bytes were always the literal
+  // `{"success":true,"dat`. Every endpoint therefore returned the same ETag,
+  // and a client honouring If-None-Match could ask for /api/menu carrying an
+  // ETag it got from /api/events and be told 304 Not Modified, then serve the
+  // wrong cached body. Verified against production before changing it.
+  //
+  // Hashing the whole payload matches the pattern already used correctly in
+  // src/app/api/portal/calendar-feed/route.ts.
   if (isGet) {
-    responseHeaders['ETag'] = `"${Buffer.from(JSON.stringify(payload))
-      .toString('base64')
-      .slice(0, 27)}"`
+    responseHeaders['ETag'] = `"${createHash('sha256')
+      .update(JSON.stringify(payload))
+      .digest('hex')
+      .slice(0, 32)}"`
   }
 
   return NextResponse.json(payload, {

--- a/src/lib/api/etag.test.ts
+++ b/src/lib/api/etag.test.ts
@@ -1,0 +1,60 @@
+/**
+ * ETag correctness for the public API.
+ *
+ * Regression guard for a live bug: createApiResponse built the validator as
+ * `Buffer.from(JSON.stringify(payload)).toString('base64').slice(0, 27)`.
+ * 27 base64 characters cover roughly the first 20 bytes, and the payload is
+ * normalised to `{ success: true, data }`, so those bytes were always the
+ * literal `{"success":true,"dat`.
+ *
+ * Every endpoint returned the identical ETag. Verified against production:
+ * /api/events, /api/menu and /api/business/hours all returned
+ * W/"eyJzdWNjZXNzIjp0cnVlLCJkYXR", and sending the events ETag to /api/menu
+ * with If-None-Match returned 304 Not Modified. A client honouring that would
+ * serve the wrong cached body.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { createApiResponse } from './auth'
+
+function etagOf(data: unknown, method = 'GET'): string | null {
+  return createApiResponse(data, 200, {}, method).headers.get('ETag')
+}
+
+describe('createApiResponse ETag', () => {
+  it('differs between two different payloads', () => {
+    const events = etagOf({ events: [{ id: 'a', name: 'Quiz Night' }] })
+    const menu = etagOf({ menu: [{ id: 'b', name: 'Burger' }] })
+    expect(events).not.toBeNull()
+    expect(events).not.toBe(menu)
+  })
+
+  it('is identical for identical payloads', () => {
+    const a = etagOf({ events: [{ id: 'a' }] })
+    const b = etagOf({ events: [{ id: 'a' }] })
+    expect(a).toBe(b)
+  })
+
+  it('changes when a nested value deep in the payload changes', () => {
+    // The old implementation could not see past the envelope prefix, so any
+    // change below the first ~20 bytes was invisible to it.
+    const before = etagOf({ events: [{ id: 'a', name: 'Quiz Night', price: 3 }] })
+    const after = etagOf({ events: [{ id: 'a', name: 'Quiz Night', price: 5 }] })
+    expect(before).not.toBe(after)
+  })
+
+  it('never emits the constant envelope-prefix validator again', () => {
+    const tag = etagOf({ anything: true })
+    expect(tag).not.toContain('eyJzdWNjZXNzIjp0cnVlLCJkYXR')
+  })
+
+  it('is a 32-character hex hash', () => {
+    const tag = etagOf({ events: [] })
+    expect(tag).toMatch(/^"[0-9a-f]{32}"$/)
+  })
+
+  it('is only set on cacheable methods', () => {
+    expect(etagOf({ ok: true }, 'GET')).not.toBeNull()
+    expect(etagOf({ ok: true }, 'POST')).toBeNull()
+  })
+})


### PR DESCRIPTION
## What changed

`createApiResponse` now hashes the full payload with sha256 instead of base64-ing it and keeping 27 characters.

## Why

27 base64 characters cover roughly the first 20 bytes. The payload is normalised two lines earlier to `{ success: true, data }`, so those bytes were always the literal `{"success":true,"dat`. Every cacheable GET on the API returned the same ETag, and it never changed when the content did.

Confirmed against production before changing anything:

```
/api/events?limit=1    200  ETag=W/"eyJzdWNjZXNzIjp0cnVlLCJkYXR"
/api/events?limit=5    200  ETag=W/"eyJzdWNjZXNzIjp0cnVlLCJkYXR"
/api/business/hours    200  ETag=W/"eyJzdWNjZXNzIjp0cnVlLCJkYXR"
/api/menu              200  ETag=W/"eyJzdWNjZXNzIjp0cnVlLCJkYXR"
```

Then, sending the ETag obtained from `/api/events` to `/api/menu` as `If-None-Match`:

```
-> 304 Not Modified
```

A client honouring that gets told the menu is unchanged on the strength of an events validator, and serves whatever it had cached. That is the bug worth fixing: it is wrong across unrelated resources, not merely inefficient.

## Testing done

- [x] New `src/lib/api/etag.test.ts`, 6 cases: different payloads differ, identical payloads match, a nested change deep in the payload is detected (the old one could not see past the envelope), the constant prefix can never reappear, the shape is 32 hex chars, and non-GET methods still get no ETag.
- [x] Full suite: 4584 passing, 610 files.
- [x] `tsc --noEmit` clean for the changed files.

## Assumptions

- Most GET payloads still carry `lastUpdated: new Date().toISOString()`, so the hash differs per request and real 304s will stay rare until those are made stable. That is a caching-efficiency question with a consumer-contract angle, so it is deliberately not bundled here. This commit fixes correctness only.

## Complexity score

XS

## Breaking changes

ETag values change shape, from a weak base64 prefix to a 32-character hex hash. Any client that cached the old constant validator gets one clean revalidation.

## Migration risk

Low. Strictly fewer false 304s than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)