### PR TITLE
feat: text guests the day before to ask whether they are still coming

### DIFF
--- a/src/app/api/cron/table-booking-confirm/route.ts
+++ b/src/app/api/cron/table-booking-confirm/route.ts
@@ -1,0 +1,203 @@
+/**
+ * Texting a guest the day before to ask whether they are still coming.
+ *
+ * WHY THIS EXISTS: 21% of table bookings in the ninety days to 9 August 2026 never
+ * happened. 52 cancelled and 12 no-shows out of 308, and every no-show came from a
+ * website booking. Nothing chased any of them.
+ *
+ * IT DOES NOT CANCEL ANYTHING. A guest who does not answer keeps their table and appears
+ * in `table_bookings_awaiting_confirmation` for staff to ring, which is exactly how the
+ * pub already handles an unfinished pre-order. Auto-release is a separate decision that
+ * should not be taken until there is a real tap rate to look at, because twelve no-shows
+ * a quarter does not justify wrongly cancelling even one genuine booking.
+ *
+ * WHO GETS ONE IS NOT DECIDED HERE. `decideConfirmReminder` owns that, so the rule can be
+ * tested without a database, a clock or Twilio. This route loads, asks, claims and sends.
+ *
+ * THE LEDGER IS THE IDEMPOTENCY. `table_booking_confirm_reminders` is unique on
+ * table_booking_id and the row is claimed BEFORE the send, so two crons racing or one
+ * running twice both lose at the database and send nothing. A claimed row is never rolled
+ * back on a failed send: deleting it to retry would turn an ambiguous failure (text
+ * delivered, log write did not) into a second text to the guest.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { authorizeCronRequest } from '@/lib/cron-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+import { reportCronFailure } from '@/lib/cron/alerting'
+import { jobQueue } from '@/lib/unified-job-queue'
+import { createBookingConfirmToken } from '@/lib/table-bookings/manage-booking'
+import { formatDateWithTimeForSms, getLocalIsoDateDaysAhead, getTodayIsoDate } from '@/lib/dateUtils'
+import {
+  buildConfirmReminderMessage,
+  CONFIRMABLE_BOOKING_STATUSES,
+  decideConfirmReminder,
+  type ConfirmCandidate,
+} from '@/lib/table-bookings/confirm-reminder'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+/** A runaway guard, not a page size. A busy Sunday is a few dozen bookings. */
+const MAX_BOOKINGS_PER_RUN = 300
+
+type BookingRow = {
+  id: string
+  booking_reference: string
+  booking_date: string
+  booking_time: string | null
+  party_size: number | null
+  status: string
+  guest_confirmed_at: string | null
+  customer_id: string | null
+  customers: {
+    id: string
+    first_name: string | null
+    mobile_e164: string | null
+    mobile_number: string | null
+    sms_status: string | null
+  } | null
+}
+
+export async function GET(request: NextRequest) {
+  const auth = authorizeCronRequest(request)
+  if (!auth.authorized) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createAdminClient()
+  // Europe/London throughout, via the project's own date helpers. A booking stored as
+  // 2026-08-10 means that date in the pub, and deriving "tomorrow" from the server's UTC
+  // clock would skip or double a day either side of midnight.
+  const todayIsoDate = getTodayIsoDate()
+  const tomorrowIsoDate = getLocalIsoDateDaysAhead(1)
+  const counts = { considered: 0, sent: 0, skipped: 0, failed: 0 }
+  const skipReasons: Record<string, number> = {}
+
+  try {
+    const { data: bookings, error: bookingsError } = await supabase
+      .from('table_bookings')
+      .select(
+        'id, booking_reference, booking_date, booking_time, party_size, status, guest_confirmed_at, customer_id, customers(id, first_name, mobile_e164, mobile_number, sms_status)',
+      )
+      .in('status', CONFIRMABLE_BOOKING_STATUSES as unknown as string[])
+      .is('guest_confirmed_at', null)
+      .eq('booking_date', tomorrowIsoDate)
+      .limit(MAX_BOOKINGS_PER_RUN)
+
+    if (bookingsError) throw bookingsError
+
+    const rows = (bookings ?? []) as unknown as BookingRow[]
+    counts.considered = rows.length
+
+    if (rows.length === 0) {
+      return NextResponse.json({ success: true, ...counts })
+    }
+
+    const { data: ledgerRows, error: ledgerError } = await supabase
+      .from('table_booking_confirm_reminders')
+      .select('table_booking_id')
+      .in(
+        'table_booking_id',
+        rows.map((row) => row.id),
+      )
+
+    if (ledgerError) throw ledgerError
+    const alreadySent = new Set((ledgerRows ?? []).map((row) => row.table_booking_id as string))
+
+    for (const row of rows) {
+      const candidate: ConfirmCandidate = {
+        id: row.id,
+        bookingReference: row.booking_reference,
+        status: row.status,
+        bookingDate: row.booking_date,
+        guestConfirmedAt: row.guest_confirmed_at,
+        reminderAlreadySent: alreadySent.has(row.id),
+        customer: row.customers
+          ? {
+              id: row.customers.id,
+              firstName: row.customers.first_name,
+              phone: row.customers.mobile_e164 || row.customers.mobile_number || null,
+              smsActive: row.customers.sms_status === 'active',
+            }
+          : null,
+      }
+
+      const decision = decideConfirmReminder(candidate, todayIsoDate)
+      if (!decision.send) {
+        counts.skipped += 1
+        skipReasons[decision.reason] = (skipReasons[decision.reason] ?? 0) + 1
+        continue
+      }
+
+      // CLAIM FIRST. A duplicate key here means another run already has this booking, and
+      // losing that race must be silent rather than an error.
+      const { error: claimError } = await supabase
+        .from('table_booking_confirm_reminders')
+        .insert({ table_booking_id: row.id })
+
+      if (claimError) {
+        counts.skipped += 1
+        skipReasons.claimed_by_another_run = (skipReasons.claimed_by_another_run ?? 0) + 1
+        continue
+      }
+
+      try {
+        const token = await createBookingConfirmToken(supabase, {
+          customerId: candidate.customer!.id,
+          tableBookingId: row.id,
+          bookingStartIso: `${row.booking_date}T${row.booking_time || '00:00'}:00`,
+          appBaseUrl: process.env.NEXT_PUBLIC_APP_URL,
+        })
+
+        const message = buildConfirmReminderMessage({
+          firstName: candidate.customer!.firstName,
+          bookingMoment: formatDateWithTimeForSms(row.booking_date, row.booking_time),
+          partySize: row.party_size,
+          confirmUrl: token.url,
+        })
+
+        // No `unique` key on the enqueue: the ledger row above is the idempotency, and a
+        // second mechanism would only add a lock round trip and another way to disagree.
+        const enqueued = await jobQueue.enqueue('send_sms', {
+          to: candidate.customer!.phone,
+          message,
+          customer_id: candidate.customer!.id,
+          booking_id: row.id,
+          metadata: {
+            table_booking_id: row.id,
+            template_key: 'table_booking_confirm_reminder',
+          },
+        })
+
+        if (!enqueued.success) {
+          throw new Error(enqueued.error || 'Failed to queue the confirmation SMS')
+        }
+
+        counts.sent += 1
+      } catch (sendError) {
+        // The ledger row STAYS. See the header: retrying an ambiguous failure is how a
+        // guest gets texted twice, and the pub rings anyone this sweep could not reach.
+        counts.failed += 1
+        logger.error('Failed to send a table booking confirm reminder', {
+          metadata: {
+            tableBookingId: row.id,
+            bookingReference: row.booking_reference,
+            error: sendError instanceof Error ? sendError.message : String(sendError),
+          },
+        })
+      }
+    }
+
+    logger.info('Table booking confirm reminders swept', { metadata: { ...counts, skipReasons } })
+    return NextResponse.json({ success: true, ...counts, skipReasons })
+  } catch (error) {
+    logger.error('Table booking confirm reminder cron failed', {
+      metadata: { error: error instanceof Error ? error.message : String(error) },
+    })
+    await reportCronFailure('table-booking-confirm', error)
+    return NextResponse.json({ error: 'Cron failed' }, { status: 500 })
+  }
+}

