### PR TITLE
feat(api): serve event artwork through a scope-gated endpoint

### DIFF
--- a/docs/guides/api/API_README.md
+++ b/docs/guides/api/API_README.md
@@ -30,6 +30,10 @@ All endpoints live in `src/app/api/`. Consult the corresponding route file for r
 - `GET /events/{id}` returns the event object as `data` (no nested `event` wrapper); `_meta.lastUpdated` is included for cache diagnostics.
 - `POST /events/{id}/check-availability` includes both legacy fields (`available_seats`, `requested_seats`) and normalized capacity fields (`capacity`, `remaining`, `percentage_full`).
 - `GET /event-categories` includes `event_count` for upcoming active events (scheduled/draft/rescheduled/postponed).
+- `GET /events` and `GET /events/{id}` carry only the website-facing image fields (`image[]`, `heroImageUrl`, `thumbnailImageUrl`, `posterImageUrl`, `squareImageUrl`, `landscapeImageUrl`, `socialImageUrl`). Story and print-poster URLs are never among them: the website reads `image[0]` ahead of every named field and prefers `posterImageUrl`, so a 9:16 crop or an A4 PDF appearing there would be published on live pages.
+- `GET /events/{id}/artwork` serves the designed kit (`square`, `story`, `landscape`) to keys holding **both** `read:events` and `read:events:artwork`. It is a separate route because its body depends on the caller's scopes, so unlike the endpoints above it is `Cache-Control: no-store` with no ETag and can never be shared between callers by a cache.
+  - `403` means the scope is missing. `404` means no such event, or an installation predating the route. `200` with all-null `variants` means the event genuinely has no artwork. Consumers must keep these apart, or a provisioning mistake looks identical to an event with no images.
+  - The `event-images` bucket is public, so the scope governs which integrations *discover* these URLs. It is not confidentiality.
 - `POST /table-bookings` is the only public table-booking endpoint. It requires `Idempotency-Key` and returns `data.state` as one of: `confirmed`, `pending_payment`, or `blocked`.
 - `POST /table-bookings` next-step behavior: when state is `pending_payment`, `next_step_url` and `hold_expires_at` are returned; when state is `blocked`, `blocked_reason` is returned.
 

--- a/docs/guides/api/openapi.yaml
+++ b/docs/guides/api/openapi.yaml
@@ -72,7 +72,77 @@ components:
       in: header
       name: X-Twilio-Signature
       description: Twilio request signature for webhook validation
+
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: >
+        Integration API key. Scopes are held per key in api_keys.permissions.
+        A key carrying "*" satisfies every scope.
   schemas:
+    EventArtworkFile:
+      type: object
+      required: [url, mimeType, sizeBytes, updatedAt, inherited]
+      properties:
+        url:
+          type: string
+          format: uri
+          description: Absolute https URL of the artwork file in public storage.
+        mimeType:
+          type: string
+          nullable: true
+        sizeBytes:
+          type: integer
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: When this variant was last replaced. Null when inherited.
+        inherited:
+          type: boolean
+          description: >
+            True when the URL comes from the event's cache column with no
+            event_images row behind it, which happens when the event inherits its
+            category default image. The file is then category stock rather than
+            artwork designed for this event, and carries no metadata.
+
+    EventArtwork:
+      type: object
+      required: [eventId, slug, kitUpdatedAt, variants]
+      properties:
+        eventId:
+          type: string
+          format: uuid
+        slug:
+          type: string
+          nullable: true
+        kitUpdatedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >
+            Newest updatedAt across the emitted variants. Variants are uploaded
+            one at a time, so a kit replaced mid-session can be observed as a
+            mixture; comparing the per-variant timestamps detects that.
+        variants:
+          type: object
+          description: >
+            All three keys are always present. A variant is either a complete
+            object or an explicit null. An absent key is not a valid response.
+          required: [square, story, landscape]
+          properties:
+            square:
+              nullable: true
+              allOf: [{ $ref: '#/components/schemas/EventArtworkFile' }]
+            story:
+              nullable: true
+              allOf: [{ $ref: '#/components/schemas/EventArtworkFile' }]
+            landscape:
+              nullable: true
+              allOf: [{ $ref: '#/components/schemas/EventArtworkFile' }]
+
     Error:
       type: object
       properties:
@@ -719,6 +789,68 @@ paths:
           description: Unauthorized
         '404':
           description: Event not found
