### PR TITLE
test(receipts): fix flaky VendorSummaryGrid watched-vendor test

### DIFF
--- a/tests/components/ReceiptVendorSummaryGrid.test.tsx
+++ b/tests/components/ReceiptVendorSummaryGrid.test.tsx
@@ -171,8 +171,10 @@ describe('VendorSummaryGrid', () => {
     render(<VendorSummaryGrid vendors={vendors} initialWatchlist={[]} initialReviews={[]} />)
 
     expect(await screen.findByText('Spend movement overview')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'All vendors' }))
-    const rows = screen.getAllByRole('row')
+    // The heading above renders while the movements are still loading, so it cannot stand
+    // in for the table being present. Wait for a control that only exists once loaded.
+    fireEvent.click(await screen.findByRole('button', { name: 'All vendors' }))
+    const rows = await screen.findAllByRole('row')
     expect(within(rows[1]).getByText('Food Supplier')).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: 'Year on year' }))
@@ -198,10 +200,12 @@ describe('VendorSummaryGrid', () => {
       />,
     )
 
-    await waitFor(() => expect(mockedGetReceiptVendorMovements).toHaveBeenCalled())
-    fireEvent.click(screen.getByRole('button', { name: 'Watched (1)' }))
+    // Wait for the panel to finish loading, not merely for the request to be issued. The
+    // view filters and the table only render once the movements promise has resolved, so
+    // asserting on the mock's call count leaves the click racing the first re-render.
+    fireEvent.click(await screen.findByRole('button', { name: 'Watched (1)' }))
 
-    const rows = screen.getAllByRole('row').slice(1)
+    const rows = (await screen.findAllByRole('row')).slice(1)
     expect(rows.some((row) => within(row).queryByText('Brewery A'))).toBe(true)
     expect(rows.some((row) => within(row).queryByText('Food Supplier'))).toBe(false)
   })


### PR DESCRIPTION
## What changed

`tests/components/ReceiptVendorSummaryGrid.test.tsx` now waits for the vendor movement panel to finish loading before clicking into it, instead of waiting for the mocked server action to have been called. Two tests were changed: `filters to watched vendors` (the reported flake) and `ranks movements by absolute pounds` (the same latent defect).

No retries, timeouts or test-runner flags were added, and no application code changed.

## Why

`VendorSummaryGrid` loads its movement data from a `useEffect`, which has already run by the time `render()` returns. So this line passed on `waitFor`'s immediate synchronous check and waited for nothing:

```ts
await waitFor(() => expect(mockedGetReceiptVendorMovements).toHaveBeenCalled())
```

The click and row queries that followed were racing the first re-render. The panel renders its filter buttons and table only once the movements promise resolves; until then it shows a loading spinner.

The tests passed only because Vitest's `mockResolvedValue` settles inside microtasks that React's async `act` happens to drain. Measured margin: 0 to 3 extra microtask ticks are absorbed, but any timer boundary is not. With a single `setTimeout(..., 1)` in the mocked action, the test fails with:

```
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name "Watched (1)"
```

`ranks movements by absolute pounds` gated on `findByText('Spend movement overview')`, which is the panel heading and renders during loading too, so it had the same defect.

It was not stale mock state, not a non-deterministic sort, and not a date-dependent assertion.

## Testing done

- [x] Manual testing: built before/after copies of the real test file with every mocked action forced across a 1ms timer boundary. Before: `filters to watched vendors` and `ranks movements by absolute pounds` both fail. After: all four tests pass.
- [x] Automated tests: fixed file run solo 5 times, green each time. Full suite green at 661 files / 5469 tests. `npx tsc --noEmit` clean. `eslint --max-warnings=0` clean on the changed file.

Caveat stated plainly: the original intermittency was not caught in the wild. Three sequential full runs, 15 solo runs and four concurrent full runs all had this test green. The diagnosis rests on the latency probe above, not on a natural reproduction.

A repo-wide sweep for the same anti-pattern found three other candidates, all safe: two already gate on a UI condition, and one asserts end state rather than gating a later interaction.

## Complexity score

XS (1) - single test file, 9 insertions, 5 deletions, no schema or integration changes.

## Breaking changes

None.

## Migration risk

None. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)