--- a/src/app/g/[token]/confirm-booking/action/route.ts
+++ b/src/app/g/[token]/confirm-booking/action/route.ts
@@ -1,0 +1,117 @@
+/**
+ * The guest's answer to "are you still coming?".
+ *
+ * POST, never GET, and that is the whole reason this route exists separately from the
+ * page. Some carriers and messaging apps prefetch links in an SMS. A GET that confirmed
+ * the booking would record "yes" for a guest who never opened the text, which turns the
+ * one signal this feature exists to produce into noise, and makes the call list wrong in
+ * the one direction that costs the pub a table.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
+import { checkGuestTokenThrottle } from '@/lib/guest/token-throttle'
+import { isAnswerable, lookupConfirmToken } from '@/lib/table-bookings/confirm-token'
+import { updateTableBookingByRawToken } from '@/lib/table-bookings/manage-booking'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+type RouteContext = {
+  params: Promise<{ token: string }>
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const { token } = await context.params
+  const supabase = createAdminClient()
+
+  const throttle = await checkGuestTokenThrottle({
+    request,
+    rawToken: token,
+    scope: 'guest_booking_confirm',
+    maxAttempts: 40,
+  })
+
+  if (!throttle.allowed) {
+    return NextResponse.redirect(new URL(`/g/${token}/confirm-booking?state=busy`, request.url), {
+      status: 303,
+    })
+  }
+
+  const form = await request.formData()
+  const answer = String(form.get('answer') || '')
+
+  const lookup = await lookupConfirmToken(supabase, token)
+  if (!lookup.ok) {
+    return NextResponse.redirect(
+      new URL(`/g/${token}/confirm-booking?state=${lookup.reason}`, request.url),
+      { status: 303 },
+    )
+  }
+
+  if (!isAnswerable(lookup.booking.status)) {
+    return NextResponse.redirect(
+      new URL(`/g/${token}/confirm-booking?state=not_answerable`, request.url),
+      { status: 303 },
+    )
+  }
+
+  if (answer === 'yes') {
+    // Idempotent by construction: a second tap writes the same column again and the guest
+    // sees the same page. Messaging apps retry POSTs, and a guest who is unsure often taps
+    // twice, so a duplicate must be uneventful rather than an error.
+    const { error } = await supabase
+      .from('table_bookings')
+      .update({ guest_confirmed_at: new Date().toISOString() })
+      .eq('id', lookup.booking.id)
+
+    if (error) {
+      logger.error('Failed to record a guest booking confirmation', {
+        metadata: { tableBookingId: lookup.booking.id, error: error.message },
+      })
+      return NextResponse.redirect(
+        new URL(`/g/${token}/confirm-booking?state=error`, request.url),
+        { status: 303 },
+      )
+    }
+
+    return NextResponse.redirect(
+      new URL(`/g/${token}/confirm-booking?state=confirmed`, request.url),
+      { status: 303 },
+    )
+  }
+
+  if (answer === 'no') {
+    // Cancelling goes through the existing guest cancel path rather than writing the
+    // status here. That path owns freeing the table, the audit row and the cancellation
+    // message; a second implementation would drift from it and silently stop releasing
+    // capacity, which is the opposite of what this feature is for.
+    try {
+      await updateTableBookingByRawToken(supabase, {
+        rawToken: token,
+        action: 'cancel',
+        cancellationReason: 'guest_declined_confirmation',
+        allowedActionTypes: ['booking_confirm'],
+      })
+    } catch (cancelError) {
+      logger.error('Failed to cancel a booking from the confirm link', {
+        metadata: {
+          tableBookingId: lookup.booking.id,
+          error: cancelError instanceof Error ? cancelError.message : String(cancelError),
+        },
+      })
+      return NextResponse.redirect(
+        new URL(`/g/${token}/confirm-booking?state=cancel_failed`, request.url),
+        { status: 303 },
+      )
+    }
+
+    return NextResponse.redirect(
+      new URL(`/g/${token}/confirm-booking?state=cancelled`, request.url),
+      { status: 303 },
+    )
+  }
+
+  return NextResponse.redirect(new URL(`/g/${token}/confirm-booking`, request.url), { status: 303 })
+}

--- a/src/app/g/[token]/confirm-booking/page.tsx
+++ b/src/app/g/[token]/confirm-booking/page.tsx
@@ -1,0 +1,145 @@
+/**
+ * "Are you still coming?" answered in one tap.
+ *
+ * The page renders; the POST in ./action records. Nothing here mutates, so a carrier or
+ * messaging app that prefetches the link in the SMS gets a page and not a false "yes".
+ *
+ * Both answers are given equal weight on purpose. A guest who cannot come and is only
+ * offered a confirm button simply closes the page, and becomes the no-show this feature
+ * exists to prevent. Making "I can't make it" easy is what actually frees the table.
+ */
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { formatDateWithTimeForSms } from '@/lib/dateUtils'
+import { isAnswerable, lookupConfirmToken } from '@/lib/table-bookings/confirm-token'
+
+export const dynamic = 'force-dynamic'
+
+const CONTACT_PHONE = process.env.NEXT_PUBLIC_CONTACT_PHONE_NUMBER || '01753 682707'
+
+type PageProps = {
+  params: Promise<{ token: string }>
+  searchParams: Promise<{ state?: string }>
+}
+
+function Shell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 py-12">
+      <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+      <div className="mt-4 space-y-4 text-gray-700">{children}</div>
+      <p className="mt-8 text-sm text-gray-500">
+        The Anchor, Stanwell Moor. Anything else, call us on{' '}
+        <a className="underline" href={`tel:${CONTACT_PHONE.replace(/\s/g, '')}`}>
+          {CONTACT_PHONE}
+        </a>
+        .
+      </p>
+    </main>
+  )
+}
+
+export default async function ConfirmBookingPage({ params, searchParams }: PageProps) {
+  const { token } = await params
+  const { state } = await searchParams
+  const supabase = createAdminClient()
+
+  if (state === 'confirmed') {
+    return (
+      <Shell title="Thanks, you're confirmed">
+        <p>We have got you down and the table is yours. See you soon.</p>
+      </Shell>
+    )
+  }
+
+  if (state === 'cancelled') {
+    return (
+      <Shell title="Your table is cancelled">
+        <p>Thanks for letting us know, it means we can give the table to someone else.</p>
+        <p>You are always welcome to book again whenever suits you.</p>
+      </Shell>
+    )
+  }
+
+  const lookup = await lookupConfirmToken(supabase, token)
+
+  // A dead link is told the same story whichever way it died, so the page never reveals
+  // whether a token existed. The phone number is the way out of every one of these.
+  if (!lookup.ok) {
+    return (
+      <Shell title="This link has expired">
+        <p>
+          Confirmation links only work up to the time of the booking. If your table is still
+          coming up, give us a ring and we will sort it out in a moment.
+        </p>
+      </Shell>
+    )
+  }
+
+  const { booking } = lookup
+  const bookingMoment = formatDateWithTimeForSms(booking.bookingDate, booking.bookingTime)
+  const greeting = booking.customerFirstName ? `${booking.customerFirstName}, y` : 'Y'
+
+  if (booking.guestConfirmedAt) {
+    return (
+      <Shell title="You're already confirmed">
+        <p>
+          {greeting}our table for {bookingMoment} is confirmed. Nothing else to do.
+        </p>
+      </Shell>
+    )
+  }
+
+  if (!isAnswerable(booking.status)) {
+    return (
+      <Shell title="This booking is no longer open">
+        <p>
+          It looks like this table has already been cancelled or has been and gone. If that is
+          not right, please give us a ring.
+        </p>
+      </Shell>
+    )
+  }
+
+  if (state === 'cancel_failed' || state === 'error') {
+    return (
+      <Shell title="Something went wrong at our end">
+        <p>We could not save that. Please give us a ring and we will sort it out.</p>
+      </Shell>
+    )
+  }
+
+  return (
+    <Shell title="Are you still coming?">
+      <p>
+        {greeting}our table
+        {booking.partySize ? ` for ${booking.partySize}` : ''} is {bookingMoment}.
+      </p>
+      <p className="text-sm text-gray-500">Booking reference {booking.bookingReference}</p>
+
+      <form method="POST" action={`/g/${token}/confirm-booking/action`} className="space-y-3 pt-2">
+        <button
+          type="submit"
+          name="answer"
+          value="yes"
+          className="w-full rounded-lg bg-emerald-700 px-4 py-4 text-lg font-semibold text-white"
+        >
+          Yes, we&apos;ll be there
+        </button>
+        <button
+          type="submit"
+          name="answer"
+          value="no"
+          className="w-full rounded-lg border border-gray-300 px-4 py-4 text-lg font-medium text-gray-700"
+        >
+          Sorry, I need to cancel
+        </button>
+      </form>
+
+      {state === 'busy' ? (
+        <p className="text-sm text-amber-700">
+          That did not go through. Please try once more in a moment.
+        </p>
+      ) : null}
+    </Shell>
+  )
+}