+
+  /events/{id}/artwork:
+    get:
+      tags:
+        - Events
+      summary: Get the designed artwork kit for one event
+      description: >
+        Square, story and landscape artwork for a single event.
+
+
+        Separate from /events/{id} on purpose. That endpoint is shared-cacheable
+        with an ETag, so a body that changed shape with the caller's scopes could
+        be cross-served between integrations. Every response here is
+        `Cache-Control: no-store` with no ETag.
+
+
+        The three outcomes are deliberately distinguishable: 403 means the key
+        lacks the scope, 404 means no such event (or an installation predating
+        this route), and 200 with all-null variants means the event genuinely has
+        no artwork. Collapsing them would let the feature fail silently.
+
+
+        Story and print-poster URLs are excluded from the website-facing image
+        fields on /events and /events/{id}; story is served here instead. The
+        underlying storage bucket is public, so this scope governs discovery, not
+        confidentiality.
+      security:
+        - apiKeyAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Event UUID or slug.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Artwork kit. Requires the read:events:artwork scope.
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/EventArtwork'
+        '401':
+          description: Invalid or missing API key
+        '403':
+          description: >
+            The key is valid but lacks read:events or read:events:artwork. Never
+            report this to a user as "no artwork".
+        '404':
+          description: Event not found, or this installation predates the route
+        '429':
+          description: Rate limit exceeded
 
   /events/{id}/check-availability:
     post:

