### PR TITLE
ci: give the typecheck step enough heap to finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
 
       - name: Typecheck
         run: npx tsc --noEmit
+        env:
+          # tsc on this codebase peaks a little over 4 GB, which is right on the
+          # runner's default heap limit, so it aborted with exit 134 rather than
+          # reporting type errors. Give it headroom. The Build step below already
+          # does the same thing for the same reason.
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Test
         run: npm run test:coverage


### PR DESCRIPTION
## What changed

Adds `NODE_OPTIONS: --max-old-space-size=8192` to the Typecheck step in `.github/workflows/ci.yml`.

## Why

`npx tsc --noEmit` peaks a little over 4 GB on this codebase, which lands right on the GitHub runner's default heap limit. It aborted with `FATAL ERROR: Ineffective mark-compacts near heap limit` and exit 134, so `build-and-lint` has gone red on every push while the code itself type-checked cleanly. CI has effectively had **no working typecheck gate for the last eight merges**, and because the job dies at Typecheck, the Test and Build steps never ran either.

## How the number was chosen

Measured, not guessed:

| Heap | `npx tsc --noEmit` |
|---|---|
| runner default (~4 GB) | OOM at 4040 MB, exit 134 |
| 4096 MB | passes, but only just |
| 6144 MB | passes |
| 8192 MB | passes |

The requirement sits on the boundary, which is why it aborts on the runner but passes locally. 8192 MB is roughly double the need on a runner with 16 GB of RAM.

## Scope

Only the Typecheck step needed it. `npm run test:coverage` was measured at **0.7 GB peak RSS** and is deliberately left alone. The Build step already sets the same option for the same reason, so this follows the existing pattern in the file rather than introducing a new one.

## Testing done

- [x] Measured tsc at 4096 / 6144 / 8192 MB on Node 20 to find the actual requirement
- [x] Ran `npm run test:coverage` exactly as CI does: 671 files / 5605 tests pass at default heap, 0.7 GB peak
- [x] YAML parses and the step's env resolves as intended
- [x] The real proof is this PR's own CI run going green

## Complexity score

XS. One step, five lines including the explanatory comment.

## Breaking changes

None. Workflow configuration only, no application code.

## Migration risk

None.