--- a/src/lib/guest/tokens.ts
+++ b/src/lib/guest/tokens.ts
@@ -10,6 +10,7 @@ type GuestTokenActionType =
   | 'waitlist_offer'
   | 'private_feedback'
   | 'private_booking_outcome'
+  | 'booking_confirm'
 
 export type CreateGuestTokenInput = {
   customerId: string

--- a/src/lib/table-bookings/confirm-reminder.test.ts
+++ b/src/lib/table-bookings/confirm-reminder.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConfirmReminderMessage,
+  decideConfirmReminder,
+  isTomorrow,
+  type ConfirmCandidate,
+} from './confirm-reminder'
+
+/**
+ * The harm this file guards against is a text to the wrong guest, so almost every test
+ * here asserts that a message is NOT sent. The one that asserts it is sent is the easy
+ * case; the rest are the ones that cost the pub a customer if they regress.
+ */
+
+const TODAY = "2026-08-09"
+const TOMORROW = "2026-08-10"
+
+function candidate(overrides: Partial<ConfirmCandidate> = {}): ConfirmCandidate {
+  return {
+    id: 'tb-1',
+    bookingReference: 'TB-0001',
+    status: 'confirmed',
+    bookingDate: TOMORROW,
+    guestConfirmedAt: null,
+    reminderAlreadySent: false,
+    customer: { id: 'cust-1', firstName: 'Jane', phone: '+447700900000', smsActive: true },
+    ...overrides,
+  }
+}
+
+describe('decideConfirmReminder', () => {
+  it('texts a confirmed booking a day out that has not answered', () => {
+    expect(decideConfirmReminder(candidate(), TODAY)).toEqual({ send: true })
+  })
+
+  it('never texts a booking that is still waiting on its deposit', () => {
+    // The deposit chase is the right conversation with this guest. Asking them to
+    // confirm a table whose hold can still expire invites them to plan an evening they
+    // have not secured, and spends an SMS on a booking that may never exist.
+    expect(decideConfirmReminder(candidate({ status: 'pending_payment' }), TODAY)).toEqual({
+      send: false,
+      reason: 'status_not_confirmable',
+    })
+  })
+
+  it.each(['cancelled', 'no_show', 'completed', 'review_clicked', 'visited_waiting_for_review'])(
+    'never texts a %s booking',
+    (status) => {
+      expect(decideConfirmReminder(candidate({ status }), TODAY).send).toBe(false)
+    },
+  )
+
+  it('does not ask a guest who has already answered', () => {
+    expect(
+      decideConfirmReminder(candidate({ guestConfirmedAt: '2026-08-09T10:00:00Z' }), TODAY),
+    ).toEqual({ send: false, reason: 'already_answered' })
+  })
+
+  it('sends exactly one reminder per booking, ever', () => {
+    expect(decideConfirmReminder(candidate({ reminderAlreadySent: true }), TODAY)).toEqual({
+      send: false,
+      reason: 'already_reminded',
+    })
+  })
+
+  it('stays quiet when the booking has no customer attached', () => {
+    expect(decideConfirmReminder(candidate({ customer: null }), TODAY)).toEqual({
+      send: false,
+      reason: 'no_customer',
+    })
+  })
+
+  it('stays quiet when there is no mobile number to text', () => {
+    expect(
+      decideConfirmReminder(
+        candidate({ customer: { id: 'c', firstName: 'Jane', phone: null, smsActive: true } }),
+        TODAY,
+      ),
+    ).toEqual({ send: false, reason: 'no_mobile' })
+  })
+
+  it('respects an SMS opt-out rather than treating it as a delivery problem', () => {
+    // Opting out is an answer. These guests get a phone call from the pub instead.
+    expect(
+      decideConfirmReminder(
+        candidate({
+          customer: { id: 'c', firstName: 'Jane', phone: '+447700900000', smsActive: false },
+        }),
+        TODAY,
+      ),
+    ).toEqual({ send: false, reason: 'sms_not_active' })
+  })
+
+  it('checks status before anything else, so a cancelled booking is never reasoned about further', () => {
+    const result = decideConfirmReminder(
+      candidate({ status: 'cancelled', customer: null, reminderAlreadySent: true }),
+      TODAY,
+    )
+    expect(result).toEqual({ send: false, reason: 'status_not_confirmable' })
+  })
+})
+
+describe('isTomorrow', () => {
+  it('accepts the day after the sweep', () => {
+    expect(isTomorrow('2026-08-10', '2026-08-09')).toBe(true)
+  })
+
+  it('rejects today, because a guest sitting down in three hours needs a phone call', () => {
+    expect(isTomorrow('2026-08-09', '2026-08-09')).toBe(false)
+  })
+
+  it('rejects a booking two days out, which waits for its own sweep', () => {
+    expect(isTomorrow('2026-08-11', '2026-08-09')).toBe(false)
+  })
+
+  it('rejects a date that has already passed', () => {
+    expect(isTomorrow('2026-08-08', '2026-08-09')).toBe(false)
+  })
+
+  it('rolls over a month end', () => {
+    expect(isTomorrow('2026-09-01', '2026-08-31')).toBe(true)
+    expect(isTomorrow('2026-03-01', '2026-02-28')).toBe(true)
+  })
+
+  it('rolls over a year end', () => {
+    expect(isTomorrow('2027-01-01', '2026-12-31')).toBe(true)
+  })
+
+  it('survives both British Summer Time boundaries', () => {
+    // The bug this pins: building the next day from a local midnight puts 29 March at
+    // 23:00 on the 28th, or 25 October at 01:00 on the 26th, and a whole day of bookings
+    // is silently never asked. Both transitions are checked because they shift opposite ways.
+    expect(isTomorrow('2026-03-29', '2026-03-28')).toBe(true)
+    expect(isTomorrow('2026-03-30', '2026-03-29')).toBe(true)
+    expect(isTomorrow('2026-10-25', '2026-10-24')).toBe(true)
+    expect(isTomorrow('2026-10-26', '2026-10-25')).toBe(true)
+  })
+
+  it('handles a leap day', () => {
+    expect(isTomorrow('2028-02-29', '2028-02-28')).toBe(true)
+    expect(isTomorrow('2028-03-01', '2028-02-29')).toBe(true)
+  })
+})
+
+describe('buildConfirmReminderMessage', () => {
+  const base = {
+    firstName: 'Jane',
+    bookingMoment: 'tomorrow at 7pm',
+    partySize: 4,
+    confirmUrl: 'https://management.orangejelly.co.uk/g/abc123/confirm-booking',
+  }
+
+  it('reads like a person wrote it and offers both answers', () => {
+    const message = buildConfirmReminderMessage(base)
+    expect(message).toContain('Jane')
+    expect(message).toContain('tomorrow at 7pm')
+    expect(message).toContain('for 4')
+    expect(message).toContain('Still coming?')
+    // Offering the cancel in the same breath is the point. A guest who cannot come and
+    // is only offered "confirm" simply ignores the text, and becomes a no-show.
+    expect(message).toContain('cancel')
+    expect(message).toContain(base.confirmUrl)
+  })
+
+  it('stays on GSM-7, because one character outside it costs every send double', () => {
+    // GSM-7 gives 160 characters a segment; a single character outside it drops the
+    // whole message to 70. Curly quotes, long dashes and the ellipsis are the usual
+    // culprits, matched here by code point so this file does not contain them either.
+    const nonGsm = new RegExp('[\\u2018\\u2019\\u201C\\u201D\\u2013\\u2014\\u2026]')
+    expect(buildConfirmReminderMessage(base)).not.toMatch(nonGsm)
+  })
+
+  it('fits a single segment for a typical booking', () => {
+    // The URL is rewritten to a short link at send time by shortenUrlsInSmsBody, so the
+    // real body is shorter than this. Measuring with the long URL is the pessimistic case.
+    const message = buildConfirmReminderMessage({
+      ...base,
+      confirmUrl: 'https://l.the-anchor.pub/abcdef',
+    })
+    expect(message.length).toBeLessThanOrEqual(160)
+  })
+
+  it('drops the greeting rather than saying "null," when the name is missing', () => {
+    const message = buildConfirmReminderMessage({ ...base, firstName: null })
+    expect(message).not.toContain('null')
+    expect(message).not.toContain('undefined')
+    expect(message).toContain('your table')
+  })
+
+  it('omits the party size rather than printing "for 0"', () => {
+    expect(buildConfirmReminderMessage({ ...base, partySize: null })).not.toContain('for ')
+    expect(buildConfirmReminderMessage({ ...base, partySize: 0 })).not.toContain('for 0')
+  })
+})