--- a/src/app/(authenticated)/settings/api-keys/ApiKeysManager.tsx
+++ b/src/app/(authenticated)/settings/api-keys/ApiKeysManager.tsx
@@ -21,6 +21,11 @@ interface ApiKeysManagerProps {
 
 const PERMISSION_OPTIONS = [
   { value: 'read:events', label: 'Read Events' },
+  // Gates GET /api/events/{id}/artwork, the only route that emits the story and
+  // print-poster URLs. Listed here so a rotated key can be issued with it: a
+  // replacement key created without it leaves artwork import reporting
+  // "unavailable" while every other check stays green.
+  { value: 'read:events:artwork', label: 'Read Event Artwork' },
   { value: 'write:events', label: 'Write Events' },
   { value: 'write:performers', label: 'Write Performers' },
   { value: 'read:menu', label: 'Read Menu' },

--- a/src/app/api/events/[id]/artwork/route.test.ts
+++ b/src/app/api/events/[id]/artwork/route.test.ts
@@ -1,0 +1,171 @@
+// The scoped artwork endpoint. What matters here is not the payload so much as
+// the three outcomes staying distinguishable (403 / 404 / 200-with-nulls) and
+// nothing this route emits ever entering a shared cache.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+type Row = Record<string, unknown> | null
+
+const eventResult: { data: Row; error: unknown } = { data: null, error: null }
+const imagesResult: { data: unknown; error: unknown } = { data: [], error: null }
+
+const maybeSingleMock = vi.fn(() => Promise.resolve(eventResult))
+const inMock = vi.fn(() => Promise.resolve(imagesResult))
+const eqMock = vi.fn(() => ({ maybeSingle: maybeSingleMock, in: inMock }))
+const selectMock = vi.fn(() => ({ eq: eqMock }))
+const fromMock = vi.fn(() => ({ select: selectMock }))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(() => ({ from: fromMock })),
+}))
+
+// Keep createApiResponse / createErrorResponse real so the cache headers under
+// test are the ones the route will actually send. Only the key lookup is faked.
+let permissions: string[] = ['read:events', 'read:events:artwork']
+vi.mock('@/lib/api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api/auth')>()
+  return {
+    ...actual,
+    withApiAuth: vi.fn(
+      (
+        handler: (req: Request, apiKey: { id: string; permissions: string[] }) => Promise<Response>,
+        required: string[],
+        req: Request,
+        options?: { cacheMode?: 'public' | 'private' }
+      ) => {
+        const allowed = required.every((p) => permissions.includes(p) || permissions.includes('*'))
+        if (!allowed) {
+          return Promise.resolve(
+            actual.createErrorResponse(
+              'Insufficient permissions',
+              'FORBIDDEN',
+              403,
+              undefined,
+              options?.cacheMode ?? 'public'
+            )
+          )
+        }
+        return handler(req, { id: 'test-key', permissions })
+      }
+    ),
+  }
+})
+
+import { GET } from './route'
+
+const EVENT = {
+  id: '9d03a427-d331-45bd-91af-142b396b82ae',
+  slug: 'karaoke-night',
+  hero_image_url: 'https://cdn/square.png',
+  story_image_url: 'https://cdn/story.png',
+  landscape_image_url: null,
+}
+
+function request(id = EVENT.id) {
+  return new NextRequest(`http://localhost/api/events/${id}/artwork`, {
+    method: 'GET',
+    headers: { 'X-API-Key': 'test-key' },
+  })
+}
+
+function context(id = EVENT.id) {
+  return { params: Promise.resolve({ id }) }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  permissions = ['read:events', 'read:events:artwork']
+  eventResult.data = EVENT
+  eventResult.error = null
+  imagesResult.data = [
+    { image_type: 'square', mime_type: 'image/png', file_size_bytes: 1, updated_at: '2026-08-24T10:00:00Z' },
+    { image_type: 'story', mime_type: 'image/png', file_size_bytes: 2, updated_at: '2026-08-24T11:00:00Z' },
+  ]
+  imagesResult.error = null
+})
+
+describe('GET /api/events/[id]/artwork', () => {
+  it('returns 403 when the key holds read:events but not the artwork scope', async () => {
+    permissions = ['read:events']
+    const res = await GET(request(), context())
+    const json = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(json.error.code).toBe('FORBIDDEN')
+    // A missing scope must not read as "this event has no artwork".
+    expect(json.data).toBeUndefined()
+  })
+
+  it('serves a wildcard key', async () => {
+    permissions = ['*']
+    const res = await GET(request(), context())
+    expect(res.status).toBe(200)
+  })
+
+  it('never allows any response to enter a shared cache', async () => {
+    // The body depends on the caller's scopes. A shared cache keyed on URL alone
+    // would hand one key's copy to another.
+    for (const perms of [['read:events'], ['read:events', 'read:events:artwork']]) {
+      permissions = perms
+      const res = await GET(request(), context())
+      expect(res.headers.get('Cache-Control')).toBe('no-store')
+      expect(res.headers.get('ETag')).toBeNull()
+    }
+  })
+
+  it('sends no ETag on a 404 either', async () => {
+    eventResult.data = null
+    const res = await GET(request(), context())
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.headers.get('ETag')).toBeNull()
+  })
+
+  it('returns every variant key with explicit nulls for an event with no artwork', async () => {
+    eventResult.data = { id: EVENT.id, slug: EVENT.slug }
+    imagesResult.data = []
+    const res = await GET(request(), context())
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data.variants).toEqual({ square: null, story: null, landscape: null })
+    expect(json.data.kitUpdatedAt).toBeNull()
+  })
+
+  it('marks an inherited square when no metadata row exists for it', async () => {
+    imagesResult.data = [{ image_type: 'story', mime_type: 'image/png', file_size_bytes: 2, updated_at: '2026-08-24T11:00:00Z' }]
+    const res = await GET(request(), context())
+    const json = await res.json()
+
+    expect(json.data.variants.square.inherited).toBe(true)
+    expect(json.data.variants.story.inherited).toBe(false)
+  })
+
+  it('still returns the URLs when the metadata query fails', async () => {
+    // Metadata is descriptive. Losing it must not cost the consumer the artwork.
+    imagesResult.data = null
+    imagesResult.error = { message: 'boom' }
+    const res = await GET(request(), context())
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data.variants.square.url).toBe('https://cdn/square.png')
+    expect(json.data.variants.square.inherited).toBe(true)
+  })
+
+  it('looks a non-uuid identifier up by slug, never by id', async () => {
+    // events.id is a uuid column: handing it a slug raises a type error and
+    // would surface a 500 for what is really a missing event.
+    await GET(request('karaoke-night'), context('karaoke-night'))
+    expect(eqMock).toHaveBeenCalledWith('slug', 'karaoke-night')
+    expect(eqMock).not.toHaveBeenCalledWith('id', 'karaoke-night')
+  })
+
+  it('returns 500 rather than 404 when the event lookup itself fails', async () => {
+    eventResult.data = null
+    eventResult.error = { message: 'connection reset' }
+    const res = await GET(request(), context())
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/app/api/events/[id]/artwork/route.ts
+++ b/src/app/api/events/[id]/artwork/route.ts
@@ -1,0 +1,109 @@
+/**
+ * GET /api/events/{idOrSlug}/artwork
+ *
+ * The designed artwork kit for one event: square, story and landscape.
+ *
+ * Deliberately a separate route rather than a conditional block on
+ * /api/events/{id}. That endpoint is cached with `public, max-age=60` and an
+ * ETag, and varies only on Origin. A body that changed shape with the caller's
+ * scopes would let a shared cache hand the website's copy to CheersAI, or the
+ * reverse, with no way for either to tell. Splitting the route keeps every
+ * existing representation single-shaped and lets this one be `private,
+ * no-store` throughout.
+ *
+ * Three outcomes the consumer must be able to tell apart:
+ *   403  the key lacks read:events:artwork
+ *   404  no such event, or an AMS that predates this route
+ *   200  authorised; `variants` always carries all three keys, each a full
+ *        object or an explicit null
+ *
+ * Without that separation, "this event has no artwork" and "artwork import is
+ * not wired up" look identical, and the feature can die silently.
+ */
+
+import { NextRequest } from 'next/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { withApiAuth, createApiResponse, createErrorResponse } from '@/lib/api/auth'
+import {
+  buildEventArtworkPayload,
+  EVENT_ARTWORK_VARIANTS,
+  type EventArtworkEventRow,
+  type EventArtworkImageRow,
+} from '@/lib/api/eventArtworkFields'
+
+const ARTWORK_SCOPE = 'read:events:artwork'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Every response from this route is caller-dependent, so none may be shared. */
+function artworkResponse(data: unknown, status = 200) {
+  return createApiResponse(data, status, {}, 'GET', 'private')
+}
+
+function artworkError(message: string, code: string, status: number) {
+  return createErrorResponse(message, code, status, undefined, 'private')
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  return withApiAuth(
+    async (_req, apiKey) => {
+      const hasArtworkScope =
+        apiKey.permissions.includes(ARTWORK_SCOPE) || apiKey.permissions.includes('*')
+
+      if (!hasArtworkScope) {
+        return artworkError(
+          `This API key is not permitted to read event artwork. Grant the ${ARTWORK_SCOPE} scope.`,
+          'FORBIDDEN',
+          403
+        )
+      }
+
+      const params = await context.params
+      const supabase = createAdminClient()
+
+      // Same lookup rule as the detail route: events.id is a uuid column, so a
+      // slug value handed to an id lookup raises a type error and would surface
+      // a 500 for what is really a missing event.
+      const selection = 'id, slug, hero_image_url, story_image_url, landscape_image_url'
+      const { data: event, error } = UUID_PATTERN.test(params.id)
+        ? await supabase.from('events').select(selection).eq('id', params.id).maybeSingle()
+        : await supabase.from('events').select(selection).eq('slug', params.id).maybeSingle()
+
+      if (error) {
+        return artworkError('Failed to load event artwork', 'DATABASE_ERROR', 500)
+      }
+
+      if (!event) {
+        return artworkError('Event not found', 'NOT_FOUND', 404)
+      }
+
+      const eventRow = event as EventArtworkEventRow
+
+      const { data: imageRows, error: imagesError } = await supabase
+        .from('event_images')
+        .select('image_type, file_name, mime_type, file_size_bytes, updated_at, created_at')
+        .eq('event_id', eventRow.id)
+        .in('image_type', [...EVENT_ARTWORK_VARIANTS])
+
+      // Metadata is descriptive only. Losing it costs the consumer the mime
+      // type, size and revision timestamp, which downgrades each variant to
+      // `inherited`; it must not cost it the URLs, which come from the event row.
+      if (imagesError) {
+        console.error('[events:artwork] failed to load event_images', imagesError)
+      }
+
+      return artworkResponse(
+        buildEventArtworkPayload(
+          eventRow,
+          Array.isArray(imageRows) ? (imageRows as EventArtworkImageRow[]) : []
+        )
+      )
+    },
+    ['read:events'],
+    request,
+    { cacheMode: 'private' }
+  )
+}

--- a/src/lib/api/__tests__/apiResponseCache.test.ts
+++ b/src/lib/api/__tests__/apiResponseCache.test.ts
@@ -1,0 +1,46 @@
+// Cache policy is the load-bearing half of the scoped artwork design, so it is
+// pinned here rather than left to the one route that needs it.
+//
+// The default must not move: every existing website route relies on
+// `public, max-age=60` plus an ETag, and a regression would be invisible until
+// the site got slower.
+
+import { describe, expect, it } from 'vitest'
+import { createApiResponse, createErrorResponse } from '../auth'
+
+describe('createApiResponse cache policy', () => {
+  it('leaves the public GET default exactly as it was', () => {
+    const res = createApiResponse({ events: [] })
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=60, stale-while-revalidate=120')
+    expect(res.headers.get('ETag')).toMatch(/^"[0-9a-f]{32}"$/)
+  })
+
+  it('keeps writes uncached, as before', () => {
+    const res = createApiResponse({ ok: true }, 200, {}, 'POST')
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.headers.get('ETag')).toBeNull()
+  })
+
+  it('drops both the shared cache and the validator in private mode', () => {
+    // An ETag on a scope-dependent body is the same cross-serving bug wearing a
+    // different hat: a cache could answer 304 to a caller that should have been
+    // given a different representation entirely.
+    const res = createApiResponse({ variants: {} }, 200, {}, 'GET', 'private')
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.headers.get('ETag')).toBeNull()
+  })
+
+  it('applies private mode to errors too', () => {
+    const res = createErrorResponse('Insufficient permissions', 'FORBIDDEN', 403, undefined, 'private')
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+    expect(res.headers.get('ETag')).toBeNull()
+  })
+
+  it('gives two different bodies two different ETags in public mode', () => {
+    // Guards the historic bug where every endpoint returned the same ETag.
+    const a = createApiResponse({ events: [1] })
+    const b = createApiResponse({ events: [2] })
+    expect(a.headers.get('ETag')).not.toBe(b.headers.get('ETag'))
+  })
+})

