### PR TITLE
fix(api): report the kitchen's real service windows, not the flattened span

### DIFF
--- a/src/app/api/business/hours/route.ts
+++ b/src/app/api/business/hours/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { getActiveVersion, getBusinessHoursForDates, listVersions } from '@/lib/business-hours/effective';
+import {
+  describeKitchenWindows,
+  kitchenWindowAt,
+  resolveKitchenWindows,
+} from '@/lib/business-hours/kitchen-windows';
 import { createApiResponse, createErrorResponse } from '@/lib/api/auth';
 import { format } from 'date-fns';
 import { toZonedTime } from 'date-fns-tz';
@@ -212,11 +217,11 @@ export async function GET(request: NextRequest) {
         ? (currentTime >= todaySpecial.opens || currentTime < todaySpecial.closes)
         : (currentTime >= todaySpecial.opens && currentTime < todaySpecial.closes);
       
-      const isKitchenOpen = todaySpecial.is_kitchen_closed ? false : 
-        !!(todaySpecial.kitchen_opens && todaySpecial.kitchen_closes &&
-        (todaySpecial.kitchen_closes <= todaySpecial.kitchen_opens
-          ? (currentTime >= todaySpecial.kitchen_opens || currentTime < todaySpecial.kitchen_closes)
-          : (currentTime >= todaySpecial.kitchen_opens && currentTime < todaySpecial.kitchen_closes)));
+      // Read the day's sittings, not the kitchen bounds. On a split day the
+      // bounds span the gap between services, which reported the kitchen open
+      // while the booking engine was refusing food bookings at the same minute.
+      const specialKitchenWindows = resolveKitchenWindows(todaySpecial);
+      const isKitchenOpen = !!kitchenWindowAt(specialKitchenWindows, currentTime);
 
       currentStatus = {
         isOpen: isCurrentlyOpen,
@@ -236,12 +241,8 @@ export async function GET(request: NextRequest) {
         ? (currentTime >= todayHours.opens || currentTime < todayHours.closes)
         : (currentTime >= todayHours.opens && currentTime < todayHours.closes);
       
-      let isKitchenOpen = false;
-      if (todayHours.kitchen_opens && todayHours.kitchen_closes) {
-        isKitchenOpen = todayHours.kitchen_closes <= todayHours.kitchen_opens
-          ? (currentTime >= todayHours.kitchen_opens || currentTime < todayHours.kitchen_closes)
-          : (currentTime >= todayHours.kitchen_opens && currentTime < todayHours.kitchen_closes);
-      }
+      const regularKitchenWindows = resolveKitchenWindows(todayHours);
+      const isKitchenOpen = !!kitchenWindowAt(regularKitchenWindows, currentTime);
 
       currentStatus = {
         isOpen: isCurrentlyOpen,
@@ -257,6 +258,10 @@ export async function GET(request: NextRequest) {
 
   // Calculate today's information
   const todayHoursData = todaySpecial || (regularHours?.find(h => h.day_of_week === currentDay));
+  // Today's real kitchen services, shared by the summary and by services.kitchen
+  // below so the two can never disagree about when food stops.
+  const todayKitchenWindows = resolveKitchenWindows(todayHoursData);
+  const activeKitchenWindow = kitchenWindowAt(todayKitchenWindows, currentTime);
   const todaysSundayOverride = sundayOverrides.find(
     (override: any) =>
       override.startDate <= todayDate && override.endDate >= todayDate
@@ -271,9 +276,13 @@ export async function GET(request: NextRequest) {
   const todayInfo = {
     date: todayDate,
     dayName: currentDayName,
-    summary: todayHoursData?.is_closed ? 'Closed' : 
+    // Every sitting, so a split day reads "Kitchen 12:00 - 15:00, 16:00 - 21:00"
+    // rather than claiming one unbroken service across the afternoon closure.
+    summary: todayHoursData?.is_closed ? 'Closed' :
       `Open ${todayHoursData?.opens || 'N/A'} - ${todayHoursData?.closes || 'N/A'}` +
-      (todayHoursData?.kitchen_opens ? `, Kitchen ${todayHoursData.kitchen_opens} - ${todayHoursData.kitchen_closes}` : ''),
+      (todayKitchenWindows.length > 0
+        ? `, Kitchen ${describeKitchenWindows(todayKitchenWindows)}`
+        : ''),
     isSpecialHours: !!todaySpecial,
     events: todayEvents?.map(e => ({
       title: e.name,
@@ -373,8 +382,12 @@ export async function GET(request: NextRequest) {
     },
     kitchen: {
       open: currentStatus.kitchenOpen,
-      closesIn: currentStatus.kitchenOpen ? 
-        (todayHoursData?.kitchen_closes ? calculateTimeUntil(currentTime, todayHoursData.kitchen_closes) : null) : null,
+      // Counts down to the end of the sitting being served, not to the end of
+      // the day. On a split day the latter promised food for hours after the
+      // kitchen had actually stopped.
+      closesIn: currentStatus.kitchenOpen && activeKitchenWindow
+        ? calculateTimeUntil(currentTime, activeKitchenWindow.closes)
+        : null,
     },
     sundayLunch: sundayLunchConfig ? {
       enabled: sundayLunchEnabledToday,

--- a/src/lib/business-hours/__tests__/kitchen-windows.test.ts
+++ b/src/lib/business-hours/__tests__/kitchen-windows.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest'
+import {
+  describeKitchenWindows,
+  kitchenWindowAt,
+  nextKitchenWindowAfter,
+  resolveKitchenWindows,
+} from '@/lib/business-hours/kitchen-windows'
+
+/**
+ * The September schedule: lunch, a deliberate hour off, then dinner. Stored as
+ * kitchen bounds of 12:00-21:00 with two services, which is why reading the
+ * bounds alone reported the kitchen open at half three.
+ */
+const SEPTEMBER_WEEKDAY = {
+  is_closed: false,
+  is_kitchen_closed: false,
+  kitchen_opens: '12:00:00',
+  kitchen_closes: '21:00:00',
+  schedule_config: [
+    { name: 'Lunch', starts_at: '12:00', ends_at: '15:00', capacity: 50, booking_type: 'regular' },
+    { name: 'Dinner', starts_at: '16:00', ends_at: '21:00', capacity: 50, booking_type: 'regular' },
+  ],
+}
+
+const SATURDAY = {
+  is_closed: false,
+  is_kitchen_closed: false,
+  kitchen_opens: '12:00:00',
+  kitchen_closes: '19:00:00',
+  schedule_config: [
+    { name: 'food service', starts_at: '12:00', ends_at: '19:00', capacity: 50, booking_type: 'regular' },
+  ],
+}
+
+describe('resolveKitchenWindows', () => {
+  it('returns both sittings on a split day', () => {
+    expect(resolveKitchenWindows(SEPTEMBER_WEEKDAY)).toEqual([
+      { opens: '12:00', closes: '15:00' },
+      { opens: '16:00', closes: '21:00' },
+    ])
+  })
+
+  it('returns one window on a day with a single service', () => {
+    expect(resolveKitchenWindows(SATURDAY)).toEqual([{ opens: '12:00', closes: '19:00' }])
+  })
+
+  it('clips a service that overhangs the kitchen close', () => {
+    // Live shape: special_hours 2026-05-09 keeps kitchen bounds 13:00-19:00 with
+    // inherited 'regular' services running 12:00-14:30 and 17:00-21:00. Those
+    // gate drinks too, so the database allows them, but they must not extend the
+    // kitchen's advertised hours.
+    const narrowedKitchen = {
+      is_closed: false,
+      is_kitchen_closed: false,
+      kitchen_opens: '13:00:00',
+      kitchen_closes: '19:00:00',
+      schedule_config: [
+        { name: 'lunch', starts_at: '12:00', ends_at: '14:30', capacity: 50, booking_type: 'regular' },
+        { name: 'dinner', starts_at: '17:00', ends_at: '21:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    expect(resolveKitchenWindows(narrowedKitchen)).toEqual([
+      { opens: '13:00', closes: '14:30' },
+      { opens: '17:00', closes: '19:00' },
+    ])
+
+    const windows = resolveKitchenWindows(narrowedKitchen)
+    expect(kitchenWindowAt(windows, '12:15:00')).toBeNull()
+    expect(kitchenWindowAt(windows, '20:30:00')).toBeNull()
+  })
+
+  it('drops a service lying entirely outside the kitchen hours', () => {
+    const drinksOnlySlot = {
+      is_closed: false,
+      is_kitchen_closed: false,
+      kitchen_opens: '13:00:00',
+      kitchen_closes: '15:00:00',
+      schedule_config: [
+        { name: 'late drinks', starts_at: '20:00', ends_at: '22:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    // Nothing bookable for food, which is what the availability engine concludes.
+    expect(resolveKitchenWindows(drinksOnlySlot)).toEqual([])
+  })
+
+  it('treats absent kitchen bounds as closed even when a service is left behind', () => {
+    // Staff use null bounds to mean "kitchen closed for the day" while an old
+    // service can still be sitting on the row.
+    const noBounds = {
+      is_closed: false,
+      is_kitchen_closed: false,
+      kitchen_opens: null,
+      kitchen_closes: null,
+      schedule_config: [
+        { name: 'dinner', starts_at: '17:00', ends_at: '21:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    expect(resolveKitchenWindows(noBounds)).toEqual([])
+  })
+
+  it('falls back to the kitchen bounds when no services are listed', () => {
+    expect(
+      resolveKitchenWindows({ ...SATURDAY, schedule_config: [] }),
+    ).toEqual([{ opens: '12:00:00', closes: '19:00:00' }])
+  })
+
+  it('reports nothing when the kitchen is flagged closed', () => {
+    expect(resolveKitchenWindows({ ...SEPTEMBER_WEEKDAY, is_kitchen_closed: true })).toEqual([])
+  })
+
+  it('reports nothing when the venue is closed all day', () => {
+    expect(resolveKitchenWindows({ ...SEPTEMBER_WEEKDAY, is_closed: true })).toEqual([])
+  })
+
+  it('merges services that run straight into each other', () => {
+    const continuous = {
+      ...SEPTEMBER_WEEKDAY,
+      schedule_config: [
+        { name: 'Lunch', starts_at: '12:00', ends_at: '15:00', capacity: 50, booking_type: 'regular' },
+        { name: 'Dinner', starts_at: '15:00', ends_at: '21:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    expect(resolveKitchenWindows(continuous)).toEqual([{ opens: '12:00', closes: '21:00' }])
+  })
+
+  it('keeps a late service that runs past midnight', () => {
+    const halloween = {
+      ...SEPTEMBER_WEEKDAY,
+      kitchen_opens: '12:00:00',
+      kitchen_closes: '00:00:00',
+      schedule_config: [
+        { name: 'Full menu', starts_at: '12:00', ends_at: '18:00', capacity: 50, booking_type: 'regular' },
+        { name: 'Pizza only', starts_at: '21:00', ends_at: '00:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    expect(resolveKitchenWindows(halloween)).toEqual([
+      { opens: '12:00', closes: '18:00' },
+      { opens: '21:00', closes: '00:00' },
+    ])
+  })
+
+  it('rejects a service that ends before it starts at a daytime hour', () => {
+    const broken = {
+      ...SEPTEMBER_WEEKDAY,
+      schedule_config: [
+        { name: 'Nonsense', starts_at: '21:00', ends_at: '16:00', capacity: 50, booking_type: 'regular' },
+      ],
+    }
+    // Nothing usable, so the stored bounds stand in rather than a 19-hour service.
+    expect(resolveKitchenWindows(broken)).toEqual([{ opens: '12:00:00', closes: '21:00:00' }])
+  })
+})
+
+describe('kitchenWindowAt', () => {
+  const windows = resolveKitchenWindows(SEPTEMBER_WEEKDAY)
+
+  it('reports the kitchen shut during the afternoon closure', () => {
+    // The defect this module exists to prevent: 15:30 sits between services.
+    expect(kitchenWindowAt(windows, '15:30:00')).toBeNull()
+    expect(kitchenWindowAt(windows, '15:00:00')).toBeNull()
+  })
+
+  it('reports the lunch sitting while it is being served', () => {
+    expect(kitchenWindowAt(windows, '13:00:00')).toEqual({ opens: '12:00', closes: '15:00' })
+    expect(kitchenWindowAt(windows, '12:00:00')).toEqual({ opens: '12:00', closes: '15:00' })
+  })
+
+  it('reports the dinner sitting once it starts', () => {
+    expect(kitchenWindowAt(windows, '16:00:00')).toEqual({ opens: '16:00', closes: '21:00' })
+    expect(kitchenWindowAt(windows, '20:59:00')).toEqual({ opens: '16:00', closes: '21:00' })
+  })
+
+  it('reports the kitchen shut before and after the day', () => {
+    expect(kitchenWindowAt(windows, '11:00:00')).toBeNull()
+    expect(kitchenWindowAt(windows, '21:00:00')).toBeNull()
+    expect(kitchenWindowAt(windows, '23:30:00')).toBeNull()
+  })
+
+  it('still serves in the small hours of a window that ran past midnight', () => {
+    const late = [{ opens: '21:00', closes: '01:00' }]
+    expect(kitchenWindowAt(late, '23:30:00')).toEqual(late[0])
+    expect(kitchenWindowAt(late, '00:30:00')).toEqual(late[0])
+    expect(kitchenWindowAt(late, '01:30:00')).toBeNull()
+  })
+})
+
+describe('nextKitchenWindowAfter', () => {
+  const windows = resolveKitchenWindows(SEPTEMBER_WEEKDAY)
+
+  it('names the dinner sitting during the gap', () => {
+    expect(nextKitchenWindowAfter(windows, '15:30:00')).toEqual({ opens: '16:00', closes: '21:00' })
+  })
+
+  it('names the lunch sitting before service starts', () => {
+    expect(nextKitchenWindowAfter(windows, '09:00:00')).toEqual({ opens: '12:00', closes: '15:00' })
+  })
+
+  it('returns nothing once the last sitting has started', () => {
+    expect(nextKitchenWindowAfter(windows, '17:00:00')).toBeNull()
+  })
+})
+
+describe('describeKitchenWindows', () => {
+  it('lists every sitting rather than one span', () => {
+    expect(describeKitchenWindows(resolveKitchenWindows(SEPTEMBER_WEEKDAY))).toBe(
+      '12:00 - 15:00, 16:00 - 21:00',
+    )
+  })
+
+  it('is empty when the kitchen is closed', () => {
+    expect(describeKitchenWindows([])).toBe('')
+  })
+})

--- a/src/lib/business-hours/kitchen-windows.ts
+++ b/src/lib/business-hours/kitchen-windows.ts
@@ -1,0 +1,173 @@
+// src/lib/business-hours/kitchen-windows.ts
+//
+// The kitchen's real service windows for a day.
+//
+// `kitchen_opens` / `kitchen_closes` bound the day, so a day that serves lunch
+// 12:00-15:00 and dinner 16:00-21:00 is stored as 12:00-21:00 with two entries
+// in `schedule_config`. Reading only the bounds says the kitchen is open right
+// through the afternoon closure, which is how `/business/hours` came to report
+// `kitchenOpen: true` at half three while the booking engine refused a food
+// booking at the same minute. The sittings are the truth; the bounds are a
+// convenience for consumers that cannot express more than one window.
+//
+// Pure, so the API route and anything else that needs to answer "is the kitchen
+// serving right now" share one definition instead of drifting.
+
+import type { ScheduleConfigItem } from '@/types/business-hours'
+
+export interface KitchenWindow {
+  /** As stored, so callers can format or compare as they already do. */
+  opens: string
+  closes: string
+}
+
+export interface KitchenWindowSource {
+  is_closed?: boolean | null
+  is_kitchen_closed?: boolean | null
+  kitchen_opens?: string | null
+  kitchen_closes?: string | null
+  schedule_config?: ScheduleConfigItem[] | null
+}
+
+/** The pub never serves past the small hours, so a later end is bad data, not a wrap. */
+const LATEST_OVERNIGHT_END_MINUTES = 6 * 60
+
+/** Accepts 'HH:MM' and 'HH:MM:SS' alike, because the two are mixed in storage. */
+export function toMinutesOfDay(value: string | null | undefined): number | null {
+  if (!value) return null
+  const match = /^(\d{1,2}):(\d{2})/.exec(String(value).trim())
+  if (!match) return null
+  const hours = Number(match[1])
+  const minutes = Number(match[2])
+  if (hours > 23 || minutes > 59) return null
+  return hours * 60 + minutes
+}
+
+/**
+ * Where a window ends, measured from the start of its own day.
+ *
+ * A service ending at or before 06:00 has run past midnight and is measured
+ * into the next day. One that ends before it starts at any other hour is
+ * malformed rather than overnight, and is rejected instead of being read as a
+ * service lasting most of a day.
+ */
+function endMinutes(window: KitchenWindow): number | null {
+  const opens = toMinutesOfDay(window.opens)
+  const closes = toMinutesOfDay(window.closes)
+  if (opens === null || closes === null) return null
+  if (closes > opens) return closes
+  if (closes <= LATEST_OVERNIGHT_END_MINUTES) return closes + 1440
+  return null
+}
+
+function fromMinutes(total: number): string {
+  const wrapped = ((total % 1440) + 1440) % 1440
+  const hours = Math.floor(wrapped / 60)
+  const minutes = wrapped % 60
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`
+}
+
+/**
+ * A day's kitchen service windows, in order, with touching services merged.
+ *
+ * The stored `kitchen_opens`/`kitchen_closes` are a CEILING, not merely a
+ * fallback: services narrow the kitchen, they never widen it. Two things force
+ * that. A `regular` service gates drinks as well as food, so the database
+ * deliberately lets it run past the kitchen close (see the exemption in
+ * validate_schedule_config), and live special-hours rows already do. And the
+ * booking engine bounds food by BOTH, looping kitchen_opens to kitchen_closes
+ * and then filtering each candidate through the service windows. Reading the
+ * services alone was therefore looser than the engine this exists to agree with,
+ * and would have advertised food outside kitchen hours.
+ *
+ * Absent bounds mean no kitchen service, whatever services remain on the row.
+ * That is the codebase's other deliberate "closed" signal: the route maps it to
+ * `kitchen: null`, and rota and booking both already honour it.
+ *
+ * Falls back to the whole bounded span when a day lists no services at all,
+ * which is still the normal case for Saturdays and most special-hours entries.
+ */
+export function resolveKitchenWindows(day: KitchenWindowSource | null | undefined): KitchenWindow[] {
+  if (!day) return []
+  if (day.is_closed === true || day.is_kitchen_closed === true) return []
+
+  const boundsOpen = toMinutesOfDay(day.kitchen_opens)
+  const boundsClose = day.kitchen_opens && day.kitchen_closes
+    ? endMinutes({ opens: day.kitchen_opens, closes: day.kitchen_closes })
+    : null
+  if (boundsOpen === null || boundsClose === null) return []
+
+  const sittings = (day.schedule_config ?? [])
+    .map((entry) => ({ opens: entry?.starts_at ?? '', closes: entry?.ends_at ?? '' }))
+    .filter((window) => toMinutesOfDay(window.opens) !== null && endMinutes(window) !== null)
+    .sort((a, b) => (toMinutesOfDay(a.opens) ?? 0) - (toMinutesOfDay(b.opens) ?? 0))
+
+  if (sittings.length === 0) {
+    return [{ opens: day.kitchen_opens as string, closes: day.kitchen_closes as string }]
+  }
+
+  const merged: KitchenWindow[] = []
+  for (const window of sittings) {
+    const previous = merged[merged.length - 1]
+    if (previous && (toMinutesOfDay(window.opens) ?? 0) <= (endMinutes(previous) ?? 0)) {
+      if ((endMinutes(window) ?? 0) > (endMinutes(previous) ?? 0)) previous.closes = window.closes
+      continue
+    }
+    merged.push({ ...window })
+  }
+
+  // Clip to the kitchen's own hours. A service lying entirely outside them is
+  // dropped: it is gating drinks, not food. If that leaves nothing, the kitchen
+  // serves nothing bookable that day, which is what the engine also concludes.
+  return merged.flatMap((window) => {
+    const start = Math.max(toMinutesOfDay(window.opens) as number, boundsOpen)
+    const end = Math.min(endMinutes(window) as number, boundsClose)
+    if (end <= start) return []
+    const unchanged =
+      start === (toMinutesOfDay(window.opens) as number) && end === (endMinutes(window) as number)
+    return [unchanged ? window : { opens: fromMinutes(start), closes: fromMinutes(end) }]
+  })
+}
+
+/** The window being served at `time`, or null when the kitchen is between services. */
+export function kitchenWindowAt(
+  windows: KitchenWindow[],
+  time: string,
+): KitchenWindow | null {
+  const nowMinutes = toMinutesOfDay(time)
+  if (nowMinutes === null) return null
+
+  for (const window of windows) {
+    const opens = toMinutesOfDay(window.opens)
+    const closes = endMinutes(window)
+    if (opens === null || closes === null) continue
+
+    // A window measured past midnight is also serving in the small hours of the
+    // day it ends, so both readings of "now" are checked.
+    if (nowMinutes >= opens && nowMinutes < closes) return window
+    if (closes > 1440 && nowMinutes + 1440 >= opens && nowMinutes + 1440 < closes) return window
+  }
+
+  return null
+}
+
+/** The next window that starts after `time` today, for an "opens at" message. */
+export function nextKitchenWindowAfter(
+  windows: KitchenWindow[],
+  time: string,
+): KitchenWindow | null {
+  const nowMinutes = toMinutesOfDay(time)
+  if (nowMinutes === null) return null
+
+  return (
+    windows.find((window) => {
+      const opens = toMinutesOfDay(window.opens)
+      return opens !== null && opens > nowMinutes
+    }) ?? null
+  )
+}
+
+/** "12:00:00 - 15:00:00, 16:00:00 - 21:00:00", for human-readable summaries. */
+export function describeKitchenWindows(windows: KitchenWindow[]): string {
+  return windows.map((window) => `${window.opens} - ${window.closes}`).join(', ')
+}


### PR DESCRIPTION
## What changed

`/api/business/hours` derived its live kitchen state from `kitchen_opens`/`kitchen_closes`, which bound the whole day. From 1 September Tue–Fri serve lunch 12:00–15:00 and dinner 16:00–21:00, stored as bounds of 12:00–21:00 with two services. At 15:30 the API therefore reported the kitchen open and counted down to 21:00, while the booking engine refused a food booking at the same minute. The website's site-wide header repeated that to every visitor.

Three outputs now read the services instead of the bounds:
- `currentStatus.kitchenOpen`, in both the special-hours and regular-hours branches
- `services.kitchen.closesIn`, which counts down to the end of the sitting being served rather than the end of the day
- `today.summary`, which lists every sitting

New `src/lib/business-hours/kitchen-windows.ts` owns the resolution, with 21 tests.

## Why the bounds are a ceiling, not a fallback

The resolver clips each service to the stored kitchen hours rather than trusting the services alone. Two things force that:

1. A `regular` service gates drinks as well as food, so `validate_schedule_config` deliberately exempts it from the kitchen-bounds check, and live `special_hours` rows already run past the kitchen close (2026-05-09 holds bounds 13:00–19:00 with services 12:00–14:30 and 17:00–21:00).
2. `check_table_availability_v06` bounds food by **both**, looping the kitchen hours and then filtering each candidate through the service windows.

Reading the services alone would have been looser than the engine this change exists to agree with, and would have advertised food outside kitchen hours. Absent kitchen hours now mean no service at all, whatever services remain on the row, matching the signal rota and booking already honour.

## Testing done

- [x] Manual: verified the live payload before the change (`kitchenOpen` derived from the flattened span; `today.summary` reading "Kitchen 12:00:00 - 21:00:00")
- [x] Live DB check: every `schedule_config` entry is a food service (`regular` or `sunday_lunch`), no drinks-only windows, so counting them all as kitchen time is safe
- [x] Automated: 21 new tests, including the two real out-of-bounds rows; full suite 702 files / 5,908 tests pass
- [x] Lint clean, typecheck clean, production build succeeds
- [x] Adversarial multi-agent review; all three confirmed findings fixed in this branch

## Complexity score

S (2)

## Breaking changes

`today.summary` now lists every sitting rather than one span. Nothing in either repo parses that string; it is a human-readable field.

## Migration risk

None. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)