--- a/src/lib/table-bookings/confirm-reminder.ts
+++ b/src/lib/table-bookings/confirm-reminder.ts
@@ -1,0 +1,162 @@
+/**
+ * Deciding who gets a "are you still coming?" text, and what it says.
+ *
+ * Kept separate from the cron route for the same reason `decidePreorderChases` is: the
+ * rule about who gets messaged is the part that can quietly harm a guest, and it should
+ * be testable without a database, a clock or an SMS provider.
+ *
+ * THE RULE, in one sentence: a confirmed booking whose guest has not already answered,
+ * whose sitting is roughly a day away, gets exactly one text.
+ *
+ * Everything below is a reason why some booking does NOT get one.
+ */
+
+import { getSmartFirstName } from '@/lib/sms/name-utils'
+
+/**
+ * Only a CONFIRMED booking is chased, as an allow-list rather than a list of dead
+ * statuses. The failure modes point opposite ways: miss a status from a deny-list and a
+ * guest gets a text they should never have had, miss one here and the sweep stays quiet,
+ * which is recoverable.
+ *
+ * `pending_payment` is the case that matters. That guest has not paid a deposit, their
+ * hold can still expire, and the booking may never exist. Asking them to confirm a table
+ * they have not secured is the wrong conversation; the deposit chase is the right one.
+ * They join this sweep the moment payment lands and they become confirmed.
+ */
+export const CONFIRMABLE_BOOKING_STATUSES = ['confirmed'] as const
+
+/**
+ * ONE SWEEP A DAY, and everyone sitting tomorrow gets asked.
+ *
+ * An hours-based window was the obvious design and it is wrong here. The sweep must not
+ * run overnight, because a text at three in the morning is worse than no text at all, and
+ * an hourly cron that sleeps from 9pm to 9am can never catch a booking at 8am tomorrow:
+ * that sitting is 24 hours away at 8am today, when nothing is running, and only 23 hours
+ * away by the time the first morning run happens. It would fall through the gap forever
+ * and nobody would notice, because the absence of a text leaves no trace.
+ *
+ * Comparing dates instead removes the edge entirely. "Is this booking tomorrow" has the
+ * same answer at any hour of the day it is asked.
+ */
+export type ConfirmCandidate = {
+  id: string
+  bookingReference: string
+  status: string
+  /** The booking's local date, as stored: YYYY-MM-DD in Europe/London. */
+  bookingDate: string
+  guestConfirmedAt: string | null
+  reminderAlreadySent: boolean
+  customer: {
+    id: string
+    firstName: string | null
+    phone: string | null
+    smsActive: boolean
+  } | null
+}
+
+export type ConfirmDecision =
+  | { send: true }
+  | { send: false; reason: ConfirmSkipReason }
+
+export type ConfirmSkipReason =
+  | 'status_not_confirmable'
+  | 'already_answered'
+  | 'already_reminded'
+  | 'no_customer'
+  | 'no_mobile'
+  | 'sms_not_active'
+  | 'not_tomorrow'
+
+/**
+ * Whether this booking should be texted on today's sweep.
+ *
+ * `todayIsoDate` is passed in rather than read, so the date edges are testable and a test
+ * cannot pass or fail depending on when it runs or which timezone the runner is in.
+ */
+export function decideConfirmReminder(
+  candidate: ConfirmCandidate,
+  todayIsoDate: string
+): ConfirmDecision {
+  if (!CONFIRMABLE_BOOKING_STATUSES.includes(candidate.status as 'confirmed')) {
+    return { send: false, reason: 'status_not_confirmable' }
+  }
+
+  // The guest has already told us. Asking again is noise, and on a booking they confirmed
+  // days ago it reads as though we lost their answer.
+  if (candidate.guestConfirmedAt) {
+    return { send: false, reason: 'already_answered' }
+  }
+
+  if (candidate.reminderAlreadySent) {
+    return { send: false, reason: 'already_reminded' }
+  }
+
+  if (!candidate.customer) {
+    return { send: false, reason: 'no_customer' }
+  }
+
+  if (!candidate.customer.phone) {
+    return { send: false, reason: 'no_mobile' }
+  }
+
+  // Opting out of texts is an answer in itself. The pub rings these guests instead, which
+  // is the fallback for every skip reason here.
+  if (!candidate.customer.smsActive) {
+    return { send: false, reason: 'sms_not_active' }
+  }
+
+  if (!isTomorrow(candidate.bookingDate, todayIsoDate)) {
+    return { send: false, reason: 'not_tomorrow' }
+  }
+
+  return { send: true }
+}
+
+/**
+ * Is this booking date the day after the sweep's date.
+ *
+ * Plain string arithmetic on YYYY-MM-DD, deliberately. Both values are already local
+ * Europe/London dates by the time they reach here, so converting either into a Date and
+ * back is an opportunity to shift a booking across midnight in British Summer Time and no
+ * opportunity to be more correct.
+ */
+export function isTomorrow(bookingDate: string, todayIsoDate: string): boolean {
+  return bookingDate === addOneDay(todayIsoDate)
+}
+
+function addOneDay(isoDate: string): string {
+  // Built at UTC noon so a daylight-saving shift in either direction cannot move the
+  // result onto the wrong calendar day.
+  const noon = new Date(`${isoDate}T12:00:00Z`)
+  if (Number.isNaN(noon.getTime())) return ''
+  noon.setUTCDate(noon.getUTCDate() + 1)
+  return noon.toISOString().slice(0, 10)
+}
+
+/**
+ * The text itself.
+ *
+ * Straight apostrophes and no dashes throughout: a single curly character switches the
+ * message from GSM-7 to UCS-2 and drops the segment limit from 160 characters to 70,
+ * which doubles the cost of every send for no visible benefit.
+ *
+ * The URL is left long. `shortenUrlsInSmsBody` rewrites every http(s) URL in an outbound
+ * body to a tracked short link at send time, so shortening here would only produce a
+ * short link to a short link.
+ */
+export function buildConfirmReminderMessage(input: {
+  firstName: string | null
+  bookingMoment: string
+  partySize: number | null
+  confirmUrl: string
+}): string {
+  const name = getSmartFirstName(input.firstName)
+  const greeting = name ? `${name}, ` : ''
+  const party = input.partySize && input.partySize > 0 ? ` for ${input.partySize}` : ''
+
+  return (
+    `The Anchor: ${greeting}your table${party} is ${input.bookingMoment}. ` +
+    `Still coming? Tap to confirm or cancel: ${input.confirmUrl}`
+  )
+}

