### PR TITLE
fix(ui): replace undefined design tokens and migrate v3 opacity utilities

### DIFF
--- a/src/app/(authenticated)/checklists/_components/AttributionPicker.tsx
+++ b/src/app/(authenticated)/checklists/_components/AttributionPicker.tsx
@@ -39,8 +39,8 @@ export function AttributionPicker({
     <div>
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
-          <Icon name="user" size={18} className="shrink-0 text-muted" />
-          <span className="shrink-0 text-sm text-muted">Completing as:</span>
+          <Icon name="user" size={18} className="shrink-0 text-text-muted" />
+          <span className="shrink-0 text-sm text-text-muted">Completing as:</span>
           <span className="truncate text-sm font-medium">
             {identity ? identity.name : 'Nobody chosen yet'}
           </span>
@@ -56,7 +56,7 @@ export function AttributionPicker({
       </div>
 
       {!identity && !open && (
-        <p className="mt-1 text-xs text-muted">Choose who you are, then tick your tasks.</p>
+        <p className="mt-1 text-xs text-text-muted">Choose who you are, then tick your tasks.</p>
       )}
 
       {open && (
@@ -71,11 +71,11 @@ export function AttributionPicker({
           />
           <div className="mt-2 max-h-72 overflow-y-auto">
             {loading ? (
-              <div className="flex items-center gap-2 p-3 text-sm text-muted">
+              <div className="flex items-center gap-2 p-3 text-sm text-text-muted">
                 <Spinner /> Loading staff
               </div>
             ) : filtered.length === 0 ? (
-              <p className="p-3 text-sm text-muted">No staff match that search.</p>
+              <p className="p-3 text-sm text-text-muted">No staff match that search.</p>
             ) : (
               <ul className="divide-y divide-border">
                 {filtered.map((c) => (

--- a/src/app/(authenticated)/checklists/_components/ChecklistMidShiftPrompt.tsx
+++ b/src/app/(authenticated)/checklists/_components/ChecklistMidShiftPrompt.tsx
@@ -122,12 +122,12 @@ export function ChecklistMidShiftPrompt() {
         </>
       }
     >
-      <p className="text-sm text-muted">These checks are due:</p>
+      <p className="text-sm text-text-muted">These checks are due:</p>
       <ul className="mt-3 space-y-2">
         {prompts.map((p) => (
           <li key={p.id} className="flex items-center justify-between gap-3 rounded-md border border-border p-2">
             <span className="min-w-0 truncate text-sm font-medium text-text">{p.title}</span>
-            <span className="shrink-0 text-xs text-muted">{p.slot}</span>
+            <span className="shrink-0 text-xs text-text-muted">{p.slot}</span>
           </li>
         ))}
       </ul>

--- a/src/app/(authenticated)/checklists/_components/ChecklistScreen.tsx
+++ b/src/app/(authenticated)/checklists/_components/ChecklistScreen.tsx
@@ -257,7 +257,7 @@ export function ChecklistScreen({ initial, error }: ChecklistScreenProps) {
           />
           {doneCount > 0 && (
             <div className="mt-2 flex items-center justify-between gap-3 border-t border-border pt-2">
-              <span className="text-xs text-muted">
+              <span className="text-xs text-text-muted">
                 {doneCount} of {allTasks.length} done
               </span>
               <button

--- a/src/app/(authenticated)/checklists/_components/TaskRow.tsx
+++ b/src/app/(authenticated)/checklists/_components/TaskRow.tsx
@@ -183,17 +183,17 @@ export function TaskRow({ task, identity, onChanged, onNeedIdentity, onBusyChang
               <span className="text-sm font-medium">{task.title}</span>
               {task.wasLate && <Badge tone="warning">Late</Badge>}
             </div>
-            <p className="mt-1 text-xs text-muted">
+            <p className="mt-1 text-xs text-text-muted">
               Done by {task.completedByName ?? 'someone'}
               {task.completedAt ? `, ${formatDateTime12Hour(task.completedAt)}` : ''}
             </p>
             {task.valueRecorded != null && (
-              <p className="mt-1 text-xs text-subtle">
+              <p className="mt-1 text-xs text-text-subtle">
                 Reading: {task.valueRecorded}
                 {task.valueUnit ? ` ${task.valueUnit}` : ''}
               </p>
             )}
-            {task.notes && <p className="mt-1 text-xs text-subtle">Note: {task.notes}</p>}
+            {task.notes && <p className="mt-1 text-xs text-text-subtle">Note: {task.notes}</p>}
             {task.valueBreach && (
               <div className="mt-2">
                 <Alert
@@ -236,12 +236,12 @@ export function TaskRow({ task, identity, onChanged, onNeedIdentity, onBusyChang
     return (
       <div className="rounded-md border border-border p-3">
         <div className="flex items-center justify-between gap-3">
-          <span className="min-w-0 flex-1 truncate text-sm text-muted">{task.title}</span>
+          <span className="min-w-0 flex-1 truncate text-sm text-text-muted">{task.title}</span>
           <Badge tone={tone}>{label}</Badge>
         </div>
         {/* The whole point of asking for a reason is that somebody reads it. */}
         {task.skipReason && (
-          <p className="mt-1 text-xs text-subtle">Reason: {task.skipReason}</p>
+          <p className="mt-1 text-xs text-text-subtle">Reason: {task.skipReason}</p>
         )}
       </div>
     )
@@ -251,7 +251,7 @@ export function TaskRow({ task, identity, onChanged, onNeedIdentity, onBusyChang
   return (
     <div className="rounded-md border border-border p-3">
       <div className="text-sm font-medium">{task.title}</div>
-      {task.instruction && <p className="mt-1 text-xs text-muted">{task.instruction}</p>}
+      {task.instruction && <p className="mt-1 text-xs text-text-muted">{task.instruction}</p>}
 
       {task.requiresValue && (
         <div className="mt-3 max-w-xs">

--- a/src/app/(authenticated)/checklists/manage/_components/TodosClient.tsx
+++ b/src/app/(authenticated)/checklists/manage/_components/TodosClient.tsx
@@ -153,9 +153,9 @@ export function TodosClient({ initial, error }: TodosClientProps) {
                       {todo.state === 'cancelled' && <Badge tone="neutral">Cancelled</Badge>}
                     </div>
                     {todo.description && (
-                      <p className="mt-1 text-xs text-muted">{todo.description}</p>
+                      <p className="mt-1 text-xs text-text-muted">{todo.description}</p>
                     )}
-                    <p className="mt-1 text-xs text-subtle">
+                    <p className="mt-1 text-xs text-text-subtle">
                       {todo.dueDate ? `Due ${formatDueDate(todo.dueDate)}` : 'No due date'}
                       {todo.assignedEmployeeName ? ` · Assigned to ${todo.assignedEmployeeName}` : ''}
                       {todo.state === 'done' && todo.completedByName

--- a/src/app/(authenticated)/dashboard/_components/DashboardClient.tsx
+++ b/src/app/(authenticated)/dashboard/_components/DashboardClient.tsx
@@ -351,11 +351,11 @@ export default function DashboardClient({
             </div>
             <div>
               <div className="text-[11px] text-text-muted">Week vs last</div>
-              <div className={`text-base font-semibold tabular-nums ${revenueSummary.vsLastWeek.startsWith('-') ? 'text-error' : revenueSummary.vsLastWeek === '--' ? 'text-text-muted' : 'text-success'}`}>{revenueSummary.vsLastWeek}</div>
+              <div className={`text-base font-semibold tabular-nums ${revenueSummary.vsLastWeek.startsWith('-') ? 'text-danger' : revenueSummary.vsLastWeek === '--' ? 'text-text-muted' : 'text-success'}`}>{revenueSummary.vsLastWeek}</div>
             </div>
             <div>
               <div className="text-[11px] text-text-muted">Last year same week</div>
-              <div className={`text-base font-semibold tabular-nums ${revenueSummary.lastYearSameWeek.startsWith('-') ? 'text-error' : revenueSummary.lastYearSameWeek === '--' ? 'text-text-muted' : 'text-success'}`}>{revenueSummary.lastYearSameWeek}</div>
+              <div className={`text-base font-semibold tabular-nums ${revenueSummary.lastYearSameWeek.startsWith('-') ? 'text-danger' : revenueSummary.lastYearSameWeek === '--' ? 'text-text-muted' : 'text-success'}`}>{revenueSummary.lastYearSameWeek}</div>
             </div>
           </div>
         </CardBody>

--- a/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
+++ b/src/app/(authenticated)/events/[id]/EventDetailClient.tsx
@@ -666,7 +666,7 @@ export default function EventDetailClient({
               <p className="text-sm text-text-muted">Checking payment…</p>
             ) : cancelRefundInfo && cancelRefundInfo.maxRefundable > 0 ? (
               cancelRefundInfo.canRefund ? (
-                <div className="space-y-2 rounded-md border border-line bg-surface-sunk p-3">
+                <div className="space-y-2 rounded-md border border-border bg-surface-2 p-3">
                   <label className="flex items-center gap-2 text-sm font-medium text-text">
                     <input
                       type="checkbox"
@@ -867,15 +867,15 @@ function ShortLinksTab({ links, totalClicks }: { links: EventMarketingLink[]; to
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Total Clicks</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{totalClicks.toLocaleString()}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{totalClicks.toLocaleString()}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Active Links</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{links.length}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{links.length}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Avg. Clicks/Link</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">
+          <p className="mt-1 text-2xl font-semibold text-text-strong">
             {links.length > 0 ? Math.round(totalClicks / links.length) : 0}
           </p>
         </Card>
@@ -1194,27 +1194,27 @@ function AttendeesTab({
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 min-[1280px]:grid-cols-6">
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Total Seats Booked</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{totalSeats}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{totalSeats}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Active Bookings</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{activeBookingsCount}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{activeBookingsCount}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Capacity</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{capacityPct !== null ? `${capacityPct}%` : '-'}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{capacityPct !== null ? `${capacityPct}%` : '-'}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Est. Revenue</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{estimatedRevenue !== null ? formatCurrency(estimatedRevenue) : '-'}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{estimatedRevenue !== null ? formatCurrency(estimatedRevenue) : '-'}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Paid</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{formatCurrency(totalPaidAmount)}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{formatCurrency(totalPaidAmount)}</p>
         </Card>
         <Card padding="md">
           <p className="text-xs font-medium text-text-muted">Link Clicks</p>
-          <p className="mt-1 text-2xl font-semibold text-text-primary">{totalLinkClicks.toLocaleString()}</p>
+          <p className="mt-1 text-2xl font-semibold text-text-strong">{totalLinkClicks.toLocaleString()}</p>
         </Card>
       </div>
 

--- a/src/app/(authenticated)/invoices/MobileInvoiceCard.tsx
+++ b/src/app/(authenticated)/invoices/MobileInvoiceCard.tsx
@@ -81,7 +81,7 @@ export function MobileInvoiceCard({
               event.stopPropagation()
               onDownload?.(invoice)
             }}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-600 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Download className="h-4 w-4" aria-hidden="true" />
           </button>

--- a/src/app/(authenticated)/marketing/campaigns/[id]/CampaignDetailClient.tsx
+++ b/src/app/(authenticated)/marketing/campaigns/[id]/CampaignDetailClient.tsx
@@ -659,7 +659,7 @@ export function CampaignDetailClient({
             will. Nothing is recorded against any contact, so it does not affect the audience,
             the frequency cap or the campaign figures.
           </p>
-          <p className="text-sm text-muted">
+          <p className="text-sm text-text-muted">
             Worth checking in Outlook on Windows, Gmail, and Apple Mail in dark mode. Those are
             the three that render email differently enough to matter.
           </p>

--- a/src/app/(authenticated)/marketing/contacts/ContactsClient.tsx
+++ b/src/app/(authenticated)/marketing/contacts/ContactsClient.tsx
@@ -429,7 +429,7 @@ export function ContactsClient({
               )}
 
               {selectedContacts.length > 0 && (
-                <div className="mb-3 flex flex-col gap-2 rounded-md border border-border bg-surface-muted p-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="mb-3 flex flex-col gap-2 rounded-md border border-border bg-surface-2 p-3 sm:flex-row sm:items-center sm:justify-between">
                   <p className="min-w-0 text-sm text-text">
                     {selectedContacts.length} selected on this page
                   </p>
@@ -597,7 +597,7 @@ export function ContactsClient({
                         <TableRow>
                           <TableCell
                             colSpan={CONTACT_TABLE_COLUMNS}
-                            className="whitespace-normal bg-surface-muted align-top"
+                            className="whitespace-normal bg-surface-2 align-top"
                           >
                             <ContactDetailPanel
                               contact={contact}

--- a/src/app/(authenticated)/mileage/_components/MileageClient.tsx
+++ b/src/app/(authenticated)/mileage/_components/MileageClient.tsx
@@ -308,7 +308,7 @@ export function MileageClient({
 
       {/* Filter row */}
       {showFilters && (
-        <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border bg-surface-1 p-4">
+        <div className="flex flex-wrap items-end gap-3 rounded-lg border border-border bg-surface p-4">
           <div className="min-w-64 flex-1">
             <label htmlFor="filter-search" className="block text-xs font-medium text-text-muted mb-1">
               Search

--- a/src/app/(authenticated)/oj-projects/clients/_components/ClientsClient.tsx
+++ b/src/app/(authenticated)/oj-projects/clients/_components/ClientsClient.tsx
@@ -1112,7 +1112,7 @@ export function ClientsClient({ initialClients }: ClientsClientProps): React.Rea
                       : ''}
                   </p>
                   {!workRecord.record.reconciles && (
-                    <p className="text-error mb-2">
+                    <p className="text-danger mb-2">
                       These figures do not add up against the invoices, so no PDF can be produced.
                       Please check the entries before sending anything to the client.
                     </p>

--- a/src/app/(authenticated)/receipts/_components/ui/ReceiptRules.tsx
+++ b/src/app/(authenticated)/receipts/_components/ui/ReceiptRules.tsx
@@ -498,7 +498,7 @@ export function ReceiptRules({
           <div className="p-4">
             <div className="grid gap-4 lg:grid-cols-2">
               <Card>
-                <h3 className="text-md font-semibold text-text-strong mb-3">New rule</h3>
+                <h3 className="text-base font-semibold text-text-strong mb-3">New rule</h3>
                 {pendingSuggestion && (
                   <div className="mb-3 rounded-md border border-border bg-success-soft p-3 text-xs text-success-fg">
                     <div className="flex flex-wrap items-center justify-between gap-2">

--- a/src/app/(authenticated)/settings/business-hours/SpecialHoursCalendar.tsx
+++ b/src/app/(authenticated)/settings/business-hours/SpecialHoursCalendar.tsx
@@ -217,8 +217,8 @@ export function SpecialHoursCalendar({ canManage, initialSpecialHours, initialOv
               const classNames = [
                 'min-h-[88px] rounded-lg border px-2 py-2 text-left transition relative',
                 day.inCurrentMonth ? 'border-gray-200' : 'border-gray-100 bg-gray-50 text-gray-400',
-                day.isToday ? 'ring-2 ring-primary-500 ring-offset-2' : '',
-                canManage ? 'hover:border-primary-400 hover:shadow-md cursor-pointer' : 'cursor-default',
+                day.isToday ? 'ring-2 ring-primary ring-offset-2' : '',
+                canManage ? 'hover:border-primary hover:shadow-md cursor-pointer' : 'cursor-default',
               ]
 
               if (hasSpecial) {

--- a/src/components/features/customers/CustomerImport.tsx
+++ b/src/components/features/customers/CustomerImport.tsx
@@ -297,7 +297,7 @@ export function CustomerImport({ onImportComplete, onCancel, existingCustomers }
             </p>
           </div>
 
-          <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg mb-6">
+          <div className="overflow-hidden shadow ring-1 ring-black/5 md:rounded-lg mb-6">
             <DataTable<ParsedCustomer>
               data={parsedData}
               getRowKey={(row: ParsedCustomer) => parsedData.indexOf(row)}

--- a/src/components/features/customers/CustomerLabelSelector.tsx
+++ b/src/components/features/customers/CustomerLabelSelector.tsx
@@ -166,7 +166,7 @@ export function CustomerLabelSelector({
       {/* Label Selector Dropdown */}
       {showSelector && canEdit && (
         <div className="relative">
-          <div className="absolute z-10 mt-1 w-64 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5">
+          <div className="absolute z-10 mt-1 w-64 rounded-md bg-white shadow-lg ring-1 ring-black/5">
             <div className="py-1">
               {availableLabels.map((label) => (
                 <button type="button"

--- a/src/components/features/employees/DeleteEmployeeButton.tsx
+++ b/src/components/features/employees/DeleteEmployeeButton.tsx
@@ -49,7 +49,7 @@ export default function DeleteEmployeeButton({ employeeId, employeeName }: Delet
 
       {isOpen && (
         <div className="relative z-10" aria-labelledby="modal-title" role="dialog" aria-modal="true">
-          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"></div>
+          <div className="fixed inset-0 bg-gray-500/75 transition-opacity"></div>
           <div className="fixed inset-0 z-10 overflow-y-auto">
             <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
               <form action={dispatch} className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">

--- a/src/components/features/employees/EmergencyContactsTab.tsx
+++ b/src/components/features/employees/EmergencyContactsTab.tsx
@@ -60,7 +60,7 @@ function DeleteContactButton({
 
       {isOpen && (
         <div className="relative z-50" role="dialog" aria-modal="true">
-          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
           <div className="fixed inset-0 z-50 overflow-y-auto">
             <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
               <form

--- a/src/components/features/employees/EmployeeAttachmentsList.tsx
+++ b/src/components/features/employees/EmployeeAttachmentsList.tsx
@@ -73,7 +73,7 @@ function DeleteAttachmentButton({
 
       {isOpen && (
         <div className="relative z-50" aria-labelledby="delete-attachment" role="dialog" aria-modal="true">
-          <div className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+          <div className="fixed inset-0 bg-gray-500/75 transition-opacity" />
           <div className="fixed inset-0 z-50 overflow-y-auto">
             <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
               <form

--- a/src/components/features/employees/InviteEmployeeModal.tsx
+++ b/src/components/features/employees/InviteEmployeeModal.tsx
@@ -24,7 +24,7 @@ export default function InviteEmployeeModal({ onClose, onSuccess }: InviteEmploy
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto" role="dialog" aria-modal="true">
-      <div className="fixed inset-0 bg-gray-500 bg-opacity-75" onClick={onClose} />
+      <div className="fixed inset-0 bg-gray-500/75" onClick={onClose} />
       <div className="flex min-h-full items-center justify-center p-4">
         <div className="relative w-full max-w-md rounded-lg bg-white shadow-xl p-6">
           <h2 className="text-lg font-semibold text-gray-900 mb-1">Invite Employee</h2>

--- a/src/components/features/invoices/RefundDialog.tsx
+++ b/src/components/features/invoices/RefundDialog.tsx
@@ -255,7 +255,7 @@ export function RefundDialog({
                   <button
                     type="button"
                     onClick={handleRefundInFull}
-                    className="text-xs text-primary-600 hover:text-primary-700 font-medium"
+                    className="text-xs text-primary hover:text-primary-hover font-medium"
                   >
                     Refund in full
                   </button>

--- a/src/components/modals/AddEmergencyContactModal.tsx
+++ b/src/components/modals/AddEmergencyContactModal.tsx
@@ -53,7 +53,7 @@ export default function AddEmergencyContactModal({
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity">
       <div className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
         <button type="button"
           onClick={onClose}

--- a/src/components/modals/EditEmergencyContactModal.tsx
+++ b/src/components/modals/EditEmergencyContactModal.tsx
@@ -52,7 +52,7 @@ export default function EditEmergencyContactModal({
   ]
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity">
       <div className="relative w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
         <button type="button"
           onClick={onClose}

--- a/src/ds/composites/DataTable.tsx
+++ b/src/ds/composites/DataTable.tsx
@@ -193,7 +193,7 @@ export function DataTable<T = unknown>({
         {isMobile ? (
           loadingIndicator
         ) : (
-          <div className={cn('overflow-hidden rounded-lg', bordered && 'shadow ring-1 ring-black ring-opacity-5')}>
+          <div className={cn('overflow-hidden rounded-lg', bordered && 'shadow ring-1 ring-black/5')}>
             <table className="min-w-full divide-y divide-gray-300">
               <thead className="bg-gray-50">
                 <tr>
@@ -363,7 +363,7 @@ export function DataTable<T = unknown>({
   // Desktop view
   return (
     <div className={cn('w-full', className)} {...props}>
-      <div className={cn('overflow-hidden rounded-lg', bordered && 'shadow ring-1 ring-black ring-opacity-5')}>
+      <div className={cn('overflow-hidden rounded-lg', bordered && 'shadow ring-1 ring-black/5')}>
         <div className="overflow-x-auto">
           <table className="min-w-full divide-y divide-gray-300">
             <thead className={cn('bg-gray-50', stickyHeader && 'sticky top-0 z-10')}>


### PR DESCRIPTION
## What changed

Two related fixes for Tailwind classes that generated no CSS rule at all.

**1. Undefined design tokens (15 files).** Twelve class names referenced tokens with no `--color-*` entry in the `@theme` block of `globals.css`, so Tailwind emitted nothing and the elements rendered with no colour. The worst was `text-muted` (13 uses across the checklists screens), which needs to be `text-text-muted`.

**2. Tailwind v3 opacity utilities (9 files).** `bg-opacity-*` and `ring-opacity-*` were removed in v4, so six modal overlays rendered as a solid grey or black sheet over the page instead of a translucent one.

## Why

Every one of these was invisible breakage: no build error, no lint error, no type error, just an element with a missing background or the wrong text colour. The opacity ones were a visible live bug, and someone had already hit it and fixed a single instance in `EmployeeStatusActions.tsx`, leaving a comment that the old class "rendered a solid grey sheet over the page". This applies that same fix everywhere else.

Replacements follow existing convention in the codebase rather than preference:

- `text-text-strong` leads `text-text` 15 to 9 for large stat numbers app-wide
- the `border-border` / `bg-surface-2` pairing is copied verbatim from the working sibling panel at `EventDetailClient.tsx:1528`, same file, same shape
- `bg-surface` is the dominant pattern for that exact filter-bar class string
- semantic `primary` leads `brand-*` shades 194 to 17, and `hover:border-primary` already existed as a convention

`settings/design-system/page.tsx` is deliberately untouched. Its `'text-muted'` and `'text-subtle'` entries are token *names* that the page derives class names from, not class names themselves. Changing them would have broken the very page that documents this trap.

Note `ReassignQueueClient.tsx` is not in this PR: #110 landed the identical fix on main while this work was in progress.

## Testing done

- [x] Automated tests: existing tests pass, 669 files / 5570 tests, exit 0
- [x] `npx tsc --noEmit` exit 0 (needs `--max-old-space-size=12288`)
- [x] `npm run lint` exit 0
- [x] Compiled `globals.css` with the Tailwind 4.3 compiler and diffed all 33k scanned candidates against the emitted CSS. **Zero dead colour classes remain.** The entries still in the raw dead list are all CSS property names (`border-radius`, `stroke-width`) or English prose (`to-do`, `divide-by-zero`), and none appear inside a `className`.
- [x] Confirmed no test asserts on any changed class name, so the suite passing is a real regression check

## Complexity score

S. 24 files, 48 lines, every change a pure class-name swap. No logic, schema, or API changes.

## Breaking changes

None.

## Migration risk

None. No database, config, or dependency changes.

The only user-visible difference is intended: the six modal overlays change from a solid sheet to a translucent one, and previously colourless text and panels now render in their intended colour.