--- a/src/lib/api/__tests__/eventArtworkFields.test.ts
+++ b/src/lib/api/__tests__/eventArtworkFields.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { buildEventArtworkPayload } from '../eventArtworkFields'
+
+const SQUARE = 'https://cdn/event-images/events/e1/square/1_sq.png'
+const STORY = 'https://cdn/event-images/events/e1/story/1_story.png'
+const LANDSCAPE = 'https://cdn/event-images/events/e1/landscape/1_wide.png'
+
+const event = {
+  id: 'e1',
+  slug: 'karaoke-night',
+  hero_image_url: SQUARE,
+  story_image_url: STORY,
+  landscape_image_url: LANDSCAPE,
+}
+
+const rows = [
+  { image_type: 'square', mime_type: 'image/png', file_size_bytes: 111, updated_at: '2026-08-24T10:00:00Z' },
+  { image_type: 'story', mime_type: 'image/png', file_size_bytes: 222, updated_at: '2026-08-24T18:16:46.387Z' },
+  { image_type: 'landscape', mime_type: 'image/png', file_size_bytes: 333, updated_at: '2026-08-24T09:00:00Z' },
+]
+
+describe('buildEventArtworkPayload', () => {
+  it('emits all three variant keys even when the event has no artwork at all', () => {
+    // The consumer distinguishes "no artwork" from "artwork unavailable" purely
+    // by this shape, so the keys have to be present with explicit nulls.
+    const payload = buildEventArtworkPayload({ id: 'e2', slug: null }, [])
+    expect(Object.keys(payload.variants).sort()).toEqual(['landscape', 'square', 'story'])
+    expect(payload.variants).toEqual({ square: null, story: null, landscape: null })
+    expect(payload.kitUpdatedAt).toBeNull()
+  })
+
+  it('carries url, metadata and revision for an owned variant', () => {
+    const payload = buildEventArtworkPayload(event, rows)
+    expect(payload.variants.story).toEqual({
+      url: STORY,
+      mimeType: 'image/png',
+      sizeBytes: 222,
+      updatedAt: '2026-08-24T18:16:46.387Z',
+      inherited: false,
+    })
+  })
+
+  it('reports kitUpdatedAt as the newest variant, not the first', () => {
+    expect(buildEventArtworkPayload(event, rows).kitUpdatedAt).toBe('2026-08-24T18:16:46.387Z')
+  })
+
+  it('marks a variant inherited when the URL exists but no event_images row does', () => {
+    // New events copy event_categories.default_image_url verbatim, so the square
+    // is frequently a category stock image this event does not own.
+    const payload = buildEventArtworkPayload(event, [rows[1]])
+    expect(payload.variants.square).toMatchObject({ url: SQUARE, inherited: true, mimeType: null, sizeBytes: null, updatedAt: null })
+    expect(payload.variants.story?.inherited).toBe(false)
+  })
+
+  it('ignores a metadata row whose URL column is empty', () => {
+    const payload = buildEventArtworkPayload({ ...event, landscape_image_url: '   ' }, rows)
+    expect(payload.variants.landscape).toBeNull()
+  })
+
+  it('never emits print poster or social, whatever the row set contains', () => {
+    const payload = buildEventArtworkPayload(
+      { ...event, print_poster_url: 'https://cdn/a4.pdf', social_image_url: 'https://cdn/fb.png' } as never,
+      [...rows, { image_type: 'print_poster', mime_type: 'application/pdf', file_size_bytes: 9 }]
+    )
+    expect(JSON.stringify(payload)).not.toContain('a4.pdf')
+    expect(JSON.stringify(payload)).not.toContain('fb.png')
+  })
+
+  it('falls back to created_at when a row has never been updated', () => {
+    const payload = buildEventArtworkPayload(event, [
+      { image_type: 'square', created_at: '2026-01-02T03:04:05Z' },
+    ])
+    expect(payload.variants.square?.updatedAt).toBe('2026-01-02T03:04:05.000Z')
+  })
+
+  it('drops an unparseable timestamp rather than emitting it', () => {
+    const payload = buildEventArtworkPayload(event, [{ image_type: 'square', updated_at: 'not-a-date' }])
+    expect(payload.variants.square?.updatedAt).toBeNull()
+    expect(payload.kitUpdatedAt).toBeNull()
+  })
+})

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -204,11 +204,23 @@ export function createCorsPreflightResponse({
   });
 }
 