--- a/src/lib/table-bookings/confirm-token.ts
+++ b/src/lib/table-bookings/confirm-token.ts
@@ -1,0 +1,98 @@
+/**
+ * Reading and answering a booking_confirm token.
+ *
+ * Split from the page and the route because both need it and neither should own it: the
+ * page reads to render, the route reads to write, and a difference between the two reads
+ * is how a guest ends up confirming a booking the page told them was already cancelled.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { hashGuestToken } from '@/lib/guest/tokens'
+
+export type ConfirmTokenBooking = {
+  id: string
+  bookingReference: string
+  bookingDate: string
+  bookingTime: string | null
+  partySize: number | null
+  status: string
+  guestConfirmedAt: string | null
+  customerFirstName: string | null
+}
+
+export type ConfirmTokenLookup =
+  | { ok: true; booking: ConfirmTokenBooking }
+  | { ok: false; reason: 'not_found' | 'expired' | 'booking_missing' }
+
+/**
+ * Resolve a raw token to its booking, or say precisely why not.
+ *
+ * A bad token and an expired token are told apart for the guest's benefit, not the
+ * attacker's: both render a page that offers the pub's phone number, and neither reveals
+ * whether the token ever existed.
+ */
+export async function lookupConfirmToken(
+  supabase: SupabaseClient<any, 'public', any>,
+  rawToken: string
+): Promise<ConfirmTokenLookup> {
+  const hashedToken = hashGuestToken(rawToken)
+
+  const { data: guestToken, error } = await supabase
+    .from('guest_tokens')
+    .select('id, customer_id, table_booking_id, expires_at')
+    .eq('hashed_token', hashedToken)
+    .eq('action_type', 'booking_confirm')
+    .maybeSingle()
+
+  if (error || !guestToken || !guestToken.table_booking_id) {
+    return { ok: false, reason: 'not_found' }
+  }
+
+  if (guestToken.expires_at && Date.parse(guestToken.expires_at) <= Date.now()) {
+    return { ok: false, reason: 'expired' }
+  }
+
+  const { data: booking } = await supabase
+    .from('table_bookings')
+    .select('id, booking_reference, booking_date, booking_time, party_size, status, guest_confirmed_at, customers(first_name)')
+    .eq('id', guestToken.table_booking_id)
+    .maybeSingle()
+
+  if (!booking) {
+    return { ok: false, reason: 'booking_missing' }
+  }
+
+  // PostgREST types an embedded one-to-one as an array. Both shapes are handled because
+  // the generated types and the runtime shape disagree depending on the relationship
+  // metadata, and guessing wrong here drops the guest's name from the page and the text.
+  const embedded = booking.customers as unknown
+  const customer = (Array.isArray(embedded) ? embedded[0] : embedded) as
+    | { first_name: string | null }
+    | null
+    | undefined
+
+  return {
+    ok: true,
+    booking: {
+      id: booking.id as string,
+      bookingReference: booking.booking_reference as string,
+      bookingDate: booking.booking_date as string,
+      bookingTime: (booking.booking_time as string | null) ?? null,
+      partySize: (booking.party_size as number | null) ?? null,
+      status: booking.status as string,
+      guestConfirmedAt: (booking.guest_confirmed_at as string | null) ?? null,
+      customerFirstName: customer?.first_name ?? null,
+    },
+  }
+}
+
+/**
+ * Whether a booking in this state can still be answered.
+ *
+ * Confirming a cancelled booking must not resurrect it, and confirming one that has
+ * already happened is meaningless. Both render a page that explains rather than a button
+ * that lies.
+ */
+export function isAnswerable(status: string): boolean {
+  return status === 'confirmed'
+}

