### PR TITLE
fix(api): stop reporting our own outage as a failed bot check

### DIFF
--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod'
 import {
   withApiAuth,
   createApiResponse,
-  createErrorResponse
+  createErrorResponse,
+  getApiKeyAuthState
 } from '@/lib/api/auth'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
@@ -110,14 +111,20 @@ function buildBookingAttribution(data: z.infer<typeof CreateEventBookingSchema>)
 }
 
 export async function POST(request: NextRequest) {
-  // Turnstile CAPTCHA verification — only for direct browser requests.
+  // Turnstile CAPTCHA verification, only for genuinely anonymous browser requests.
   // API-key-authenticated requests (the website proxy) skip Turnstile here: the
   // website uses its own Turnstile widget with a *different* secret key, so its
   // single-use token cannot be validated with this app's secret (attempting to
   // always fails with "Turnstile verification failed"). The website verifies the
   // token itself before proxying. Mirrors the established table-bookings route.
-  const hasApiKey = Boolean(request.headers.get('x-api-key') || request.headers.get('authorization'))
-  if (!hasApiKey) {
+  //
+  // This used to test for the mere presence of an x-api-key or authorization
+  // header, which nobody authenticates, so `x-api-key: anything` walked straight
+  // past the bot check. It now validates the key properly, and distinguishes a
+  // key we could not check (an outage) from one that is simply absent, so our
+  // own downtime is never reported to a guest as a failed bot check.
+  const authState = await getApiKeyAuthState(request.headers)
+  if (authState === 'anonymous') {
     const turnstileToken = request.headers.get('x-turnstile-token')
     const turnstile = await verifyTurnstileToken(turnstileToken, getClientIp(request))
     if (!turnstile.success) {

--- a/src/app/api/private-booking-enquiry/route.ts
+++ b/src/app/api/private-booking-enquiry/route.ts
@@ -20,7 +20,7 @@ import { recordPrivateBookingWebEnquiryCommunication } from '@/lib/communication
 import { OptionalCommunicationConsentSchema, consentHashPayload } from '@/lib/consent/validation'
 import { ConsentService } from '@/services/consent'
 import { parseLondonDateTimeLocal } from '@/lib/dateUtils'
-import { isApiKeyAuthenticated } from '@/lib/api/auth'
+import { getApiKeyAuthState } from '@/lib/api/auth'
 
 const EnquirySchema = z.object({
   phone: z.string().min(5),
@@ -127,8 +127,12 @@ export async function POST(request: NextRequest) {
     // Turnstile CAPTCHA verification, skipped only for requests carrying an API
     // key that actually validates. An unrecognised key is treated as anonymous
     // and still has to pass the bot check.
-    const apiKeyAuthenticated = await isApiKeyAuthenticated(request.headers)
-    if (!apiKeyAuthenticated) {
+    //
+    // A key we could not check at all is a third case: that is our outage, not
+    // a bot, and the caller has no widget to solve. It falls through to
+    // withApiAuth, which reports 503 rather than blaming their bot check.
+    const authState = await getApiKeyAuthState(request.headers)
+    if (authState === 'anonymous') {
       const turnstileToken = request.headers.get('x-turnstile-token')
       const clientIp = getClientIp(request)
       const turnstile = await verifyTurnstileToken(turnstileToken, clientIp)

--- a/src/app/api/public/private-booking/route.ts
+++ b/src/app/api/public/private-booking/route.ts
@@ -19,7 +19,7 @@ import { verifyTurnstileToken, getClientIp } from '@/lib/turnstile';
 import { recordPrivateBookingWebEnquiryCommunication } from '@/lib/communications/web-enquiry';
 import { OptionalCommunicationConsentSchema, consentHashPayload } from '@/lib/consent/validation';
 import { ConsentService } from '@/services/consent';
-import { isApiKeyAuthenticated } from '@/lib/api/auth';
+import { getApiKeyAuthState } from '@/lib/api/auth';
 
 const BookingItemSchema = z.object({
     item_type: z.enum(['space', 'catering', 'vendor', 'other']),
@@ -105,8 +105,12 @@ export async function POST(request: NextRequest) {
         // Turnstile CAPTCHA verification, skipped only for requests carrying an
         // API key that actually validates. An unrecognised key is treated as
         // anonymous and still has to pass the bot check.
-        const apiKeyAuthenticated = await isApiKeyAuthenticated(request.headers);
-        if (!apiKeyAuthenticated) {
+        //
+        // A key we could not check at all is a third case: that is our outage,
+        // not a bot, and the caller has no widget to solve. It falls through to
+        // withApiAuth, which reports 503 rather than blaming their bot check.
+        const authState = await getApiKeyAuthState(request.headers);
+        if (authState === 'anonymous') {
             const turnstileToken = request.headers.get('x-turnstile-token');
             const clientIp = getClientIp(request);
             const turnstile = await verifyTurnstileToken(turnstileToken, clientIp);

--- a/src/app/api/table-bookings/route.ts
+++ b/src/app/api/table-bookings/route.ts
@@ -4,7 +4,7 @@ import {
   withApiAuth,
   createApiResponse,
   createErrorResponse,
-  isApiKeyAuthenticated
+  getApiKeyAuthState
 } from '@/lib/api/auth'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
@@ -284,24 +284,33 @@ export async function POST(request: NextRequest) {
   // would let any anonymous caller send `x-api-key: anything` and walk past both the IP limiter
   // and Turnstile. withApiAuth re-validates and rejects the junk key, so the only thing an
   // invalid key buys the caller now is the anonymous treatment it deserves.
-  const authenticated = await isApiKeyAuthenticated(request.headers)
+  const authState = await getApiKeyAuthState(request.headers)
 
   // IP-based rate limiting, the first line of defence before any DB work, for anonymous callers.
   // Authenticated callers are exempt: they arrive from a proxy's egress IPs, so one bucket
   // covered every guest on the public site at once. Their budget is the per-key hourly limit
   // enforced in withApiAuth (5,000/hour for the website key) plus the per-guest limit below.
-  if (!authenticated) {
+  // 'unavailable' is limited alongside anonymous: we cannot prove the caller is trusted, and
+  // the limiter only delays them, whereas the Turnstile gate below would refuse them outright.
+  if (authState !== 'authenticated') {
     const ipRateLimitResponse = await tableBookingIpLimiter(request)
     if (ipRateLimitResponse) {
       return ipRateLimitResponse
     }
   }
 
-  // Turnstile CAPTCHA verification, only for direct browser requests.
-  // API-key-authenticated requests (e.g. from the website proxy) skip Turnstile
-  // because the website has its own Turnstile widget with a different secret key
-  // and handles verification before proxying.
-  if (!authenticated) {
+  // Turnstile CAPTCHA verification, only for genuinely anonymous browser requests.
+  // API-key-authenticated requests (e.g. from the website proxy) skip Turnstile because the
+  // website has its own Turnstile widget, with a DIFFERENT secret key, and verifies the token
+  // itself before proxying. That difference is the whole reason this gate must not catch them:
+  // our secret cannot validate a token minted by their site key, so every guest routed here
+  // fails, no matter what they do.
+  //
+  // Hence 'anonymous' and not merely "not authenticated". A caller who presented a key we could
+  // not check (a database blip) is not a browser, has no widget to solve, and used to be told
+  // "Turnstile verification failed" for what was actually our outage. They now fall through to
+  // withApiAuth, which answers 503 AUTH_UNAVAILABLE and says what really happened.
+  if (authState === 'anonymous') {
     const turnstileToken = request.headers.get('x-turnstile-token')
     const clientIp = getClientIp(request)
     const turnstile = await verifyTurnstileToken(turnstileToken, clientIp)

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -23,9 +23,27 @@ export async function generateApiKey(): Promise<string> {
   return 'anch_' + Buffer.from(bytes).toString('base64url');
 }
 
-async function validateApiKey(apiKey: string | null): Promise<ApiKey | null> {
+/**
+ * The three genuinely different answers to "is this caller authenticated?".
+ *
+ * `unavailable` is the one that used to be missing. Collapsing a database
+ * failure into `invalid` made an outage indistinguishable from a forged key,
+ * and callers that treat "not authenticated" as "anonymous browser" then drew
+ * exactly the wrong conclusion: the public booking routes sent a website
+ * request to their Turnstile gate and rejected the guest for failing a bot
+ * check they had actually passed. Follows the same convention as
+ * checkRateLimit, which already returns null so callers can fail explicitly.
+ */
+export type ApiKeyAuthState = 'authenticated' | 'anonymous' | 'unavailable';
+
+type ApiKeyResolution =
+  | { state: 'authenticated'; key: ApiKey }
+  | { state: 'anonymous' }
+  | { state: 'unavailable' };
+
+async function resolveApiKey(apiKey: string | null): Promise<ApiKeyResolution> {
   if (!apiKey) {
-    return null;
+    return { state: 'anonymous' };
   }
 
   // Use admin client for API key validation since api_keys table requires elevated permissions
@@ -39,12 +57,13 @@ async function validateApiKey(apiKey: string | null): Promise<ApiKey | null> {
     .eq('is_active', true);
 
   if (error) {
+    // Infrastructure, not the caller. Say so, rather than blaming the key.
     console.error('[API Auth] Failed to validate API key');
-    return null;
+    return { state: 'unavailable' };
   }
 
   if (!data || data.length === 0) {
-    return null;
+    return { state: 'anonymous' };
   }
 
   if (data.length > 1) {
@@ -56,7 +75,7 @@ async function validateApiKey(apiKey: string | null): Promise<ApiKey | null> {
   // Check expiry
   if (keyData.expires_at && new Date(keyData.expires_at) < new Date()) {
     console.warn('[API Auth] Rejected expired API key', { id: keyData.id });
-    return null;
+    return { state: 'anonymous' };
   }
 
   // Fire-and-forget — don't block the response for observational timestamp update
@@ -81,7 +100,18 @@ async function validateApiKey(apiKey: string | null): Promise<ApiKey | null> {
       })
     );
 
-  return keyData as ApiKey;
+  return { state: 'authenticated', key: keyData as ApiKey };
+}
+
+/**
+ * Back-compatible wrapper. Treats `unavailable` as "no key", which is the old
+ * behaviour, so callers that only care whether they hold a usable key are
+ * unchanged. Anything that must tell an outage apart from a bad key should use
+ * resolveApiKey or getApiKeyAuthState instead.
+ */
+async function validateApiKey(apiKey: string | null): Promise<ApiKey | null> {
+  const resolution = await resolveApiKey(apiKey);
+  return resolution.state === 'authenticated' ? resolution.key : null;
 }
 
 // Returns `null` when rate limit checks are unavailable so callers can fail closed explicitly.
@@ -256,11 +286,23 @@ export function createErrorResponse(
  * could defeat the CAPTCHA by sending "x-api-key: anything".
  */
 export async function isApiKeyAuthenticated(headersList: Headers): Promise<boolean> {
+  return (await getApiKeyAuthState(headersList)) === 'authenticated';
+}
+
+/**
+ * As isApiKeyAuthenticated, but keeps `unavailable` distinct from `anonymous`.
+ *
+ * Use this wherever "not authenticated" is about to be read as "an anonymous
+ * browser", because that inference is only safe for `anonymous`. A caller that
+ * presented a key we could not check is not a browser, and must not be handed
+ * a bot challenge it was never given the means to answer.
+ */
+export async function getApiKeyAuthState(headersList: Headers): Promise<ApiKeyAuthState> {
   const apiKey = extractApiKey(headersList);
   if (!apiKey) {
-    return false;
+    return 'anonymous';
   }
-  return (await validateApiKey(apiKey)) !== null;
+  return (await resolveApiKey(apiKey)).state;
 }
 
 function extractApiKey(headersList: Headers): string | null {
@@ -336,12 +378,25 @@ export async function withApiAuth(
   const startTime = Date.now();
   const headersList = await headers();
   const apiKey = extractApiKey(headersList);
-  const validatedKey = await validateApiKey(apiKey);
-  
-  if (!validatedKey) {
+  const resolution = await resolveApiKey(apiKey);
+
+  // An outage is not a bad key. Answering 401 here sent integrators hunting for
+  // a credential problem that did not exist, and matched what checkRateLimit
+  // already does below when its own backing store is unreachable.
+  if (resolution.state === 'unavailable') {
+    return createErrorResponse(
+      'Authentication is temporarily unavailable',
+      'AUTH_UNAVAILABLE',
+      503
+    );
+  }
+
+  if (resolution.state === 'anonymous') {
     return createErrorResponse('Invalid or missing API key', 'UNAUTHORIZED', 401);
   }
-  
+
+  const validatedKey = resolution.key;
+
   // Check permissions
   const hasPermissions = requiredPermissions.every(perm => 
     validatedKey.permissions.includes(perm) || validatedKey.permissions.includes('*')

--- a/tests/api/bookingCreateIdempotencyFailClosed.test.ts
+++ b/tests/api/bookingCreateIdempotencyFailClosed.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/lib/api/auth', () => ({
   // These cases exercise an API-key-authenticated request, which is the one
   // case allowed to skip the Turnstile bot check.
   isApiKeyAuthenticated: vi.fn().mockResolvedValue(true),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
 }))
 
 vi.mock('@/lib/api/idempotency', () => ({

--- a/tests/api/event-bookings-cutoff.test.ts
+++ b/tests/api/event-bookings-cutoff.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/lib/api/auth', () => ({
     ) => handler(request)
   ),
   createApiResponse: vi.fn((data: unknown, status = 200) => Response.json(data, { status })),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
   createErrorResponse: vi.fn((message: string, code: string, status = 400) =>
     Response.json(
       {

--- a/tests/api/eventBookingsRouteSmsMeta.test.ts
+++ b/tests/api/eventBookingsRouteSmsMeta.test.ts
@@ -10,6 +10,7 @@ vi.mock('@/lib/api/auth', () => ({
     ) => handler(request)
   ),
   createApiResponse: vi.fn((data: unknown, status = 200) => Response.json(data, { status })),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
   createErrorResponse: vi.fn((error: string, code: string, status = 400) =>
     Response.json(
       {

--- a/tests/api/idempotencyPersistFailClosedAdditionalRoutes.test.ts
+++ b/tests/api/idempotencyPersistFailClosedAdditionalRoutes.test.ts
@@ -15,6 +15,7 @@ vi.mock('@/lib/api/auth', () => ({
   // These cases exercise an API-key-authenticated request, which is the one
   // case allowed to skip the Turnstile bot check.
   isApiKeyAuthenticated: vi.fn().mockResolvedValue(true),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
   createApiResponse: vi.fn((data: any, status = 200) => {
     const payload =
       data && typeof data === 'object' && 'success' in data ? data : { success: true, data }

--- a/tests/api/publicEndpointTurnstileGate.test.ts
+++ b/tests/api/publicEndpointTurnstileGate.test.ts
@@ -4,29 +4,68 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 /**
- * Both public private-booking endpoints used to skip Turnstile whenever an
- * x-api-key or authorization header was merely present. Neither header is
- * authenticated by anything on its own, so any anonymous caller could defeat the
- * bot check by sending "x-api-key: anything". The bypass must depend on a key
- * that actually validates.
+ * Two rules hold every public endpoint that skips Turnstile for API-key callers.
+ *
+ * 1. The skip must depend on a key that actually validates. These routes used to
+ *    skip whenever an x-api-key or authorization header was merely present, and
+ *    neither header is authenticated by anything on its own, so any anonymous
+ *    caller could defeat the bot check with "x-api-key: anything".
+ *
+ * 2. The gate must fire on `anonymous` specifically, never on "not
+ *    authenticated". Those differ when a key is presented that we could not
+ *    check, which is our outage rather than a bot. Such a caller has no widget
+ *    to solve, and the website's token is minted from a different Turnstile
+ *    widget whose secret this app does not hold, so gating them rejects a real
+ *    guest 100% of the time and calls our downtime a failed bot check.
  */
 const PUBLIC_ROUTES = [
   'src/app/api/private-booking-enquiry/route.ts',
-  'src/app/api/public/private-booking/route.ts'
+  'src/app/api/public/private-booking/route.ts',
+  'src/app/api/table-bookings/route.ts',
+  'src/app/api/event-bookings/route.ts'
 ]
 
 describe('public endpoint Turnstile gate', () => {
   it.each(PUBLIC_ROUTES)('%s validates the API key before skipping Turnstile', (route) => {
     const source = readFileSync(join(process.cwd(), route), 'utf8')
 
-    expect(source).toContain('isApiKeyAuthenticated')
+    expect(source).toContain('getApiKeyAuthState')
 
     // The header-presence test that made the bypass free.
     expect(source).not.toMatch(/Boolean\(\s*request\.headers\.get\('x-api-key'\)/)
   })
 
+  it.each(PUBLIC_ROUTES)('%s gates on anonymous, not on "not authenticated"', (route) => {
+    const source = readFileSync(join(process.cwd(), route), 'utf8')
+
+    expect(source).toMatch(/authState === 'anonymous'/)
+
+    // The negated forms are what swept an unverifiable key into the bot gate.
+    expect(source).not.toMatch(/if \(!authenticated\)\s*\{[\s\S]{0,400}?verifyTurnstileToken/)
+    expect(source).not.toMatch(/if \(!apiKeyAuthenticated\)\s*\{[\s\S]{0,400}?verifyTurnstileToken/)
+  })
+
   it.each(PUBLIC_ROUTES)('%s still runs verifyTurnstileToken', (route) => {
     const source = readFileSync(join(process.cwd(), route), 'utf8')
     expect(source).toContain('verifyTurnstileToken')
+  })
+})
+
+/**
+ * An unverifiable key must be reported as an outage, not as a bad credential.
+ * Answering 401 sent integrators hunting for a credential problem that did not
+ * exist, and matched what checkRateLimit already does when its own backing
+ * store is unreachable.
+ */
+describe('auth resolution', () => {
+  const source = readFileSync(join(process.cwd(), 'src/lib/api/auth.ts'), 'utf8')
+
+  it('keeps unavailable distinct from anonymous', () => {
+    expect(source).toContain("'unavailable'")
+    expect(source).toContain('AUTH_UNAVAILABLE')
+  })
+
+  it('answers 503 rather than 401 when the key cannot be checked', () => {
+    expect(source).toMatch(/state === 'unavailable'[\s\S]{0,300}?503/)
   })
 })

--- a/tests/api/tableBookingStructuredPersistence.test.ts
+++ b/tests/api/tableBookingStructuredPersistence.test.ts
@@ -42,6 +42,7 @@ vi.mock('@/lib/api/auth', () => ({
   // The table-bookings route now checks whether the API key actually validates
   // before skipping the bot check, so the mock has to provide it.
   isApiKeyAuthenticated: vi.fn().mockResolvedValue(true),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
   withApiAuth: vi.fn(
     async (handler: (request: Request) => Promise<Response>, _permissions: string[], request: Request) =>
       handler(request),

--- a/tests/api/tableBookingsRouteSmsMeta.test.ts
+++ b/tests/api/tableBookingsRouteSmsMeta.test.ts
@@ -5,6 +5,7 @@ vi.mock('@/lib/api/auth', () => ({
   // The table-bookings route now checks whether the API key actually validates
   // before skipping the bot check, so the mock has to provide it.
   isApiKeyAuthenticated: vi.fn().mockResolvedValue(true),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
   withApiAuth: vi.fn(
     async (
       handler: (request: Request) => Promise<Response>,


### PR DESCRIPTION
## What changed

`validateApiKey` returned `null` both for a key that is genuinely invalid and for a key we could not check at all, because any Supabase error was swallowed into the same `null`. Callers then read "not authenticated" as "anonymous browser", which is only true for the first case.

The public booking routes drew the worst possible conclusion from that. They run their Turnstile gate for unauthenticated callers, so a database blip during key validation sent a genuine website request into a bot check. The website mints its tokens from a **different** Turnstile widget whose secret this app does not hold, so our secret cannot validate their token under any circumstances. Every guest caught by this was refused with "Turnstile verification failed" for an outage that was entirely ours, and was left retrying a CAPTCHA that could never pass.

Key resolution is now a tri-state: `authenticated`, `anonymous`, or `unavailable`.

- The Turnstile gates fire on `anonymous` specifically. A caller presenting a key we could not check falls through to `withApiAuth`.
- `withApiAuth` answers **503 `AUTH_UNAVAILABLE`** instead of 401 when the key cannot be checked, matching what `checkRateLimit` already does when its own backing store is unreachable.
- `isApiKeyAuthenticated` keeps its boolean contract, so callers that only care whether they hold a usable key are unchanged.

Also tightens the `event-bookings` gate, which skipped Turnstile whenever an `x-api-key` or `authorization` header was merely *present*. Nothing authenticates either header on its own, so `x-api-key: anything` walked past the bot check there. It now validates the key like the other three public routes.

## Why

Reported live: a table booking on the-anchor.pub failed on Turnstile verification. The website side is fixed separately (peterjpitcher/the-anchor.pub#119, which makes the website verify its own token with the secret that actually pairs with its widget). This PR fixes the half that turns an authentication outage into a misleading bot-check rejection, and it is what stops the same symptom recurring the next time key validation has a bad moment.

## Testing done

- [x] Automated tests: 645 suites, 5,252 tests pass. `tests/api/publicEndpointTurnstileGate.test.ts` extended to cover all four public routes and to assert the gate keys on `anonymous` rather than on "not authenticated", plus new assertions that an unverifiable key is answered with 503 and not 401.
- [x] Lint clean, typecheck clean, production build succeeds.

## Complexity score

S

## Breaking changes

One response-code change worth noting for API consumers: a request whose API key cannot be validated because of an infrastructure failure now returns **503 `AUTH_UNAVAILABLE`** rather than **401 `UNAUTHORIZED`**. A genuinely invalid or missing key still returns 401. This is the point of the change: a 401 sent integrators hunting for a credential problem that did not exist.

## Migration risk

Low. No schema changes and no data migration. Behaviour for a valid key and for a genuinely absent key is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)