+/**
+ * How a response may be stored by caches.
+ *
+ * `private` exists for routes whose body depends on the caller's scopes. Those
+ * must never sit in a shared cache: two keys asking for the same URL get
+ * different bodies, and a cached copy of one would be served to the other. It
+ * also drops the ETag, because a validator on a scope-dependent body invites
+ * exactly the same cross-serving through a 304.
+ */
+export type ApiCacheMode = 'public' | 'private';
+
 export function createApiResponse(
   data: any,
   status: number = 200,
   headers: Record<string, string> = {},
-  method?: string
+  method?: string,
+  cacheMode: ApiCacheMode = 'public'
 ) {
   // Normalise payload so consumers always see a success/data envelope
   const payload =
@@ -217,7 +229,8 @@ export function createApiResponse(
       : { success: true, data };
 
   const isGet = !method || method.toUpperCase() === 'GET' || method.toUpperCase() === 'OPTIONS'
-  const cacheControl = isGet
+  const isCacheable = isGet && cacheMode === 'public'
+  const cacheControl = isCacheable
     ? 'public, max-age=60, stale-while-revalidate=120'
     : 'no-store'
 
@@ -245,7 +258,7 @@ export function createApiResponse(
   //
   // Hashing the whole payload matches the pattern already used correctly in
   // src/app/api/portal/calendar-feed/route.ts.
-  if (isGet) {
+  if (isCacheable) {
     responseHeaders['ETag'] = `"${createHash('sha256')
       .update(JSON.stringify(payload))
       .digest('hex')
@@ -262,7 +275,8 @@ export function createErrorResponse(
   message: string, 
   code: string, 
   status: number = 400,
-  details?: any
+  details?: any,
+  cacheMode: ApiCacheMode = 'public'
 ) {
   return createApiResponse(
     {
@@ -273,7 +287,10 @@ export function createErrorResponse(
         ...(details && { details }),
       },
     },
-    status
+    status,
+    {},
+    undefined,
+    cacheMode
   );
 }
 
@@ -370,11 +387,22 @@ async function safeLogApiUsage(
   }
 }
 
+export interface WithApiAuthOptions {
+  /**
+   * `private` for routes whose body depends on the caller's scopes. It applies
+   * to the guard's own 401/403/429/503 replies too: a publicly cached 403 for
+   * one key could otherwise be replayed to a key that does hold the scope.
+   */
+  cacheMode?: ApiCacheMode;
+}
+
 export async function withApiAuth(
   handler: (req: Request, apiKey: ApiKey) => Promise<Response>,
   requiredPermissions: string[] = ['read:events'],
-  request?: Request
+  request?: Request,
+  options?: WithApiAuthOptions
 ): Promise<Response> {
+  const cacheMode: ApiCacheMode = options?.cacheMode ?? 'public';
   const startTime = Date.now();
   const headersList = await headers();
   const apiKey = extractApiKey(headersList);
@@ -387,12 +415,14 @@ export async function withApiAuth(
     return createErrorResponse(
       'Authentication is temporarily unavailable',
       'AUTH_UNAVAILABLE',
-      503
+      503,
+      undefined,
+      cacheMode
     );
   }
 
   if (resolution.state === 'anonymous') {
-    return createErrorResponse('Invalid or missing API key', 'UNAUTHORIZED', 401);
+    return createErrorResponse('Invalid or missing API key', 'UNAUTHORIZED', 401, undefined, cacheMode);
   }
 
   const validatedKey = resolution.key;
@@ -424,7 +454,7 @@ export async function withApiAuth(
         error: err instanceof Error ? err.message : String(err),
       })
     );
-    return createErrorResponse('Insufficient permissions', 'FORBIDDEN', 403);
+    return createErrorResponse('Insufficient permissions', 'FORBIDDEN', 403, undefined, cacheMode);
   }
   
   // Check rate limit
@@ -434,7 +464,9 @@ export async function withApiAuth(
     return createErrorResponse(
       'Rate limiting is temporarily unavailable',
       'RATE_LIMIT_UNAVAILABLE',
-      503
+      503,
+      undefined,
+      cacheMode
     );
   }
   
@@ -442,7 +474,9 @@ export async function withApiAuth(
     return createErrorResponse(
       'Rate limit exceeded', 
       'RATE_LIMIT_EXCEEDED', 
-      429
+      429,
+      undefined,
+      cacheMode
     );
   }
   
@@ -486,7 +520,9 @@ export async function withApiAuth(
     return createErrorResponse(
       'Internal server error',
       'INTERNAL_ERROR',
-      500
+      500,
+      undefined,
+      cacheMode
     );
   }
 }

--- a/src/lib/api/eventArtworkFields.ts
+++ b/src/lib/api/eventArtworkFields.ts
@@ -1,0 +1,139 @@
+/**
+ * The scoped artwork contract: GET /api/events/{id}/artwork.
+ *
+ * Deliberately separate from `eventImageFields.ts`. That module is the
+ * website-facing shape, and the rule that it never carries story or print
+ * poster URLs is load-bearing: the-anchor.pub reads `image[0]` ahead of every
+ * named field and prefers `posterImageUrl` over the hero, so a story crop or an
+ * A4 PDF appearing there would be published on live pages and downloaded by
+ * social crawlers. Keeping the two builders apart means the guarantee is
+ * structural, not a matter of remembering.
+ *
+ * This one exists for a single consumer holding `read:events:artwork`, and is
+ * allowed to carry everything.
+ */
+
+export const EVENT_ARTWORK_VARIANTS = ['square', 'story', 'landscape'] as const
+
+export type EventArtworkVariant = (typeof EVENT_ARTWORK_VARIANTS)[number]
+
+export interface EventArtworkFile {
+  url: string
+  mimeType: string | null
+  sizeBytes: number | null
+  updatedAt: string | null
+  /**
+   * True when the URL came from the cache column on `events` with no matching
+   * `event_images` row. New events inherit `event_categories.default_image_url`
+   * verbatim, so a square can exist as a URL that this event does not own and
+   * has no metadata for. The consumer needs to know, because an inherited
+   * square is a category stock image rather than artwork designed for this
+   * event.
+   */
+  inherited: boolean
+}
+
+export type EventArtworkVariants = Record<EventArtworkVariant, EventArtworkFile | null>
+
+export interface EventArtworkPayload {
+  eventId: string
+  slug: string | null
+  /** Newest `updatedAt` across the emitted variants, or null when none is owned. */
+  kitUpdatedAt: string | null
+  variants: EventArtworkVariants
+}
+
+export interface EventArtworkEventRow {
+  id: string
+  slug?: string | null
+  hero_image_url?: string | null
+  story_image_url?: string | null
+  landscape_image_url?: string | null
+}
+
+/**
+ * Cache column on `events` backing each artwork variant.
+ *
+ * Note that the square lives in `hero_image_url`: that column has always held
+ * the square, and the 20260812 migration deliberately left it alone so the
+ * website kept seeing exactly what it saw before.
+ */
+const CACHE_COLUMN: Record<EventArtworkVariant, keyof EventArtworkEventRow> = {
+  square: 'hero_image_url',
+  story: 'story_image_url',
+  landscape: 'landscape_image_url',
+}
+
+export interface EventArtworkImageRow {
+  image_type: string
+  file_name?: string | null
+  mime_type?: string | null
+  file_size_bytes?: number | null
+  updated_at?: string | null
+  created_at?: string | null
+}
+
+function clean(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function toIso(value: unknown): string | null {
+  const raw = clean(value)
+  if (!raw) return null
+  const parsed = new Date(raw)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+/**
+ * Build the artwork block.
+ *
+ * The URL always comes from the cache column, never from `event_images`, so the
+ * consumer receives exactly what the website would resolve. The metadata row
+ * only supplies the descriptive fields, and its absence downgrades the variant
+ * to `inherited` rather than dropping it.
+ */
+export function buildEventArtworkPayload(
+  event: EventArtworkEventRow,
+  imageRows: EventArtworkImageRow[]
+): EventArtworkPayload {
+  const rowByType = new Map<string, EventArtworkImageRow>()
+  for (const row of imageRows) {
+    if (row && typeof row.image_type === 'string') {
+      rowByType.set(row.image_type, row)
+    }
+  }
+
+  const variants = {} as EventArtworkVariants
+  const timestamps: string[] = []
+
+  for (const variant of EVENT_ARTWORK_VARIANTS) {
+    const url = clean(event[CACHE_COLUMN[variant]])
+
+    if (!url) {
+      variants[variant] = null
+      continue
+    }
+
+    const row = rowByType.get(variant)
+    const updatedAt = row ? toIso(row.updated_at ?? row.created_at) : null
+
+    variants[variant] = {
+      url,
+      mimeType: row ? clean(row.mime_type) : null,
+      sizeBytes: row && typeof row.file_size_bytes === 'number' ? row.file_size_bytes : null,
+      updatedAt,
+      inherited: !row,
+    }
+
+    if (updatedAt) timestamps.push(updatedAt)
+  }
+
+  timestamps.sort()
+
+  return {
+    eventId: event.id,
+    slug: clean(event.slug),
+    kitUpdatedAt: timestamps.length ? timestamps[timestamps.length - 1] : null,
+    variants,
+  }
+}

--- a/supabase/migrations/20260825090130_event_artwork_api_scope.sql
+++ b/supabase/migrations/20260825090130_event_artwork_api_scope.sql
@@ -1,0 +1,78 @@
+-- Scoped event artwork for CheersAI.
+--
+-- Adds the `read:events:artwork` scope and grants it to the single active key
+-- named "cheersai". The scope gates GET /api/events/{id}/artwork, which is the
+-- only route that emits the story and print-poster URLs.
+--
+-- Purely additive. No existing route reads this scope, so applying it ahead of
+-- the code deploy changes nothing, and rolling the code back leaves an unused
+-- scope rather than a broken one.
+
+-- ---------------------------------------------------------------------------
+-- 1. Grant the scope
+--
+-- Idempotent: the append only fires when the scope is missing, and `||`
+-- preserves every other entry.
+--
+-- The row-count check matters. An UPDATE that matches nothing still reports
+-- success, so without it a renamed or rotated key would silently ship a feature
+-- that can never return artwork. A database with no cheersai key at all (fresh
+-- or local) is a different case and is allowed through with a notice.
+-- ---------------------------------------------------------------------------
+
+do $$
+declare
+  v_candidates int;
+  v_already    int;
+  v_updated    int;
+begin
+  select count(*) into v_candidates
+  from public.api_keys
+  where lower(name) = 'cheersai'
+    and is_active = true
+    and jsonb_typeof(permissions) = 'array';
+
+  select count(*) into v_already
+  from public.api_keys
+  where lower(name) = 'cheersai'
+    and is_active = true
+    and jsonb_typeof(permissions) = 'array'
+    and (permissions ? 'read:events:artwork' or permissions ? '*');
+
+  update public.api_keys
+  set
+    permissions = permissions || '["read:events:artwork"]'::jsonb,
+    updated_at = now()
+  where lower(name) = 'cheersai'
+    and is_active = true
+    and jsonb_typeof(permissions) = 'array'
+    and permissions ? 'read:events'
+    and not permissions ? 'read:events:artwork'
+    and not permissions ? '*';
+
+  get diagnostics v_updated = row_count;
+
+  if v_candidates = 0 then
+    raise notice
+      'No active api_keys row named "cheersai". Skipping the artwork scope grant. Grant it through Settings > API Keys before pointing CheersAI at this environment.';
+  elsif v_updated = 0 and v_already = 0 then
+    raise exception
+      'Found % active "cheersai" key(s) but granted the artwork scope to none of them. Check the key still holds read:events.', v_candidates;
+  else
+    raise notice 'Artwork scope: % key(s) updated, % already held it.', v_updated, v_already;
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Correct the column comments
+--
+-- These said "Never emitted by the public API", which stops being true the
+-- moment the scoped artwork endpoint ships. Left as-is they would send the next
+-- person changing this area to the wrong conclusion.
+-- ---------------------------------------------------------------------------
+
+comment on column public.events.story_image_url is
+  '9:16 artwork. Not part of the website-facing image fields; served only through GET /api/events/{id}/artwork, which requires the read:events:artwork scope.';
+
+comment on column public.events.print_poster_url is
+  'A4 print artwork, image or PDF. Not part of the website-facing image fields; served only through GET /api/events/{id}/artwork, which requires the read:events:artwork scope.';


### PR DESCRIPTION
## What changed

Adds `GET /api/events/{id}/artwork`, returning the square, story and landscape artwork for one event to API keys holding the new `read:events:artwork` scope. Also adds the scope to the API key admin list, and grants it to the existing `cheersai` key by migration.

The two existing event routes are **not touched**. `buildEventImageFields`, `buildEventImageList` and their test are unchanged.

## Why

CheersAI's "Import from events" brings across the name, date, time and CTA links but no artwork, so the square and story are downloaded from here and re-uploaded by hand every time. It also has to crop its own 9:16 story from the square, keeping only the middle 56% of the width, which cuts the sides off artwork designed to fit a square.

## Why a separate route

`/api/events/{id}` is served with `public, max-age=60` plus an ETag, varying only on `Origin`. A body whose shape depended on the caller's scopes could be cross-served between the website and CheersAI by any shared cache, with neither able to tell. Every response from the new route is `no-store` with no ETag, success and error alike.

## Three distinguishable outcomes

| Status | Meaning |
|---|---|
| 403 | Key lacks `read:events:artwork` |
| 404 | No such event, or an installation predating this route |
| 200, all-null variants | The event genuinely has no artwork |

Collapsing these would let a provisioning mistake look exactly like an ordinary empty result.

## Testing done

- [x] Manual: migration applied to production and verified. The `cheersai` key now holds `read:events:artwork`; column comments updated.
- [x] Automated: 8 builder tests, 9 route tests (403/404/200, explicit nulls, inherited variant, header assertions), 5 cache-policy regression tests pinning the existing `public, max-age=60` + ETag default.
- [x] Full suite: 687 files / 5721 tests pass. `eslint --max-warnings=0` and `tsc --noEmit` clean.

`src/lib/api/__tests__/eventImageFields.test.ts` is untouched and still green. That is the evidence the website contract did not move: the-anchor.pub reads `image[0]` ahead of every named field and prefers `posterImageUrl`, so a 9:16 crop or an A4 PDF appearing there would be published on live pages.

## Complexity score

M (3)

## Breaking changes

None. No existing response body or header changes. The new scope is unread by any other route.

## Migration risk

Low. Additive and idempotent. The row-count assertion is deliberate: an `UPDATE` matching nothing still reports success, so a renamed or rotated key would otherwise ship a scope that was never granted.

## Assumptions

The `event-images` bucket is public and stays public, so this scope governs which integrations *discover* these URLs rather than providing confidentiality. Stated explicitly in the OpenAPI description and the API README.

## Kill switch

Revoke `read:events:artwork` from the `cheersai` key. CheersAI degrades to today's behaviour with no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)