--- a/src/lib/table-bookings/manage-booking.ts
+++ b/src/lib/table-bookings/manage-booking.ts
@@ -98,16 +98,32 @@ async function findTableAssignment(
   }
 }
 
+/**
+ * Which token types may drive the manage flow.
+ *
+ * Defaults to 'manage' alone so every existing caller behaves exactly as before. The
+ * 24-hour confirm link passes 'booking_confirm', because its "no, cancel my table" button
+ * has to reach this same code path: that path owns freeing the table, the audit row and
+ * the cancellation message, and a second cancel implementation would drift from it and
+ * quietly stop releasing capacity.
+ *
+ * Widening this is not a widening of access. Both token types are per-booking, hashed,
+ * expiring and tied to the same customer, and the confirm PAGE still demands
+ * action_type = 'booking_confirm', so an old manage link cannot be used to answer.
+ */
+type ManageTokenActionType = 'manage' | 'booking_confirm'
+
 async function getTableManageTokenRow(
   supabase: SupabaseClient<any, 'public', any>,
-  rawToken: string
+  rawToken: string,
+  allowedActionTypes: readonly ManageTokenActionType[] = ['manage']
 ): Promise<{ customer_id: string; table_booking_id: string } | null> {
   const tokenHash = hashGuestToken(rawToken)
 
   const { data: tokenRow } = await supabase.from('guest_tokens')
     .select('customer_id, table_booking_id, expires_at, consumed_at')
     .eq('hashed_token', tokenHash)
-    .eq('action_type', 'manage')
+    .in('action_type', allowedActionTypes as unknown as string[])
     .maybeSingle()
 
   if (!tokenRow || !tokenRow.table_booking_id || !tokenRow.customer_id) {
@@ -271,11 +287,49 @@ export async function createTableManageToken(
   }
 }
 
+/**
+ * The token behind the "are you still coming?" text.
+ *
+ * Deliberately its own action type rather than reusing 'manage'. A manage token is a
+ * general key to the booking that the guest may have been given days earlier for another
+ * reason; this one exists to answer one question at one moment, and keeping them separate
+ * means the confirm page cannot be reached by an old link and a manage link cannot be
+ * mistaken for an answer.
+ *
+ * Expiry follows the manage-token rule, so the link dies with the sitting rather than
+ * lingering as a working key to a booking that has already happened.
+ */
+export async function createBookingConfirmToken(
+  supabase: SupabaseClient<any, 'public', any>,
+  input: {
+    customerId: string
+    tableBookingId: string
+    bookingStartIso?: string | null
+    appBaseUrl?: string
+  }
+): Promise<{ rawToken: string; url: string; expiresAt: string }> {
+  const expiresAt = computeManageTokenExpiry(input.bookingStartIso)
+  const token = await createGuestToken(supabase, {
+    customerId: input.customerId,
+    actionType: 'booking_confirm',
+    tableBookingId: input.tableBookingId,
+    expiresAt
+  })
+
+  const baseUrl = resolveAppBaseUrl(input.appBaseUrl)
+  return {
+    rawToken: token.rawToken,
+    url: `${baseUrl}/g/${token.rawToken}/confirm-booking`,
+    expiresAt
+  }
+}
+
 export async function getTableManagePreviewByRawToken(
   supabase: SupabaseClient<any, 'public', any>,
-  rawToken: string
+  rawToken: string,
+  allowedActionTypes: readonly ManageTokenActionType[] = ['manage']
 ): Promise<TableManagePreviewResult> {
-  const tokenRow = await getTableManageTokenRow(supabase, rawToken)
+  const tokenRow = await getTableManageTokenRow(supabase, rawToken, allowedActionTypes)
   if (!tokenRow) {
     return { state: 'blocked', reason: 'invalid_token' }
   }
@@ -343,9 +397,15 @@ export async function updateTableBookingByRawToken(
     cancellationReason?: string | null
     cancellationReasonDetail?: string | null
     appBaseUrl?: string
+    /** See ManageTokenActionType. Defaults to manage-only, as every existing caller expects. */
+    allowedActionTypes?: readonly ManageTokenActionType[]
   }
 ): Promise<TableManageUpdateResult> {
-  const preview = await getTableManagePreviewByRawToken(supabase, input.rawToken)
+  const preview = await getTableManagePreviewByRawToken(
+    supabase,
+    input.rawToken,
+    input.allowedActionTypes ?? ['manage']
+  )
   if (preview.state !== 'ready' || !preview.table_booking_id || !preview.customer_id) {
     return {
       state: 'blocked',

--- a/supabase/migrations/20260809110000_table_booking_tap_to_confirm.sql
+++ b/supabase/migrations/20260809110000_table_booking_tap_to_confirm.sql
@@ -1,0 +1,91 @@
+-- Tap-to-confirm for table bookings.
+--
+-- WHY: 21% of table bookings in the last ninety days never happened. 52 cancelled and
+-- 12 no-shows out of 308, and every single no-show originated on the website. Nothing
+-- currently chases them. A guest who taps "yes, we'll be there" the day before is a
+-- guest who turns up; a guest who does not tap is a name on a call list for the pub to
+-- ring, which is how The Anchor already handles an incomplete pre-order.
+--
+-- THIS MIGRATION DOES NOT CANCEL ANYTHING. There is deliberately no auto-release here.
+-- Twelve no-shows in ninety days is not worth wrongly cancelling one real booking, so
+-- the confirm SMS ships first and runs long enough to show a tap rate. Auto-release is
+-- a separate decision the owner has not been asked to make yet.
+
+BEGIN;
+
+-- 1. The guest's answer, recorded on the booking itself.
+--
+-- Three states, and the third is the point: confirmed (tapped yes), declined (tapped
+-- no, which is a cancellation the guest can make without ringing), and NULL meaning
+-- "asked, no answer". NULL plus a sent reminder is the call list.
+ALTER TABLE public.table_bookings
+  ADD COLUMN IF NOT EXISTS guest_confirmed_at timestamptz;
+
+COMMENT ON COLUMN public.table_bookings.guest_confirmed_at IS
+  'When the guest tapped the confirm link in the 24h reminder. NULL after a reminder was sent means no answer: that booking belongs on the staff call list, not in an automatic cancellation.';
+
+-- 2. The ledger, which IS the idempotency.
+--
+-- Same shape and the same reasoning as booking_preorder_reminders: the row is claimed
+-- BEFORE anything is sent, so two crons racing or one cron running twice both lose at
+-- the database and send nothing. One reminder per booking, ever. A claimed row is never
+-- rolled back on a failed send, because deleting it to retry turns an ambiguous failure
+-- (SMS delivered, log write did not) into a second text to the guest.
+CREATE TABLE IF NOT EXISTS public.table_booking_confirm_reminders (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  table_booking_id uuid NOT NULL REFERENCES public.table_bookings(id) ON DELETE CASCADE,
+  sent_at          timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT table_booking_confirm_reminders_once UNIQUE (table_booking_id)
+);
+
+ALTER TABLE public.table_booking_confirm_reminders ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.table_booking_confirm_reminders FROM anon, authenticated;
+GRANT ALL ON public.table_booking_confirm_reminders TO service_role;
+
+-- 3. The token action type.
+--
+-- Rebuilt from the LIVE constraint rather than from any migration, because
+-- 20260508000007 deliberately left 'card_capture' in place for two live rows while
+-- removing the feature, so a definition reconstructed from the feature history would
+-- silently drop it and fail on those rows.
+ALTER TABLE public.guest_tokens DROP CONSTRAINT IF EXISTS guest_tokens_action_type_check;
+ALTER TABLE public.guest_tokens ADD CONSTRAINT guest_tokens_action_type_check CHECK (
+  action_type = ANY (ARRAY[
+    'manage'::text,
+    'sunday_preorder'::text,
+    'card_capture'::text,
+    'payment'::text,
+    'review_redirect'::text,
+    'charge_approval'::text,
+    'waitlist_offer'::text,
+    'private_feedback'::text,
+    'private_booking_outcome'::text,
+    'booking_confirm'::text
+  ])
+);
+
+-- 4. The staff call list.
+--
+-- A view rather than a query in the UI, so "who has not answered" has exactly one
+-- definition and the dashboard and any future report cannot drift apart. Bookings are
+-- listed once the reminder has gone out and the guest has neither confirmed nor
+-- cancelled, for bookings still in the future.
+CREATE OR REPLACE VIEW public.table_bookings_awaiting_confirmation AS
+SELECT
+  tb.id,
+  tb.booking_reference,
+  tb.booking_date,
+  tb.booking_time,
+  tb.party_size,
+  tb.customer_id,
+  r.sent_at AS reminder_sent_at
+FROM public.table_bookings tb
+JOIN public.table_booking_confirm_reminders r ON r.table_booking_id = tb.id
+WHERE tb.status = 'confirmed'
+  AND tb.guest_confirmed_at IS NULL
+  AND (tb.booking_date + COALESCE(tb.booking_time, '00:00'::time)) >= now() AT TIME ZONE 'Europe/London';
+
+COMMENT ON VIEW public.table_bookings_awaiting_confirmation IS
+  'Bookings that were sent a 24h confirm reminder and have not answered. This is a call list for staff. It is NOT a cancellation queue: nothing in the system acts on this view automatically.';
+
+COMMIT;

--- a/tests/lib/tableManageCancellationSideEffects.test.ts
+++ b/tests/lib/tableManageCancellationSideEffects.test.ts
@@ -45,9 +45,15 @@ function buildSupabaseForLateCancellation() {
     },
     error: null,
   })
+  // The action_type filter is `.in(...)` rather than `.eq(...)`, because the 24h confirm
+  // link reaches this same cancel path with a 'booking_confirm' token. Both terminators
+  // are offered so this double does not care which the query uses.
   const guestTokenSecondEq = vi.fn().mockReturnValue({ maybeSingle: guestTokenMaybeSingle })
-  const guestTokenFirstEq = vi.fn().mockReturnValue({ eq: guestTokenSecondEq })
-  const guestTokenSelect = vi.fn().mockReturnValue({ eq: guestTokenFirstEq })
+  const guestTokenIn = vi.fn().mockReturnValue({ maybeSingle: guestTokenMaybeSingle })
+  const guestTokenFirstEq = vi
+    .fn()
+    .mockReturnValue({ eq: guestTokenSecondEq, in: guestTokenIn })
+  const guestTokenSelect = vi.fn().mockReturnValue({ eq: guestTokenFirstEq, in: guestTokenIn })
 
   const bookingPreviewMaybeSingle = vi.fn().mockResolvedValue({
     data: {

--- a/vercel.json
+++ b/vercel.json
@@ -274,6 +274,10 @@
       "schedule": "0 12 * * *"
     },
     {
+      "path": "/api/cron/table-booking-confirm",
+      "schedule": "0 10 * * *"
+    },
+    {
       "path": "/api/cron/preorder-reports",
       "schedule": "30 6 * * *"
     }


### PR DESCRIPTION
Stacked on #100. Rebase target becomes `main` once that merges.

## What changed
One text goes out the day before a table booking: *"Still coming? Tap to confirm or cancel."* Confirming is one tap. Cancelling routes through the existing guest-cancel path so the table is genuinely released, not just marked.

Guests who do not answer keep their table and appear in a new `table_bookings_awaiting_confirmation` view for staff to ring.

## Why
**21% of table bookings in the last 90 days never happened**: 52 cancelled and 12 no-shows out of 308, and every single no-show came from a website booking. Nothing chased any of them.

## It cancels nothing by itself
There is deliberately no auto-release. Twelve no-shows a quarter does not justify wrongly cancelling even one genuine booking, so the text ships first and runs long enough to show a real tap rate. Auto-release is a separate decision.

## Design notes worth keeping
- **POST, not GET.** Carriers and messaging apps prefetch links in an SMS. A GET that confirmed the booking would record "yes" for a guest who never opened the text, corrupting the one signal this feature exists to produce.
- **One sweep a day, not an hourly window.** The obvious hours-based design is wrong here: the sweep must not run overnight, and an hourly cron sleeping 9pm to 9am can never catch a booking at 8am tomorrow. That sitting is 24h away at 8am today when nothing is running, and only 23h away by the first morning run. It would fall through the gap forever and leave no trace, because the absence of a text is invisible. Comparing dates gives the same answer at any hour.
- **The ledger is the idempotency**, claimed before the send and never rolled back on failure. Same shape and reasoning as `booking_preorder_reminders`.
- **`pending_payment` bookings are excluded.** That guest has not paid a deposit and their hold can still expire; the deposit chase is the right conversation, not this one.
- `getTableManageTokenRow` now takes an allow-list of token action types, defaulting to manage-only so every existing caller is unchanged.

The `guest_tokens` CHECK constraint is rebuilt from the **live** definition, not from migration history: `20260508000007` deliberately left `card_capture` in place for two live rows while removing the feature, so a constraint reconstructed from that history would drop it and fail on those rows.

## Testing done
- [x] Automated: 4,662 tests pass including 26 new ones covering the send/skip rule, the date boundary, both British Summer Time transitions, a leap day, and the GSM-7 message encoding. Lint clean, `tsc --noEmit` clean, production build passes.

## Complexity score
M

## Breaking changes
None.

## Migration risk
Low. Adds one column, one table, one view, and widens a CHECK constraint. Nothing is dropped.

## Deploy note
This starts sending real SMS to real guests at 10am the day after deploy. Disable by removing the cron entry from `vercel.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)