### PR TITLE
feat(foh): let the floor change a booking time without dragging

### DIFF
--- a/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
@@ -21,6 +21,7 @@ import {
   getLondonDateIso,
   minutesFromServiceDate,
   postBookingAction,
+  buildTimeChangeOptions,
 } from './utils'
 import { useFohBookings } from './hooks/useFohBookings'
 import { useFohRealtime } from './hooks/useFohRealtime'
@@ -35,6 +36,7 @@ import { FohOutsideBookings } from './components/FohOutsideBookings'
 import { FohBookingDetailModal } from './components/FohBookingDetailModal'
 import { FohCreateBookingModal } from './components/FohCreateBookingModal'
 import { FohPartySizeModal, FohWalkoutModal } from './components/FohMiniModals'
+import { FohChangeTimeModal } from './components/FohChangeTimeModal'
 
 export function FohScheduleClient({
   initialDate,
@@ -65,6 +67,11 @@ export function FohScheduleClient({
   const [partySizeEditOpen, setPartySizeEditOpen] = useState(false)
   const [partySizeEditValue, setPartySizeEditValue] = useState('')
   const [partySizeEditBookingId, setPartySizeEditBookingId] = useState<string | null>(null)
+  const [changeTimeOpen, setChangeTimeOpen] = useState(false)
+  const [changeTimeBookingId, setChangeTimeBookingId] = useState<string | null>(null)
+  // Kept local to the modal rather than pushed to the page banner: a conflict message that
+  // renders behind an open dialog is a message nobody reads.
+  const [changeTimeError, setChangeTimeError] = useState<string | null>(null)
   const [walkoutModalOpen, setWalkoutModalOpen] = useState(false)
   const [walkoutAmountValue, setWalkoutAmountValue] = useState('')
   const [walkoutBookingId, setWalkoutBookingId] = useState<string | null>(null)
@@ -176,7 +183,7 @@ export function FohScheduleClient({
   const hasActiveFohWork = Boolean(
     bookingActionInFlight || createBooking.submittingBooking || submittingFoodOrderAlert
     || createBooking.isCreateModalOpen || selectedBookingContext || showCancelBookingConfirmation
-    || partySizeEditOpen || walkoutModalOpen
+    || partySizeEditOpen || walkoutModalOpen || changeTimeOpen
   )
 
   useFohDeploymentRefresh({
@@ -317,6 +324,7 @@ export function FohScheduleClient({
     setSelectedBookingContext(null); setBookingActionInFlight(null)
     setShowCancelBookingConfirmation(false); setShowNoShowConfirmation(false)
     setPartySizeEditOpen(false); setWalkoutModalOpen(false)
+    setChangeTimeOpen(false); setChangeTimeError(null)
   }
 
   async function sendFoodOrderAlert() {
@@ -330,6 +338,92 @@ export function FohScheduleClient({
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : 'Failed to send food order alert')
     } finally { setSubmittingFoodOrderAlert(false) }
+  }
+
+
+  // --- Change time ---
+  //
+  // The booking is looked up fresh from the schedule on every render rather than held from
+  // when the modal opened, so a realtime refresh mid-decision re-marks the grid instead of
+  // leaving staff choosing against a stale picture.
+  const changeTimeBooking = useMemo(() => {
+    if (!changeTimeBookingId) return null
+    const fromSchedule = schedule
+      ? [
+          ...schedule.lanes.flatMap((lane) => lane.bookings),
+          ...(schedule.unassigned_bookings || []),
+          ...(schedule.outside_bookings || []),
+        ].find((booking) => booking.id === changeTimeBookingId) ?? null
+      : null
+    if (fromSchedule) return fromSchedule
+    return selectedBookingContext?.booking.id === changeTimeBookingId
+      ? selectedBookingContext.booking
+      : null
+  }, [changeTimeBookingId, schedule, selectedBookingContext])
+
+  const changeTimeOptions = useMemo(() => {
+    if (!changeTimeBooking) return []
+    return buildTimeChangeOptions({
+      schedule,
+      booking: changeTimeBooking,
+      timeline,
+      serviceDateIso: schedule?.date || date,
+      referenceNow: clockNow,
+    })
+  }, [changeTimeBooking, schedule, timeline, date, clockNow])
+
+  async function submitTimeChange(time: string) {
+    const bookingId = changeTimeBookingId
+    if (!bookingId) return
+    setChangeTimeError(null)
+    setErrorMessage(null)
+    setStatusMessage(null)
+    setBookingActionInFlight('change_time')
+    try {
+      const resp = await fetch(`/api/foh/bookings/${bookingId}/time`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ time }),
+      })
+      const payload = await resp.json().catch(() => null) as
+        | { error?: string; data?: { state?: string; high_chairs_lost?: number } }
+        | null
+
+      if (resp.status === 409 || resp.status === 422) {
+        // Someone else got there first, or the booking moved on. Keep the modal open so the
+        // message is visible, and refresh so the grid stops offering the time that failed.
+        setChangeTimeError(payload?.error ?? 'That time is no longer available.')
+        await reloadSchedule()
+        return
+      }
+      if (!resp.ok) {
+        throw new Error(payload?.error || 'Failed to change the booking time')
+      }
+
+      setChangeTimeOpen(false)
+      closeBookingDetails()
+      await reloadSchedule()
+
+      const lostChairs = Number(payload?.data?.high_chairs_lost ?? 0)
+      setStatusMessage(
+        payload?.data?.state === 'unchanged'
+          ? 'No change was made.'
+          : lostChairs > 0
+            ? `Moved to ${time}. The guest has been told. ${lostChairs} high chair${lostChairs === 1 ? '' : 's'} could not be held at the new time.`
+            : `Moved to ${time}. The guest has been told.`
+      )
+    } catch (error) {
+      // A network failure leaves the outcome genuinely unknown, so refresh and say so rather
+      // than inviting a retry that could move the booking twice.
+      setChangeTimeError(
+        error instanceof Error
+          ? `${error.message}. Check the timeline before trying again.`
+          : 'The time change could not be confirmed. Check the timeline before trying again.'
+      )
+      await reloadSchedule().catch(() => {})
+    } finally {
+      setBookingActionInFlight(null)
+    }
   }
 
   // --- Render ---
@@ -420,6 +514,7 @@ export function FohScheduleClient({
         onSetShowNoShowConfirmation={setShowNoShowConfirmation}
         onOpenPartySizeEdit={(bid, size) => { setPartySizeEditBookingId(bid); setPartySizeEditValue(String(size)); setPartySizeEditOpen(true) }}
         onOpenWalkoutModal={(bid) => { setWalkoutBookingId(bid); setWalkoutAmountValue(''); setWalkoutModalOpen(true) }}
+        onOpenChangeTime={(bid) => { setChangeTimeBookingId(bid); setChangeTimeError(null); setChangeTimeOpen(true) }}
       />
 
       <FohCreateBookingModal
@@ -497,6 +592,22 @@ export function FohScheduleClient({
             if (ok) closeBookingDetails()
           })()
         }}
+      />
+      <FohChangeTimeModal
+        open={changeTimeOpen && Boolean(changeTimeBooking)}
+        bookingLabel={
+          changeTimeBooking?.guest_name
+          || changeTimeBooking?.booking_reference
+          || changeTimeBooking?.id.slice(0, 8)
+          || 'Booking'
+        }
+        currentTime={(changeTimeBooking?.booking_time || '').slice(0, 5)}
+        isSeated={Boolean(changeTimeBooking?.seated_at)}
+        options={changeTimeOptions}
+        submitting={bookingActionInFlight === 'change_time'}
+        error={changeTimeError}
+        onClose={() => { setChangeTimeOpen(false); setChangeTimeError(null) }}
+        onConfirm={(time) => { void submitTimeChange(time) }}
       />
     </div>
   )

--- a/src/app/(authenticated)/table-bookings/foh/changeTime.test.ts
+++ b/src/app/(authenticated)/table-bookings/foh/changeTime.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildTimeChangeOptions,
+  collectBusyIntervals,
+  formatMinutesAsClock,
+  getFohTimeChangeBlocker,
+  isFohBookingLive,
+} from './utils'
+import type { FohBooking, FohScheduleResponse, TimelineRange } from './types'
+
+const SERVICE_DATE = '2026-09-01'
+const NOW = new Date('2026-09-01T17:00:00.000Z')
+
+function makeBooking(overrides: Partial<FohBooking> = {}): FohBooking {
+  return {
+    id: 'booking-1',
+    booking_reference: 'TB-001',
+    guest_name: 'Smith',
+    booking_time: '18:00',
+    party_size: 2,
+    booking_type: 'regular',
+    booking_purpose: 'food',
+    status: 'confirmed',
+    notes: null,
+    start_datetime: '2026-09-01T17:00:00.000Z',
+    end_datetime: '2026-09-01T18:30:00.000Z',
+    assigned_table_ids: ['table-a'],
+    assignment_count: 1,
+    ...overrides,
+  }
+}
+
+function makeSchedule(laneBookings: FohBooking[], tableId = 'table-a'): FohScheduleResponse['data'] {
+  return {
+    date: SERVICE_DATE,
+    service_window: { start_time: '12:00', end_time: '22:00', end_next_day: false, source: 'test' },
+    lanes: [
+      {
+        table_id: tableId,
+        table_name: 'Table 1',
+        capacity: 4,
+        area: null,
+        bookings: laneBookings,
+      },
+    ],
+    unassigned_bookings: [],
+  }
+}
+
+// 12:00 to 22:30, matching what buildTimelineRange produces for a 12:00-22:00 service.
+const TIMELINE: TimelineRange = {
+  startMin: 11 * 60 + 30,
+  endMin: 22 * 60 + 30,
+  ticks: [],
+}
+
+describe('isFohBookingLive', () => {
+  it('treats a confirmed booking as holding its table', () => {
+    expect(isFohBookingLive(makeBooking(), NOW)).toBe(true)
+  })
+
+  it.each(['cancelled', 'no_show'])('does not let a %s booking block', (status) => {
+    expect(isFohBookingLive(makeBooking({ status }), NOW)).toBe(false)
+  })
+
+  it('releases the table once the party has left, whatever the status says', () => {
+    expect(isFohBookingLive(makeBooking({ left_at: '2026-09-01T18:00:00.000Z' }), NOW)).toBe(false)
+  })
+
+  it('releases an expired unpaid hold', () => {
+    const booking = makeBooking({
+      status: 'pending_payment',
+      hold_expires_at: '2026-09-01T16:00:00.000Z',
+      payment_status: 'pending',
+    })
+    expect(isFohBookingLive(booking, NOW)).toBe(false)
+  })
+
+  it('keeps an expired hold that was actually paid', () => {
+    const booking = makeBooking({
+      status: 'pending_payment',
+      hold_expires_at: '2026-09-01T16:00:00.000Z',
+      payment_status: 'completed',
+    })
+    expect(isFohBookingLive(booking, NOW)).toBe(true)
+  })
+
+  it('keeps a hold that has not expired yet', () => {
+    const booking = makeBooking({
+      status: 'pending_payment',
+      hold_expires_at: '2026-09-01T18:00:00.000Z',
+      payment_status: 'pending',
+    })
+    expect(isFohBookingLive(booking, NOW)).toBe(true)
+  })
+
+  it('ignores hold expiry for a confirmed booking', () => {
+    const booking = makeBooking({
+      status: 'confirmed',
+      hold_expires_at: '2026-09-01T16:00:00.000Z',
+      payment_status: 'pending',
+    })
+    expect(isFohBookingLive(booking, NOW)).toBe(true)
+  })
+})
+
+describe('collectBusyIntervals', () => {
+  const subject = makeBooking()
+
+  it('ignores the booking being moved', () => {
+    const schedule = makeSchedule([subject])
+    expect(collectBusyIntervals({ schedule, booking: subject, serviceDateIso: SERVICE_DATE, referenceNow: NOW })).toEqual([])
+  })
+
+  it('returns nothing for a booking that holds no table', () => {
+    const schedule = makeSchedule([subject])
+    const outside = makeBooking({ id: 'booking-2', assigned_table_ids: [] })
+    expect(collectBusyIntervals({ schedule, booking: outside, serviceDateIso: SERVICE_DATE, referenceNow: NOW })).toEqual([])
+  })
+
+  it('only looks at lanes this booking actually sits on', () => {
+    const other = makeBooking({ id: 'booking-2', start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' })
+    const schedule = makeSchedule([other], 'table-z')
+    expect(collectBusyIntervals({ schedule, booking: subject, serviceDateIso: SERVICE_DATE, referenceNow: NOW })).toEqual([])
+  })
+
+  it('labels private and communal blocks distinctly from ordinary bookings', () => {
+    const schedule = makeSchedule([
+      subject,
+      makeBooking({ id: 'pb-1', is_private_block: true, start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+      makeBooking({ id: 'communal-1', is_communal_event_block: true, start_datetime: '2026-09-01T20:00:00.000Z', end_datetime: '2026-09-01T21:00:00.000Z' }),
+      makeBooking({ id: 'booking-3', start_datetime: '2026-09-01T12:00:00.000Z', end_datetime: '2026-09-01T13:00:00.000Z' }),
+    ])
+    const reasons = collectBusyIntervals({ schedule, booking: subject, serviceDateIso: SERVICE_DATE, referenceNow: NOW })
+      .map((interval) => interval.reason)
+      .sort()
+    expect(reasons).toEqual(['event', 'private', 'taken'])
+  })
+
+  it('drops a departed booking, which no longer holds the table', () => {
+    const schedule = makeSchedule([
+      subject,
+      makeBooking({ id: 'booking-2', left_at: '2026-09-01T18:00:00.000Z', start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+    ])
+    expect(collectBusyIntervals({ schedule, booking: subject, serviceDateIso: SERVICE_DATE, referenceNow: NOW })).toEqual([])
+  })
+})
+
+describe('buildTimeChangeOptions', () => {
+  const subject = makeBooking()
+
+  it('always offers the booking its own current time, marked as current', () => {
+    const options = buildTimeChangeOptions({
+      schedule: makeSchedule([subject]),
+      booking: subject,
+      timeline: TIMELINE,
+      serviceDateIso: SERVICE_DATE,
+      referenceNow: NOW,
+    })
+    const current = options.filter((option) => option.isCurrent)
+    expect(current).toHaveLength(1)
+    expect(current[0]!.time).toBe('18:00')
+    // The current time is shown but never offered as a destination.
+    expect(current[0]!.available).toBe(false)
+  })
+
+  it('keeps an off-grid current time rather than quietly rounding it', () => {
+    // Live data holds times like 20:19 and 20:55.
+    const offGrid = makeBooking({
+      booking_time: '20:19',
+      start_datetime: '2026-09-01T19:19:00.000Z',
+      end_datetime: '2026-09-01T20:49:00.000Z',
+    })
+    const options = buildTimeChangeOptions({
+      schedule: makeSchedule([offGrid]),
+      booking: offGrid,
+      timeline: TIMELINE,
+      serviceDateIso: SERVICE_DATE,
+      referenceNow: NOW,
+    })
+    expect(options.find((option) => option.isCurrent)?.time).toBe('20:19')
+  })
+
+  it('blocks a slot that would overlap another live booking', () => {
+    const schedule = makeSchedule([
+      subject,
+      // 20:00 to 21:00 London.
+      makeBooking({ id: 'booking-2', start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+    ])
+    const options = buildTimeChangeOptions({
+      schedule, booking: subject, timeline: TIMELINE, serviceDateIso: SERVICE_DATE, referenceNow: NOW,
+    })
+    const at1930 = options.find((option) => option.time === '19:30')
+    expect(at1930?.available).toBe(false)
+    expect(at1930?.blockedBy).toBe('taken')
+  })
+
+  it('uses half-open overlap, so a slot starting as another ends is free', () => {
+    const schedule = makeSchedule([
+      subject,
+      // Ends at 20:00 London exactly.
+      makeBooking({ id: 'booking-2', start_datetime: '2026-09-01T18:00:00.000Z', end_datetime: '2026-09-01T19:00:00.000Z' }),
+    ])
+    const options = buildTimeChangeOptions({
+      schedule, booking: subject, timeline: TIMELINE, serviceDateIso: SERVICE_DATE, referenceNow: NOW,
+    })
+    expect(options.find((option) => option.time === '20:00')?.available).toBe(true)
+    // And the slot immediately before it, which would overlap, is not.
+    expect(options.find((option) => option.time === '19:45')?.available).toBe(false)
+  })
+
+  it('reports a private block ahead of an ordinary clash on the same slot', () => {
+    const schedule = makeSchedule([
+      subject,
+      makeBooking({ id: 'booking-2', start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+      makeBooking({ id: 'pb-1', is_private_block: true, start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+    ])
+    const options = buildTimeChangeOptions({
+      schedule, booking: subject, timeline: TIMELINE, serviceDateIso: SERVICE_DATE, referenceNow: NOW,
+    })
+    expect(options.find((option) => option.time === '20:00')?.blockedBy).toBe('private')
+  })
+
+  it('never offers a slot whose booking would run past the end of the timeline', () => {
+    const options = buildTimeChangeOptions({
+      schedule: makeSchedule([subject]),
+      booking: subject,
+      timeline: TIMELINE,
+      serviceDateIso: SERVICE_DATE,
+      referenceNow: NOW,
+    })
+    // 90-minute booking against a 22:30 timeline end, so 21:00 is the last start offered.
+    const latest = options.filter((option) => !option.isCurrent).at(-1)
+    expect(latest?.time).toBe('21:00')
+  })
+
+  it('offers every slot to a booking that holds no table', () => {
+    const outside = makeBooking({ id: 'outside-1', assigned_table_ids: [], is_outside_seating: true })
+    const schedule = makeSchedule([
+      makeBooking({ id: 'booking-2', start_datetime: '2026-09-01T19:00:00.000Z', end_datetime: '2026-09-01T20:00:00.000Z' }),
+    ])
+    const options = buildTimeChangeOptions({
+      schedule, booking: outside, timeline: TIMELINE, serviceDateIso: SERVICE_DATE, referenceNow: NOW,
+    })
+    expect(options.every((option) => option.available || option.isCurrent)).toBe(true)
+  })
+})
+
+describe('getFohTimeChangeBlocker', () => {
+  it('allows a plain confirmed booking', () => {
+    expect(getFohTimeChangeBlocker(makeBooking())).toBeNull()
+  })
+
+  it('allows a seated booking, which is warned about rather than blocked', () => {
+    expect(getFohTimeChangeBlocker(makeBooking({ seated_at: '2026-09-01T17:05:00.000Z' }))).toBeNull()
+  })
+
+  it.each(['cancelled', 'no_show', 'completed'])('blocks a %s booking', (status) => {
+    expect(getFohTimeChangeBlocker(makeBooking({ status }))).toBe('This booking is closed.')
+  })
+
+  it('blocks a booking whose party has left', () => {
+    expect(getFohTimeChangeBlocker(makeBooking({ left_at: '2026-09-01T19:00:00.000Z' })))
+      .toBe('This party has already left.')
+  })
+
+  it('blocks an event booking, which the schedule marks by purpose', () => {
+    expect(getFohTimeChangeBlocker(makeBooking({ booking_purpose: 'event' })))
+      .toMatch(/event/i)
+  })
+
+  it('blocks a private-hire block', () => {
+    expect(getFohTimeChangeBlocker(makeBooking({ is_private_block: true })))
+      .toMatch(/private booking/i)
+  })
+})
+
+describe('formatMinutesAsClock', () => {
+  it('formats a normal time', () => {
+    expect(formatMinutesAsClock(18 * 60 + 30)).toBe('18:30')
+  })
+
+  it('wraps past midnight for a late service window', () => {
+    expect(formatMinutesAsClock(24 * 60 + 30)).toBe('00:30')
+  })
+})

--- a/src/app/(authenticated)/table-bookings/foh/components/FohBookingDetailModal.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/FohBookingDetailModal.tsx
@@ -20,6 +20,7 @@ import {
   getBookingVisualState,
   statusBadgeClass,
   postBookingAction,
+  getFohTimeChangeBlocker,
 } from '../utils'
 
 type FohBookingDetailModalProps = {
@@ -42,6 +43,7 @@ type FohBookingDetailModalProps = {
   onSetShowNoShowConfirmation: (value: boolean) => void
   onOpenPartySizeEdit: (bookingId: string, currentSize: number) => void
   onOpenWalkoutModal: (bookingId: string) => void
+  onOpenChangeTime: (bookingId: string) => void
 }
 
 export const FohBookingDetailModal = React.memo(function FohBookingDetailModal(props: FohBookingDetailModalProps) {
@@ -61,6 +63,7 @@ export const FohBookingDetailModal = React.memo(function FohBookingDetailModal(p
     onSetShowNoShowConfirmation,
     onOpenPartySizeEdit,
     onOpenWalkoutModal,
+    onOpenChangeTime,
   } = props
 
   const selectedBooking = selectedBookingContext?.booking ?? null
@@ -187,6 +190,8 @@ export const FohBookingDetailModal = React.memo(function FohBookingDetailModal(p
             onSetShowNoShowConfirmation={onSetShowNoShowConfirmation}
             onOpenPartySizeEdit={onOpenPartySizeEdit}
             onOpenWalkoutModal={onOpenWalkoutModal}
+            onOpenChangeTime={onOpenChangeTime}
+            timeChangeBlocker={getFohTimeChangeBlocker(selectedBooking)}
           />
         )}
 
@@ -283,6 +288,8 @@ function BookingActions(props: {
   onSetShowNoShowConfirmation: (value: boolean) => void
   onOpenPartySizeEdit: (bookingId: string, currentSize: number) => void
   onOpenWalkoutModal: (bookingId: string) => void
+  onOpenChangeTime: (bookingId: string) => void
+  timeChangeBlocker: string | null
 }) {
   const {
     selectedBooking,
@@ -302,6 +309,8 @@ function BookingActions(props: {
     onSetShowNoShowConfirmation,
     onOpenPartySizeEdit,
     onOpenWalkoutModal,
+    onOpenChangeTime,
+    timeChangeBlocker,
   } = props
 
   return (
@@ -320,7 +329,7 @@ function BookingActions(props: {
               if (ok) onClose()
             })()
           }}
-          className="rounded-md border border-gray-300 px-2 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+          className="min-h-[44px] rounded-md border border-gray-300 px-2 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {bookingActionInFlight === 'seated' ? 'Marking...' : 'Mark seated'}
         </button>
@@ -337,7 +346,7 @@ function BookingActions(props: {
               if (ok) onClose()
             })()
           }}
-          className="rounded-md border border-gray-300 px-2 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+          className="min-h-[44px] rounded-md border border-gray-300 px-2 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {bookingActionInFlight === 'left' ? 'Marking...' : 'Mark left'}
         </button>
@@ -348,7 +357,7 @@ function BookingActions(props: {
             onSetShowNoShowConfirmation(!showNoShowConfirmation)
           }}
           className={cn(
-            'rounded-md border px-2 py-2.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60',
+            'min-h-[44px] rounded-md border px-2 py-2 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60',
             showNoShowConfirmation
               ? 'border-red-400 bg-red-100 text-red-800'
               : 'border-red-300 text-red-700 hover:bg-red-50'
@@ -363,9 +372,24 @@ function BookingActions(props: {
             const currentSize = Math.max(1, Number(selectedBooking.party_size || 1))
             onOpenPartySizeEdit(selectedBooking.id, currentSize)
           }}
-          className="rounded-md border border-gray-300 px-2 py-2.5 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+          className="min-h-[44px] rounded-md border border-gray-300 px-2 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {bookingActionInFlight === 'party_size' ? 'Saving...' : 'Edit party size'}
+        </button>
+        {/* Until this existed, the only way to re-time a booking was to drag it on the
+            timeline, and drag is switched off in kiosk mode, which is what the floor iPad
+            runs. There was no route to a time change at all on that screen. */}
+        <button
+          type="button"
+          disabled={Boolean(bookingActionInFlight) || Boolean(timeChangeBlocker)}
+          title={timeChangeBlocker ?? undefined}
+          onClick={() => {
+            if (timeChangeBlocker) return
+            onOpenChangeTime(selectedBooking.id)
+          }}
+          className="min-h-[44px] rounded-md border border-gray-300 px-2 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {bookingActionInFlight === 'change_time' ? 'Changing...' : 'Change time'}
         </button>
         <button
           type="button"
@@ -375,7 +399,7 @@ function BookingActions(props: {
             onSetShowCancelBookingConfirmation(!showCancelBookingConfirmation)
           }}
           className={cn(
-            'rounded-md border px-2 py-2.5 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60',
+            'min-h-[44px] rounded-md border px-2 py-2 text-xs font-medium focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60',
             showCancelBookingConfirmation
               ? 'border-red-400 bg-red-100 text-red-800'
               : 'border-red-300 text-red-700 hover:bg-red-50'
@@ -389,7 +413,7 @@ function BookingActions(props: {
           onClick={() => {
             onOpenWalkoutModal(selectedBooking.id)
           }}
-          className="rounded-md border border-red-300 px-2 py-2.5 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60"
+          className="min-h-[44px] rounded-md border border-red-300 px-2 py-2 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-300 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {bookingActionInFlight === 'walkout' ? 'Saving...' : 'Flag walkout'}
         </button>

--- a/src/app/(authenticated)/table-bookings/foh/components/FohChangeTimeModal.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/FohChangeTimeModal.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import React from 'react'
+import { Modal, ModalActions } from '@/ds'
+import { cn } from '@/lib/utils'
+import type { TimeSlotOption } from '../utils'
+
+const BLOCK_LABEL: Record<NonNullable<TimeSlotOption['blockedBy']>, string> = {
+  private: 'Private',
+  event: 'Event',
+  taken: 'Taken',
+}
+
+/** Offered either side of the current time. Covers the everyday "they are running late" nudge. */
+const NUDGE_STEPS = [-30, -15, 15, 30] as const
+
+type FohChangeTimeModalProps = {
+  open: boolean
+  /** Who is being moved, for the heading. */
+  bookingLabel: string
+  currentTime: string
+  /** True when the party is already at the table. Changes the warning, not the rules. */
+  isSeated: boolean
+  options: TimeSlotOption[]
+  submitting: boolean
+  /** Set on a refused move so the message lands inside the flow, not behind the modal. */
+  error: string | null
+  onClose: () => void
+  onConfirm: (time: string) => void
+}
+
+export const FohChangeTimeModal = React.memo(function FohChangeTimeModal(props: FohChangeTimeModalProps) {
+  const {
+    open,
+    bookingLabel,
+    currentTime,
+    isSeated,
+    options,
+    submitting,
+    error,
+    onClose,
+    onConfirm,
+  } = props
+
+  const [selected, setSelected] = React.useState<string | null>(null)
+  const gridRef = React.useRef<HTMLDivElement | null>(null)
+  const currentRef = React.useRef<HTMLButtonElement | null>(null)
+
+  // Reopening for another booking must not inherit the last one's choice.
+  React.useEffect(() => {
+    if (open) setSelected(null)
+  }, [open, currentTime])
+
+  // A 12-hour service is around 45 tiles. Without this the modal opens showing lunch while
+  // the floor is working the evening.
+  React.useEffect(() => {
+    if (!open) return
+    const frame = window.requestAnimationFrame(() => {
+      // Guarded because scrollIntoView is not universally implemented and this is a nicety,
+      // never a reason for the modal to fail to open.
+      const node = currentRef.current
+      if (typeof node?.scrollIntoView === 'function') node.scrollIntoView({ block: 'center' })
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [open, options])
+
+  const byTime = React.useMemo(() => {
+    const map = new Map<string, TimeSlotOption>()
+    for (const option of options) map.set(option.time, option)
+    return map
+  }, [options])
+
+  const currentOption = options.find((option) => option.isCurrent) ?? null
+
+  const nudges = React.useMemo(() => {
+    if (!currentOption) return []
+    return NUDGE_STEPS.map((step) => {
+      const target = options.find((option) => option.minutes === currentOption.minutes + step)
+      return { step, option: target ?? null }
+    })
+  }, [currentOption, options])
+
+  const selectedOption = selected ? byTime.get(selected) ?? null : null
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Change booking time"
+      size="md"
+      footer={
+        <ModalActions>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="min-h-[44px] rounded-md border border-gray-300 bg-white px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={submitting || !selectedOption?.available}
+            onClick={() => {
+              if (selectedOption?.available) onConfirm(selectedOption.time)
+            }}
+            className="min-h-[44px] rounded-md bg-sidebar px-4 text-sm font-medium text-white hover:bg-sidebar/90 disabled:opacity-50"
+          >
+            {submitting
+              ? 'Changing...'
+              : selectedOption
+                ? `Change to ${selectedOption.time}`
+                : 'Change time'}
+          </button>
+        </ModalActions>
+      }
+    >
+      <div className="space-y-4">
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-3">
+          <p className="text-sm font-semibold text-gray-900">{bookingLabel}</p>
+          <p className="mt-0.5 text-sm text-gray-700">
+            Currently booked for <strong>{currentTime}</strong>
+          </p>
+        </div>
+
+        {/* Every change texts or emails the guest, so a mistap is not silent. Staff are told
+            that before they pick, not after. */}
+        <p className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+          {isSeated
+            ? 'This party is already seated. Changing the time will still tell them their booking has moved, and will free their table for the old time.'
+            : 'The guest is told about every time change.'}
+        </p>
+
+        {options.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            No other time is available for this booking today.
+          </p>
+        ) : (
+          <>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Quick change
+              </p>
+              <div className="mt-2 grid grid-cols-4 gap-2">
+                {nudges.map(({ step, option }) => {
+                  const usable = Boolean(option?.available)
+                  const isSelected = Boolean(option && selected === option.time)
+                  return (
+                    <button
+                      key={step}
+                      type="button"
+                      disabled={!usable || submitting}
+                      aria-label={
+                        option
+                          ? `${step > 0 ? `${step} minutes later` : `${Math.abs(step)} minutes earlier`}, ${option.time}${usable ? '' : ', unavailable'}`
+                          : `${step} minutes, unavailable`
+                      }
+                      onClick={() => option && setSelected(option.time)}
+                      className={cn(
+                        'flex min-h-[3.5rem] flex-col items-center justify-center rounded-lg border px-1 text-center',
+                        'focus:outline-none focus:ring-2 focus:ring-green-500',
+                        'disabled:cursor-not-allowed disabled:opacity-40',
+                        isSelected
+                          ? 'border-green-600 bg-green-50 text-green-800'
+                          : 'border-gray-300 text-gray-800 hover:bg-gray-50',
+                      )}
+                    >
+                      <span className="text-sm font-semibold leading-tight">
+                        {step > 0 ? `+${step}` : step}
+                      </span>
+                      <span className="mt-0.5 text-xs text-gray-500">
+                        {option ? option.time : '--:--'}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+                All times
+              </p>
+              <div
+                ref={gridRef}
+                role="group"
+                aria-label="Available booking times"
+                className="mt-2 max-h-64 overflow-y-auto rounded-md border border-gray-200 p-2"
+              >
+                <div className="grid grid-cols-4 gap-2">
+                  {options.map((option) => {
+                    const isSelected = selected === option.time
+                    return (
+                      <button
+                        key={option.time}
+                        ref={option.isCurrent ? currentRef : undefined}
+                        type="button"
+                        disabled={!option.available || submitting}
+                        aria-current={option.isCurrent ? 'true' : undefined}
+                        aria-label={
+                          option.isCurrent
+                            ? `${option.time}, current booking time`
+                            : option.available
+                              ? option.time
+                              : `${option.time}, unavailable, ${BLOCK_LABEL[option.blockedBy!].toLowerCase()}`
+                        }
+                        onClick={() => setSelected(option.time)}
+                        className={cn(
+                          'flex min-h-[3.5rem] flex-col items-center justify-center rounded-lg border px-1 text-center',
+                          'focus:outline-none focus:ring-2 focus:ring-green-500',
+                          'disabled:cursor-not-allowed',
+                          option.isCurrent
+                            ? 'border-gray-500 bg-gray-100 text-gray-900 opacity-100'
+                            : isSelected
+                              ? 'border-green-600 bg-green-50 text-green-800'
+                              : option.available
+                                ? 'border-gray-300 text-gray-800 hover:bg-gray-50'
+                                : 'border-gray-200 text-gray-400 opacity-60',
+                        )}
+                      >
+                        <span className="text-sm font-semibold leading-tight">{option.time}</span>
+                        {option.isCurrent ? (
+                          <span className="mt-0.5 text-[10px] font-medium text-gray-600">Current</span>
+                        ) : option.blockedBy ? (
+                          <span className="mt-0.5 text-[10px] text-gray-400">
+                            {BLOCK_LABEL[option.blockedBy]}
+                          </span>
+                        ) : null}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+
+        {error && (
+          <p
+            role="alert"
+            className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800"
+          >
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  )
+})

--- a/src/app/(authenticated)/table-bookings/foh/components/FohTimeline.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/FohTimeline.tsx
@@ -119,10 +119,10 @@ export const FohTimeline = React.memo(function FohTimeline(props: FohTimelinePro
     'font-semibold uppercase tracking-wide text-gray-600',
     isManagerKioskStyle ? 'px-2 py-1.5 text-[10px]' : 'px-3 py-2 text-xs'
   )
-  const timelineHeaderTrackClass = cn(
-    'relative',
-    isManagerKioskStyle ? 'h-10 px-1.5' : 'h-10 px-2'
-  )
+  // No horizontal padding. The drag snap measures this element and converts a pointer offset
+  // into a time, but the lane tracks below it have no padding, so any here made the header a
+  // few pixels wider than the lanes and skewed every snapped time by that difference.
+  const timelineHeaderTrackClass = 'relative h-10'
   const laneMetaCellClass = cn(
     'space-y-1 bg-white',
     isManagerKioskStyle ? 'px-2 py-1.5' : 'px-3 py-2'

--- a/src/app/(authenticated)/table-bookings/foh/components/__tests__/FohBookingDetailModal.test.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/__tests__/FohBookingDetailModal.test.tsx
@@ -51,6 +51,7 @@ function renderModal(booking: FohBooking) {
       onSetShowNoShowConfirmation={vi.fn()}
       onOpenPartySizeEdit={vi.fn()}
       onOpenWalkoutModal={vi.fn()}
+      onOpenChangeTime={vi.fn()}
     />
   )
 }

--- a/src/app/(authenticated)/table-bookings/foh/components/__tests__/FohChangeTimeModal.test.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/__tests__/FohChangeTimeModal.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { FohChangeTimeModal } from '../FohChangeTimeModal'
+import type { TimeSlotOption } from '../../utils'
+
+function slot(time: string, overrides: Partial<TimeSlotOption> = {}): TimeSlotOption {
+  const [hours, minutes] = time.split(':').map(Number)
+  return {
+    minutes: hours! * 60 + minutes!,
+    time,
+    available: true,
+    blockedBy: null,
+    isCurrent: false,
+    ...overrides,
+  }
+}
+
+const OPTIONS: TimeSlotOption[] = [
+  slot('17:30'),
+  slot('17:45'),
+  slot('18:00', { isCurrent: true, available: false }),
+  slot('18:15'),
+  slot('18:30', { available: false, blockedBy: 'taken' }),
+  slot('19:00', { available: false, blockedBy: 'private' }),
+]
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof FohChangeTimeModal>> = {}) {
+  const onConfirm = vi.fn()
+  const onClose = vi.fn()
+  render(
+    <FohChangeTimeModal
+      open
+      bookingLabel="Smith"
+      currentTime="18:00"
+      isSeated={false}
+      options={OPTIONS}
+      submitting={false}
+      error={null}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      {...overrides}
+    />,
+  )
+  return { onConfirm, onClose }
+}
+
+describe('FohChangeTimeModal', () => {
+  it('shows who is being moved and when they are currently booked', () => {
+    renderModal()
+    expect(screen.getByText('Smith')).toBeInTheDocument()
+    // The heading states the current time, and the grid separately marks that tile as current.
+    expect(screen.getByText(/currently booked for/i)).toHaveTextContent('18:00')
+    expect(screen.getByRole('button', { name: /18:00, current booking time/i })).toBeInTheDocument()
+  })
+
+  it('always warns that the guest will be told', () => {
+    renderModal()
+    expect(screen.getByText(/guest is told about every time change/i)).toBeInTheDocument()
+  })
+
+  it('warns harder when the party is already seated', () => {
+    renderModal({ isSeated: true })
+    expect(screen.getByText(/already seated/i)).toBeInTheDocument()
+    expect(screen.getByText(/free their table for the old time/i)).toBeInTheDocument()
+  })
+
+  it('marks the current time and refuses to submit it', async () => {
+    const user = userEvent.setup()
+    const { onConfirm } = renderModal()
+
+    const current = screen.getByRole('button', { name: /18:00, current booking time/i })
+    expect(current).toBeDisabled()
+    await user.click(current)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('disables a blocked slot and names the reason for assistive technology', () => {
+    renderModal()
+    const taken = screen.getByRole('button', { name: /18:30, unavailable, taken/i })
+    expect(taken).toBeDisabled()
+    const priv = screen.getByRole('button', { name: /19:00, unavailable, private/i })
+    expect(priv).toBeDisabled()
+  })
+
+  it('needs an explicit confirm after picking, because the guest gets a message', async () => {
+    const user = userEvent.setup()
+    const { onConfirm } = renderModal()
+
+    // Nothing chosen yet, so there is nothing to confirm.
+    expect(screen.getByRole('button', { name: /change time/i })).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: '18:15' }))
+    // Picking a slot does not send anything on its own.
+    expect(onConfirm).not.toHaveBeenCalled()
+
+    const confirm = screen.getByRole('button', { name: /change to 18:15/i })
+    expect(confirm).toBeEnabled()
+    await user.click(confirm)
+    expect(onConfirm).toHaveBeenCalledWith('18:15')
+  })
+
+  it('offers quick nudges either side of the current time', async () => {
+    const user = userEvent.setup()
+    const { onConfirm } = renderModal()
+
+    await user.click(screen.getByRole('button', { name: /15 minutes earlier, 17:45/i }))
+    await user.click(screen.getByRole('button', { name: /change to 17:45/i }))
+    expect(onConfirm).toHaveBeenCalledWith('17:45')
+  })
+
+  it('disables a nudge that lands on a blocked time rather than hiding it', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: /30 minutes later, 18:30, unavailable/i })).toBeDisabled()
+  })
+
+  it('shows a refusal inside the modal, where staff are looking', () => {
+    renderModal({ error: 'Selected time conflicts with another booking or private block.' })
+    expect(screen.getByRole('alert')).toHaveTextContent(/conflicts with another booking/i)
+  })
+
+  it('locks every control while the change is in flight', async () => {
+    const user = userEvent.setup()
+    renderModal({ submitting: true })
+    expect(screen.getByRole('button', { name: /changing/i })).toBeDisabled()
+    const slot1815 = screen.getByRole('button', { name: '18:15' })
+    expect(slot1815).toBeDisabled()
+    await user.click(slot1815)
+    expect(screen.getByRole('button', { name: /changing/i })).toBeDisabled()
+  })
+
+  it('says so plainly when there is nowhere to move to', () => {
+    renderModal({ options: [] })
+    expect(screen.getByText(/no other time is available/i)).toBeInTheDocument()
+  })
+})

--- a/src/app/(authenticated)/table-bookings/foh/utils.ts
+++ b/src/app/(authenticated)/table-bookings/foh/utils.ts
@@ -633,3 +633,218 @@ export function splitName(fullName: string): { firstName?: string; lastName?: st
     lastName: parts.slice(1).join(' ')
   }
 }
+
+// ---------------------------------------------------------------------------
+// Changing a booking's time from the floor.
+//
+// The candidate grid is worked out in the browser from the schedule the page has
+// already loaded, rather than through another request. Every window that can block
+// a table is already in `schedule.lanes[]`: real bookings, private-hire blocks and
+// communal event blocks all arrive with a start and an end. On an iPad mid-service
+// an instant grid beats a round trip, and the database trigger stays the authority
+// either way, so the worst a stale client can do is earn a 409.
+// ---------------------------------------------------------------------------
+
+/**
+ * Does this booking still hold its table?
+ *
+ * Mirrors `public.is_booking_live(status, left_at, hold_expires_at, payment_status)`,
+ * which is what the `enforce_booking_table_assignment_integrity_v05` trigger uses to
+ * decide whether an existing assignment blocks a new one. If the two ever drift, the
+ * grid starts offering times the server then refuses, so keep them in step: the SQL
+ * lives in `supabase/migrations/20260801000600_booking_liveness_helpers.sql`.
+ *
+ * `referenceNow` is passed in rather than read from the clock so the result is stable
+ * across a render and testable without faking time.
+ */
+export function isFohBookingLive(booking: FohBooking, referenceNow: Date): boolean {
+  const status = (booking.status || '').toLowerCase()
+  if (status === 'cancelled' || status === 'no_show') return false
+  if (booking.left_at) return false
+
+  const isHold = status === 'pending_payment' || status === 'pending_card_capture'
+  if (isHold && booking.hold_expires_at) {
+    const expiresMs = Date.parse(booking.hold_expires_at)
+    const paid = (booking.payment_status || '').toLowerCase() === 'completed'
+    if (Number.isFinite(expiresMs) && expiresMs <= referenceNow.getTime() && !paid) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export type TimeSlotBlockReason = 'private' | 'event' | 'taken'
+
+export type TimeSlotOption = {
+  /** Minutes from midnight on the service date. Can exceed 1440 on a late window. */
+  minutes: number
+  /** London clock time, "HH:MM", which is what the endpoint takes. */
+  time: string
+  available: boolean
+  /** Why it cannot be used. Null when it can. */
+  blockedBy: TimeSlotBlockReason | null
+  /** True for the booking's own current time, which is shown but not offered. */
+  isCurrent: boolean
+}
+
+type BusyInterval = { start: number; end: number; reason: TimeSlotBlockReason }
+
+/**
+ * The windows that would block this booking if it moved, across every table it sits on.
+ *
+ * A booking joined across two tables is returned once per lane by the schedule API, so the
+ * lanes are filtered by the booking's own `assigned_table_ids` and the booking itself is
+ * always excluded. A booking with no table (unassigned, or outside seating) has nothing to
+ * clash with and yields no intervals.
+ */
+export function collectBusyIntervals(input: {
+  schedule: FohScheduleResponse['data'] | null
+  booking: FohBooking
+  serviceDateIso: string
+  referenceNow: Date
+}): BusyInterval[] {
+  const { schedule, booking, serviceDateIso, referenceNow } = input
+  if (!schedule) return []
+
+  const tableIds = new Set(booking.assigned_table_ids ?? [])
+  if (tableIds.size === 0) return []
+
+  const intervals: BusyInterval[] = []
+  const seen = new Set<string>()
+
+  for (const lane of schedule.lanes) {
+    if (!tableIds.has(lane.table_id)) continue
+
+    for (const other of lane.bookings) {
+      if (other.id === booking.id) continue
+
+      // Blocks are synthesised per table, so the same private booking legitimately appears
+      // on several lanes. De-duplicate per lane+block so one clash is not counted twice.
+      const key = `${lane.table_id}:${other.id}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const reason: TimeSlotBlockReason = other.is_private_block
+        ? 'private'
+        : other.is_communal_event_block
+          ? 'event'
+          : 'taken'
+
+      // Private and communal blocks are not bookings and carry no liveness fields; they
+      // always block. Real bookings block only while they still hold the table.
+      if (reason === 'taken' && !isFohBookingLive(other, referenceNow)) continue
+
+      const window = resolveBookingWindowMinutes(other, serviceDateIso)
+      if (!window) continue
+
+      intervals.push({ start: window.start, end: window.end, reason })
+    }
+  }
+
+  return intervals
+}
+
+/**
+ * Every time this booking could move to, marked free or blocked.
+ *
+ * Slots run on `stepMinutes` across the visible timeline. A candidate is rejected when the
+ * booking's whole window would not fit before the end of the timeline, and when it overlaps
+ * anything busy. Overlap is half-open, `[start, end)`, matching the SQL trigger, so a booking
+ * ending at 19:00 does not block one starting at 19:00.
+ *
+ * The booking's current time is included even when it is off-grid, because live data holds
+ * times like 20:19 and 20:55, and a picker that quietly dropped the current time would look
+ * broken.
+ */
+export function buildTimeChangeOptions(input: {
+  schedule: FohScheduleResponse['data'] | null
+  booking: FohBooking
+  timeline: TimelineRange
+  serviceDateIso: string
+  referenceNow: Date
+  stepMinutes?: number
+}): TimeSlotOption[] {
+  const { schedule, booking, timeline, serviceDateIso, referenceNow, stepMinutes = 15 } = input
+
+  const currentWindow = resolveBookingWindowMinutes(booking, serviceDateIso)
+  if (!currentWindow) return []
+
+  const durationMinutes = Math.max(15, currentWindow.end - currentWindow.start)
+  const busy = collectBusyIntervals({ schedule, booking, serviceDateIso, referenceNow })
+
+  const candidates = new Set<number>()
+  const firstSlot = Math.ceil(timeline.startMin / stepMinutes) * stepMinutes
+  for (let minute = firstSlot; minute + durationMinutes <= timeline.endMin; minute += stepMinutes) {
+    candidates.add(minute)
+  }
+  // Always offer the booking back to where it started, grid-aligned or not.
+  candidates.add(currentWindow.start)
+
+  return Array.from(candidates)
+    .sort((left, right) => left - right)
+    .map((minutes) => {
+      const isCurrent = minutes === currentWindow.start
+      const end = minutes + durationMinutes
+
+      // Reason priority: a private block is the least negotiable thing on the timeline and
+      // an event block the next, so they win over an ordinary clash when windows overlap.
+      const clashes = busy.filter((interval) => interval.start < end && interval.end > minutes)
+      const blockedBy: TimeSlotBlockReason | null =
+        clashes.find((c) => c.reason === 'private')?.reason
+        ?? clashes.find((c) => c.reason === 'event')?.reason
+        ?? clashes.find((c) => c.reason === 'taken')?.reason
+        ?? null
+
+      return {
+        minutes,
+        time: formatMinutesAsClock(minutes),
+        available: blockedBy == null && !isCurrent,
+        blockedBy,
+        isCurrent,
+      }
+    })
+}
+
+/** Minutes from midnight to a London "HH:MM" clock, wrapping past a midnight-crossing window. */
+export function formatMinutesAsClock(minutes: number): string {
+  const wrapped = ((minutes % 1440) + 1440) % 1440
+  const hours = Math.floor(wrapped / 60)
+  const mins = wrapped % 60
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`
+}
+
+/**
+ * Whether the floor may re-time this booking at all.
+ *
+ * The same rules the endpoint enforces, so the button is never offered for something the
+ * server would refuse. The server is still the authority; this only keeps staff from
+ * tapping into a guaranteed error.
+ */
+export const FOH_TIME_CHANGE_EDITABLE_STATUSES = new Set([
+  'confirmed',
+  'pending_payment',
+  'pending_card_capture',
+  'visited_waiting_for_review',
+  'review_clicked',
+])
+
+export function getFohTimeChangeBlocker(booking: FohBooking): string | null {
+  if (booking.is_private_block) return 'Managed by the private booking.'
+  if (booking.is_communal_event_block || booking.id.startsWith('communal-') || booking.id.startsWith('standing-')) {
+    return 'Managed from the event.'
+  }
+  if (booking.left_at) return 'This party has already left.'
+  // The schedule API does not expose event_id, but it rewrites both type and purpose to
+  // 'event' for a booking that has one, and carries the event name. An event diner's table
+  // is tied to their ticket, so re-timing only the table half would split the pair; the
+  // endpoint refuses it too.
+  if (booking.booking_purpose === 'event' || booking.booking_type === 'event' || booking.event_name) {
+    return 'Tied to an event. Change it from the event.'
+  }
+  const status = (booking.status || '').toLowerCase()
+  if (!FOH_TIME_CHANGE_EDITABLE_STATUSES.has(status)) {
+    return 'This booking is closed.'
+  }
+  return null
+}

--- a/src/app/api/foh/bookings/[id]/time/route.test.ts
+++ b/src/app/api/foh/bookings/[id]/time/route.test.ts
@@ -2,13 +2,21 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { PATCH } from './route'
 import { NextRequest } from 'next/server'
 import { requireFohPermission } from '@/lib/foh/api-auth'
+import { logAuditEvent } from '@/app/actions/audit'
+import { sendTableBookingRescheduledNotificationIfAllowed } from '@/lib/table-bookings/bookings'
 
 vi.mock('@/lib/foh/api-auth', () => ({
   requireFohPermission: vi.fn(),
-  getLondonDateIso: vi.fn((date: Date) => date.toISOString().slice(0, 10)),
+  // Real London date extraction, so BST handling stays exercised rather than stubbed away.
+  getLondonDateIso: vi.fn((date: Date) =>
+    new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/London' }).format(date),
+  ),
 }))
 vi.mock('@/lib/logger', () => ({
-  logger: { error: vi.fn(), info: vi.fn() },
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}))
+vi.mock('@/app/actions/audit', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
 }))
 // The rescheduled-notification side effect is exercised in its own tests; mock it
 // here so this route test doesn't run the real helper against the minimal DB mock.
@@ -36,33 +44,63 @@ const mockAuthFail = () => {
   } as unknown as Awaited<ReturnType<typeof requireFohPermission>>)
 }
 
-const createSupabaseMock = () => {
-  // Track calls to from() so we can differentiate between tables
-  const assignmentEq = vi.fn().mockResolvedValue({
-    data: [{
-      start_datetime: '2026-03-15T13:00:00.000Z',
-      end_datetime: '2026-03-15T15:00:00.000Z',
-    }],
-    error: null,
-  })
-  const assignmentSelect = vi.fn().mockReturnValue({ eq: assignmentEq })
+/**
+ * A 105-minute guest booking at 13:00 UTC with a 15-minute turnaround gap, so the assignment
+ * runs 15 minutes past the booking. This is the shape that the previous version of the route
+ * collapsed into a single 120-minute booking.
+ */
+const DEFAULT_BOOKING = {
+  id: VALID_UUID,
+  status: 'confirmed',
+  booking_time: '13:00:00',
+  booking_date: '2026-03-15',
+  start_datetime: '2026-03-15T13:00:00.000Z',
+  end_datetime: '2026-03-15T14:45:00.000Z',
+  duration_minutes: 105,
+  seated_at: null,
+  left_at: null,
+  event_id: null,
+  high_chair_count: 0,
+}
 
-  const rpc = vi.fn().mockResolvedValue({
-    data: { state: 'updated', assignment_count: 1 },
-    error: null,
-  })
+const DEFAULT_ASSIGNMENTS = [
+  { start_datetime: '2026-03-15T13:00:00.000Z', end_datetime: '2026-03-15T15:00:00.000Z' },
+]
+
+const createSupabaseMock = (options: {
+  booking?: Record<string, unknown> | null
+  assignments?: Array<Record<string, unknown>>
+  rpcResult?: unknown
+  rpcError?: unknown
+} = {}) => {
+  const {
+    booking = DEFAULT_BOOKING,
+    assignments = DEFAULT_ASSIGNMENTS,
+    rpcResult = {
+      state: 'updated',
+      assignment_count: 1,
+      high_chairs_requested: 0,
+      high_chairs_granted: 0,
+    },
+    rpcError = null,
+  } = options
+
+  const rpc = vi.fn().mockResolvedValue({ data: rpcResult, error: rpcError })
 
   const from = vi.fn().mockImplementation((table: string) => {
-    if (table === 'booking_table_assignments') {
-      return { select: assignmentSelect }
-    }
     if (table === 'table_bookings') {
-      return { select: assignmentSelect }
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: () => Promise.resolve({ data: booking, error: null }) }),
+        }),
+      }
     }
-    return { select: assignmentSelect }
+    return {
+      select: () => ({ eq: () => Promise.resolve({ data: assignments, error: null }) }),
+    }
   })
 
-  return { from, rpc, _assignmentEq: assignmentEq }
+  return { from, rpc }
 }
 
 const mockAuthSuccess = (dbMock: Record<string, unknown> = {}) => {
@@ -78,54 +116,257 @@ describe('PATCH /api/foh/bookings/[id]/time', () => {
     vi.clearAllMocks()
   })
 
-  it('returns 401 when auth fails', async () => {
-    mockAuthFail()
-    const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
-    expect(res.status).toBe(401)
+  describe('request validation', () => {
+    it('returns 401 when auth fails', async () => {
+      mockAuthFail()
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 400 for invalid UUID in params', async () => {
+      mockAuthSuccess({})
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams('not-a-uuid'))
+      expect(res.status).toBe(400)
+      const json = await res.json()
+      expect(json.error).toMatch(/invalid booking id/i)
+    })
+
+    it('returns 400 for missing time field', async () => {
+      mockAuthSuccess({})
+      const res = await PATCH(makeRequest({}), makeParams())
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for invalid time format (e.g. "25:00")', async () => {
+      mockAuthSuccess({})
+      const res = await PATCH(makeRequest({ time: '25:00' }), makeParams())
+      expect(res.status).toBe(400)
+      const json = await res.json()
+      expect(json.error).toMatch(/hh:mm/i)
+    })
+
+    it('returns 400 for invalid time format (e.g. "9:00" without leading zero)', async () => {
+      mockAuthSuccess({})
+      const res = await PATCH(makeRequest({ time: '9:00' }), makeParams())
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 404 when the booking does not exist', async () => {
+      mockAuthSuccess(createSupabaseMock({ booking: null }))
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(404)
+    })
   })
 
-  it('returns 400 for invalid UUID in params', async () => {
-    mockAuthSuccess({})
-    const res = await PATCH(makeRequest({ time: '14:00' }), makeParams('not-a-uuid'))
-    expect(res.status).toBe(400)
-    const json = await res.json()
-    expect(json.error).toMatch(/invalid booking id/i)
+  describe('eligibility, enforced server-side rather than trusted from the UI', () => {
+    it.each(['cancelled', 'no_show', 'completed'])('refuses a %s booking', async (status) => {
+      const db = createSupabaseMock({ booking: { ...DEFAULT_BOOKING, status } })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(409)
+      expect((await res.json()).code).toBe('ineligible_status')
+      expect(db.rpc).not.toHaveBeenCalled()
+    })
+
+    it('refuses a booking whose party has already left, even on a live status', async () => {
+      const db = createSupabaseMock({
+        booking: { ...DEFAULT_BOOKING, status: 'confirmed', left_at: '2026-03-15T14:00:00.000Z' },
+      })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(409)
+      expect((await res.json()).code).toBe('already_left')
+      expect(db.rpc).not.toHaveBeenCalled()
+    })
+
+    it('refuses an event-linked booking so the table cannot drift from its event', async () => {
+      const db = createSupabaseMock({
+        booking: { ...DEFAULT_BOOKING, event_id: 'b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a22' },
+      })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(409)
+      expect((await res.json()).code).toBe('event_linked')
+      expect(db.rpc).not.toHaveBeenCalled()
+    })
+
+    it('allows a seated booking, which the UI warns about rather than blocking', async () => {
+      const db = createSupabaseMock({
+        booking: { ...DEFAULT_BOOKING, seated_at: '2026-03-15T13:05:00.000Z' },
+      })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(200)
+      expect(db.rpc).toHaveBeenCalled()
+    })
+
+    it('returns 422 rather than a generic 500 when the stored window is unusable', async () => {
+      const db = createSupabaseMock({
+        booking: {
+          ...DEFAULT_BOOKING,
+          start_datetime: null,
+          booking_date: null,
+          booking_time: null,
+        },
+      })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
+      expect(res.status).toBe(422)
+      expect((await res.json()).code).toBe('corrupt_window')
+      expect(db.rpc).not.toHaveBeenCalled()
+    })
   })
 
-  it('returns 400 for missing time field', async () => {
-    mockAuthSuccess({})
-    const res = await PATCH(makeRequest({}), makeParams())
-    expect(res.status).toBe(400)
+  describe('window arithmetic', () => {
+    it('keeps the guest booking and the table hold as two separate windows', async () => {
+      const db = createSupabaseMock()
+      mockAuthSuccess(db)
+
+      const res = await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      expect(res.status).toBe(200)
+
+      // 13:00 UTC is 13:00 London on 2026-03-15 (before the clocks go forward), and the guest
+      // booking is 105 minutes with a 15-minute turnaround on top.
+      const args = db.rpc.mock.calls[0]?.[1] as Record<string, string>
+      expect(db.rpc).toHaveBeenCalledWith('move_table_booking_time_v06', expect.any(Object))
+      expect(args.p_table_booking_id).toBe(VALID_UUID)
+      expect(args.p_booking_time).toBe('18:00:00')
+      expect(args.p_start_datetime).toBe('2026-03-15T18:00:00.000Z')
+      // The guest keeps their 105 minutes.
+      expect(args.p_booking_end_datetime).toBe('2026-03-15T19:45:00.000Z')
+      // The table stays held for the extra 15.
+      expect(args.p_assignment_end_datetime).toBe('2026-03-15T20:00:00.000Z')
+    })
+
+    it('preserves the gap this booking actually carries, not the current setting', async () => {
+      // A booking taken when no turnaround was configured: assignment ends with the booking.
+      const db = createSupabaseMock({
+        assignments: [
+          { start_datetime: '2026-03-15T13:00:00.000Z', end_datetime: '2026-03-15T14:45:00.000Z' },
+        ],
+      })
+      mockAuthSuccess(db)
+
+      await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      const args = db.rpc.mock.calls[0]?.[1] as Record<string, string>
+      expect(args.p_booking_end_datetime).toBe('2026-03-15T19:45:00.000Z')
+      expect(args.p_assignment_end_datetime).toBe('2026-03-15T19:45:00.000Z')
+    })
+
+    it('falls back to duration_minutes when the booking row has no end', async () => {
+      const db = createSupabaseMock({
+        booking: { ...DEFAULT_BOOKING, end_datetime: null, duration_minutes: 90 },
+        assignments: [],
+      })
+      mockAuthSuccess(db)
+
+      await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      const args = db.rpc.mock.calls[0]?.[1] as Record<string, string>
+      expect(args.p_booking_end_datetime).toBe('2026-03-15T19:30:00.000Z')
+      expect(args.p_assignment_end_datetime).toBe('2026-03-15T19:30:00.000Z')
+    })
+
+    it('handles a booking with no table assignment at all', async () => {
+      const db = createSupabaseMock({ assignments: [] })
+      mockAuthSuccess(db)
+      const res = await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      expect(res.status).toBe(200)
+      const args = db.rpc.mock.calls[0]?.[1] as Record<string, string>
+      expect(args.p_assignment_end_datetime).toBe(args.p_booking_end_datetime)
+    })
+
+    it('converts London clock time correctly during British Summer Time', async () => {
+      // 1 July: London is UTC+1, so an 18:00 London arrival is 17:00 UTC.
+      const db = createSupabaseMock({
+        booking: {
+          ...DEFAULT_BOOKING,
+          booking_date: '2026-07-01',
+          start_datetime: '2026-07-01T12:00:00.000Z',
+          end_datetime: '2026-07-01T13:45:00.000Z',
+        },
+        assignments: [
+          { start_datetime: '2026-07-01T12:00:00.000Z', end_datetime: '2026-07-01T14:00:00.000Z' },
+        ],
+      })
+      mockAuthSuccess(db)
+
+      await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      const args = db.rpc.mock.calls[0]?.[1] as Record<string, string>
+      expect(args.p_start_datetime).toBe('2026-07-01T17:00:00.000Z')
+    })
   })
 
-  it('returns 400 for invalid time format (e.g. "25:00")', async () => {
-    mockAuthSuccess({})
-    const res = await PATCH(makeRequest({ time: '25:00' }), makeParams())
-    expect(res.status).toBe(400)
-    const json = await res.json()
-    expect(json.error).toMatch(/hh:mm/i)
+  describe('no-op and conflict', () => {
+    it('writes nothing and tells nobody when the time is unchanged', async () => {
+      const db = createSupabaseMock()
+      mockAuthSuccess(db)
+
+      const res = await PATCH(makeRequest({ time: '13:00' }), makeParams())
+      expect(res.status).toBe(200)
+      expect((await res.json()).data.state).toBe('unchanged')
+      expect(db.rpc).not.toHaveBeenCalled()
+      expect(sendTableBookingRescheduledNotificationIfAllowed).not.toHaveBeenCalled()
+      expect(logAuditEvent).not.toHaveBeenCalled()
+    })
+
+    it('maps a table clash to a 409 with a readable message', async () => {
+      const db = createSupabaseMock({
+        rpcError: { code: '23P01', message: 'table_assignment_overlap' },
+      })
+      mockAuthSuccess(db)
+
+      const res = await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      expect(res.status).toBe(409)
+      const json = await res.json()
+      expect(json.code).toBe('conflict')
+      expect(json.error).toMatch(/conflicts with another booking/i)
+      expect(sendTableBookingRescheduledNotificationIfAllowed).not.toHaveBeenCalled()
+    })
   })
 
-  it('returns 400 for invalid time format (e.g. "9:00" without leading zero)', async () => {
-    mockAuthSuccess({})
-    const res = await PATCH(makeRequest({ time: '9:00' }), makeParams())
-    expect(res.status).toBe(400)
-  })
+  describe('side effects', () => {
+    it('always tells the guest when the time actually changed', async () => {
+      mockAuthSuccess(createSupabaseMock())
+      await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      expect(sendTableBookingRescheduledNotificationIfAllowed).toHaveBeenCalledWith(
+        expect.anything(),
+        { tableBookingId: VALID_UUID },
+      )
+    })
 
-  it('returns 200 and moves booking plus assignments through the atomic RPC', async () => {
-    const db = createSupabaseMock()
-    mockAuthSuccess(db)
+    it('audits the move with both windows and the surface', async () => {
+      mockAuthSuccess(createSupabaseMock())
+      await PATCH(makeRequest({ time: '18:00' }), makeParams())
 
-    const res = await PATCH(makeRequest({ time: '14:00' }), makeParams())
-    expect(res.status).toBe(200)
-    const json = await res.json()
-    expect(json.success).toBe(true)
+      expect(logAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operation_type: 'change_time',
+          resource_type: 'table_booking',
+          resource_id: VALID_UUID,
+          operation_status: 'success',
+          old_values: expect.objectContaining({ booking_time: '13:00' }),
+          new_values: expect.objectContaining({ booking_time: '18:00' }),
+          additional_info: expect.objectContaining({ surface: 'foh', turnaround_minutes: 15 }),
+        }),
+      )
+    })
 
-    // Duration comes from assignments; mutation happens in the database RPC transaction.
-    expect(db.from).toHaveBeenCalledWith('booking_table_assignments')
-    expect(db.rpc).toHaveBeenCalledWith('move_table_booking_time_v05', expect.objectContaining({
-      p_table_booking_id: VALID_UUID,
-      p_booking_time: '14:00:00',
-    }))
+    it('reports a high chair lost to the move', async () => {
+      const db = createSupabaseMock({
+        booking: { ...DEFAULT_BOOKING, high_chair_count: 2 },
+        rpcResult: {
+          state: 'updated',
+          assignment_count: 1,
+          high_chairs_requested: 2,
+          high_chairs_granted: 1,
+        },
+      })
+      mockAuthSuccess(db)
+
+      const res = await PATCH(makeRequest({ time: '18:00' }), makeParams())
+      const json = await res.json()
+      expect(json.data.high_chairs_granted).toBe(1)
+      expect(json.data.high_chairs_lost).toBe(1)
+    })
   })
 })

--- a/src/app/api/foh/bookings/[id]/time/route.ts
+++ b/src/app/api/foh/bookings/[id]/time/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { fromZonedTime } from 'date-fns-tz'
 import { requireFohPermission, getLondonDateIso } from '@/lib/foh/api-auth'
 import { logger } from '@/lib/logger'
+import { logAuditEvent } from '@/app/actions/audit'
 import { isAssignmentConflictError } from '@/lib/table-bookings/move-table'
 import { sendTableBookingRescheduledNotificationIfAllowed } from '@/lib/table-bookings/bookings'
 
@@ -11,6 +12,46 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 const TimeSchema = z.object({
   time: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'time must be HH:MM format'),
 })
+
+/**
+ * Statuses a staff member may re-time from the floor.
+ *
+ * A blacklist was the first instinct, but it fails open: a status added later would silently
+ * become editable. Anything not named here is refused.
+ */
+const EDITABLE_STATUSES = new Set([
+  'confirmed',
+  'pending_payment',
+  'pending_card_capture',
+  'visited_waiting_for_review',
+  'review_clicked',
+])
+
+type BookingRow = {
+  id: string
+  status: string | null
+  booking_time: string | null
+  booking_date: string | null
+  start_datetime: string | null
+  end_datetime: string | null
+  duration_minutes: number | null
+  seated_at: string | null
+  left_at: string | null
+  event_id: string | null
+  high_chair_count: number | null
+}
+
+function londonClock(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/London',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).formatToParts(date)
+  const hour = parts.find((part) => part.type === 'hour')?.value ?? '00'
+  const minute = parts.find((part) => part.type === 'minute')?.value ?? '00'
+  return `${hour}:${minute}`
+}
 
 export async function PATCH(
   request: NextRequest,
@@ -45,7 +86,67 @@ export async function PATCH(
   const { time: newTime } = parsed.data
 
   try {
-    // Step 1: Fetch booking_table_assignments (authoritative for the FOH-rendered duration)
+    // Step 1: the booking row is the authority on the GUEST window and on whether this booking
+    // may be re-timed at all. The UI hides the action for ineligible bookings, but a disabled
+    // button is not a business rule, so every check is repeated here.
+    const { data: bookingRaw, error: bookingError } = await auth.supabase
+      .from('table_bookings')
+      .select(
+        'id, status, booking_time, booking_date, start_datetime, end_datetime, duration_minutes, seated_at, left_at, event_id, high_chair_count',
+      )
+      .eq('id', bookingId)
+      .maybeSingle()
+
+    if (bookingError) {
+      logger.error('FOH time update: failed to fetch booking', {
+        error: bookingError instanceof Error ? bookingError : new Error(String(bookingError)),
+        metadata: { bookingId },
+      })
+      return NextResponse.json({ error: 'Failed to fetch booking' }, { status: 500 })
+    }
+
+    if (!bookingRaw) {
+      return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
+    }
+
+    const booking = bookingRaw as BookingRow
+    const status = (booking.status || '').toLowerCase()
+
+    if (!EDITABLE_STATUSES.has(status)) {
+      return NextResponse.json(
+        { error: 'This booking can no longer be re-timed.', code: 'ineligible_status' },
+        { status: 409 },
+      )
+    }
+
+    // A party that has left is finished, whatever the raw status still says. left_at is set
+    // without moving the status, so checking status alone would let a departed booking through.
+    if (booking.left_at) {
+      return NextResponse.json(
+        { error: 'This party has already left, so the time cannot be changed.', code: 'already_left' },
+        { status: 409 },
+      )
+    }
+
+    // An event diner's table reservation is tied to a ticketed event booking and the event's own
+    // start. Moving the table half of that pair on its own would split them, and nothing here
+    // updates the event side. Refused until an event-aware reschedule exists.
+    if (booking.event_id) {
+      return NextResponse.json(
+        {
+          error: 'This booking is tied to an event. Change it from the event instead.',
+          code: 'event_linked',
+        },
+        { status: 409 },
+      )
+    }
+
+    // Step 2: work out the two windows this booking carries.
+    //
+    // The guest window comes from the booking row. The table is held longer than that whenever a
+    // turnaround gap is configured, and that longer window lives on the assignment rows. Reading
+    // the duration from the assignments (as the previous version did) folded the gap into the
+    // guest's booking on every move.
     const { data: assignments, error: assignmentError } = await auth.supabase
       .from('booking_table_assignments')
       .select('start_datetime, end_datetime')
@@ -59,89 +160,84 @@ export async function PATCH(
       return NextResponse.json({ error: 'Failed to fetch booking assignment' }, { status: 500 })
     }
 
-    let startDt: string
-    let endDt: string
-    const assignmentRows = Array.isArray(assignments) ? assignments : []
-    const assignmentWindows = assignmentRows
-      .map((row) => ({
-        start: new Date(row.start_datetime as string),
-        end: new Date(row.end_datetime as string),
-      }))
-      .filter((window) => Number.isFinite(window.start.getTime()) && Number.isFinite(window.end.getTime()))
+    const bookingStart = booking.start_datetime
+      ? new Date(booking.start_datetime)
+      : booking.booking_date && booking.booking_time
+        ? fromZonedTime(`${booking.booking_date}T${booking.booking_time}`, 'Europe/London')
+        : null
 
-    if (assignmentWindows.length > 0) {
-      const earliestStart = assignmentWindows.reduce((earliest, current) =>
-        current.start.getTime() < earliest.getTime() ? current.start : earliest,
-      assignmentWindows[0]!.start)
-      const latestEnd = assignmentWindows.reduce((latest, current) =>
-        current.end.getTime() > latest.getTime() ? current.end : latest,
-      assignmentWindows[0]!.end)
-      startDt = earliestStart.toISOString()
-      endDt = latestEnd.toISOString()
-    } else {
-      // Fallback to table_bookings
-      const { data: booking, error: bookingError } = await auth.supabase
-        .from('table_bookings')
-        .select('start_datetime, end_datetime, booking_date')
-        .eq('id', bookingId)
-        .maybeSingle()
-
-      if (bookingError) {
-        logger.error('FOH time update: failed to fetch table_bookings', {
-          error: bookingError instanceof Error ? bookingError : new Error(String(bookingError)),
-          metadata: { bookingId },
-        })
-        return NextResponse.json({ error: 'Failed to fetch booking' }, { status: 500 })
-      }
-
-      if (!booking) {
-        return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
-      }
-
-      startDt = booking.start_datetime as string
-      endDt = booking.end_datetime as string
+    if (!bookingStart || !Number.isFinite(bookingStart.getTime())) {
+      return NextResponse.json(
+        { error: 'This booking has no usable start time and must be fixed in the back office.', code: 'corrupt_window' },
+        { status: 422 },
+      )
     }
 
-    // Step 2: Calculate duration
-    const startDate = new Date(startDt)
-    const endDate = new Date(endDt)
-    const durationMs = endDate.getTime() - startDate.getTime()
+    const guestDurationMs = (() => {
+      if (booking.end_datetime) {
+        const end = new Date(booking.end_datetime)
+        const ms = end.getTime() - bookingStart.getTime()
+        if (Number.isFinite(ms) && ms > 0) return ms
+      }
+      const minutes = Number(booking.duration_minutes)
+      if (Number.isFinite(minutes) && minutes > 0) return minutes * 60 * 1000
+      return null
+    })()
 
-    // Step 3: Build new start/end datetimes
-    // Use getLondonDateIso to get the booking date in London local time, then combine
-    // with the new London-local time using fromZonedTime to get the correct UTC value.
-    // Using setUTCHours would treat the London clock time as UTC, causing a 1-hour
-    // offset in British Summer Time (BST, UTC+1).
-    const londonDateIso = getLondonDateIso(startDate)
+    if (guestDurationMs == null) {
+      return NextResponse.json(
+        { error: 'This booking has no usable duration and must be fixed in the back office.', code: 'corrupt_window' },
+        { status: 422 },
+      )
+    }
+
+    // The gap is whatever this specific booking already carries, not the current setting. Re-reading
+    // the setting would silently re-length bookings taken before it changed.
+    const assignmentRows = Array.isArray(assignments) ? assignments : []
+    const assignmentEnds = assignmentRows
+      .map((row) => new Date(row.end_datetime as string))
+      .filter((value) => Number.isFinite(value.getTime()))
+    const latestAssignmentEnd = assignmentEnds.length > 0
+      ? assignmentEnds.reduce((latest, current) => (current.getTime() > latest.getTime() ? current : latest))
+      : null
+    const bookingEndMs = bookingStart.getTime() + guestDurationMs
+    const turnaroundMs = latestAssignmentEnd
+      ? Math.max(0, latestAssignmentEnd.getTime() - bookingEndMs)
+      : 0
+
+    // Step 3: build the new windows. fromZonedTime is what keeps this correct through BST; using
+    // setUTCHours would land an hour out for seven months of the year.
+    const londonDateIso = getLondonDateIso(bookingStart)
+    const fromTime = londonClock(bookingStart)
+
+    if (fromTime === newTime) {
+      // Nothing to write, and nothing to tell the guest about.
+      return NextResponse.json({
+        success: true,
+        data: { state: 'unchanged', booking_time: fromTime },
+      })
+    }
+
     const newStart = fromZonedTime(`${londonDateIso}T${newTime}:00`, 'Europe/London')
-    const newEnd = new Date(newStart.getTime() + durationMs)
+    const newBookingEnd = new Date(newStart.getTime() + guestDurationMs)
+    const newAssignmentEnd = new Date(newBookingEnd.getTime() + turnaroundMs)
 
-    // Record original time for logging — derive from UTC using same getLondonDateIso approach
-    const origLondonParts = new Intl.DateTimeFormat('en-GB', {
-      timeZone: 'Europe/London',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).formatToParts(startDate)
-    const fromHour = origLondonParts.find(p => p.type === 'hour')?.value ?? '00'
-    const fromMinute = origLondonParts.find(p => p.type === 'minute')?.value ?? '00'
-    const fromTime = `${fromHour}:${fromMinute}`
-
-    // Step 4: Move the booking row and all table assignments atomically.
+    // Step 4: move the booking row and every assignment atomically.
     const { data: moveResultRaw, error: moveError } = await (auth.supabase as any).rpc(
-      'move_table_booking_time_v05',
+      'move_table_booking_time_v06',
       {
         p_table_booking_id: bookingId,
         p_booking_time: `${newTime}:00`,
         p_start_datetime: newStart.toISOString(),
-        p_end_datetime: newEnd.toISOString(),
+        p_booking_end_datetime: newBookingEnd.toISOString(),
+        p_assignment_end_datetime: newAssignmentEnd.toISOString(),
       },
     )
 
     if (moveError) {
       if (isAssignmentConflictError(moveError)) {
         return NextResponse.json(
-          { error: 'Selected time conflicts with another booking or private block.' },
+          { error: 'Selected time conflicts with another booking or private block.', code: 'conflict' },
           { status: 409 },
         )
       }
@@ -153,19 +249,74 @@ export async function PATCH(
       return NextResponse.json({ error: 'Failed to update booking time' }, { status: 500 })
     }
 
-    const moveResult = (moveResultRaw || {}) as { state?: string; reason?: string; assignment_count?: number }
+    const moveResult = (moveResultRaw || {}) as {
+      state?: string
+      reason?: string
+      assignment_count?: number
+      high_chairs_requested?: number
+      high_chairs_granted?: number
+    }
     if (moveResult.state === 'blocked' && moveResult.reason === 'booking_not_found') {
       return NextResponse.json({ error: 'Booking not found' }, { status: 404 })
     }
 
-    // Confirm the new time to the customer, but only when the time actually changed.
-    // Awaited (not fire-and-forget) so the send completes before this serverless
-    // function is frozen; the helper swallows its own errors and never fails the move.
-    if (fromTime !== newTime) {
-      await sendTableBookingRescheduledNotificationIfAllowed(auth.supabase, { tableBookingId: bookingId })
-    }
+    const highChairsRequested = Number(moveResult.high_chairs_requested ?? 0)
+    const highChairsGranted = Number(moveResult.high_chairs_granted ?? 0)
+    const highChairsLost = Math.max(0, highChairsRequested - highChairsGranted)
 
-    return NextResponse.json({ success: true, assignment_count: moveResult.assignment_count ?? assignmentRows.length })
+    // Audited before the notification, because the move has already committed and the notification
+    // can take seconds. An audit written only on the happy path is an audit you cannot trust.
+    await logAuditEvent({
+      user_id: auth.userId,
+      operation_type: 'change_time',
+      resource_type: 'table_booking',
+      resource_id: bookingId,
+      operation_status: 'success',
+      old_values: {
+        booking_time: fromTime,
+        start_datetime: bookingStart.toISOString(),
+        end_datetime: new Date(bookingEndMs).toISOString(),
+        high_chair_count: highChairsRequested,
+      },
+      new_values: {
+        booking_time: newTime,
+        start_datetime: newStart.toISOString(),
+        end_datetime: newBookingEnd.toISOString(),
+        assignment_end_datetime: newAssignmentEnd.toISOString(),
+        high_chair_count: highChairsGranted,
+      },
+      additional_info: {
+        surface: 'foh',
+        assignment_count: moveResult.assignment_count ?? assignmentRows.length,
+        turnaround_minutes: Math.round(turnaroundMs / 60000),
+        was_seated: Boolean(booking.seated_at),
+      },
+    })
+
+    // Every time change is confirmed to the guest. Awaited rather than fire-and-forget so the send
+    // completes before this serverless function is frozen; the helper swallows its own errors and
+    // never fails the move.
+    await sendTableBookingRescheduledNotificationIfAllowed(auth.supabase, { tableBookingId: bookingId })
+
+    return NextResponse.json({
+      success: true,
+      assignment_count: moveResult.assignment_count ?? assignmentRows.length,
+      data: {
+        state: 'updated',
+        booking_time: newTime,
+        start_datetime: newStart.toISOString(),
+        end_datetime: newBookingEnd.toISOString(),
+        high_chairs_granted: highChairsGranted,
+        high_chairs_lost: highChairsLost,
+      },
+      booking: {
+        id: bookingId,
+        booking_time: newTime,
+        start_datetime: newStart.toISOString(),
+        end_datetime: newBookingEnd.toISOString(),
+        high_chair_count: highChairsGranted,
+      },
+    })
   } catch (error) {
     logger.error('FOH time update: unexpected error', {
       error: error instanceof Error ? error : new Error(String(error)),

--- a/src/components/foh/DraggableBookingBlock.tsx
+++ b/src/components/foh/DraggableBookingBlock.tsx
@@ -99,6 +99,11 @@ export function DraggableBookingBlock({
         position: 'absolute',
         left: `${leftPct}%`,
         width: `${widthPct}%`,
+        // dnd-kit's PointerSensor needs this on touch devices. Without it the browser claims
+        // the gesture as a pan of the timeline's horizontal scroller and fires pointercancel,
+        // so a touch drag can never start. Only set when the block is actually draggable, so
+        // panning still works by starting the gesture on a locked or non-editable block.
+        ...(canDragThis ? { touchAction: 'none' as const } : null),
         ...style,
       }}
       title={title}

--- a/supabase/migrations/20260901120000_move_table_booking_time_v06.sql
+++ b/supabase/migrations/20260901120000_move_table_booking_time_v06.sql
@@ -1,0 +1,146 @@
+-- Moving a booking's time must not lengthen the guest's booking by the turnaround gap.
+--
+-- WHAT IS WRONG
+--
+-- Since turn times were switched on, a booking carries TWO windows on purpose:
+--
+--   table_bookings.start/end_datetime          the time quoted to the guest
+--   booking_table_assignments.start/end        the same window PLUS turnaround_gap_minutes,
+--                                              because the table is held longer than the guest sits
+--
+-- `create_table_booking_core_v06` writes them separately and correctly. `move_table_booking_time_v05`
+-- collapses them: it is handed ONE end time, and writes that same value to the assignment rows and
+-- to the booking row. The caller derives that end from the assignment window, so a 105 minute guest
+-- booking with a 15 minute gap comes back as a 120 minute booking row while duration_minutes still
+-- says 105.
+--
+-- The damage is not only cosmetic. `count_high_chairs_in_window` overlaps on the BOOKING window, so
+-- an inflated booking row makes a party contend for high chairs for 15 minutes it is not there, and
+-- availability, reporting and the guest's own manage page all read the same inflated end.
+--
+-- WHY NOTHING IS BROKEN YET
+--
+-- v05's only caller is the FOH drag-to-move path, which is disabled on the kiosk account the floor
+-- actually uses and needs a touch-action fix to work on any tablet. Checked on production: no live
+-- booking carries the +15 signature. The defect is dormant, and this migration lands before the tap
+-- UI that would make it fire on every use.
+--
+-- THE FIX
+--
+-- v06 takes the two end times as separate arguments and writes each to its own place. High chairs
+-- are re-granted over the GUEST window, matching count_high_chairs_in_window, rather than the
+-- occupancy window v05 used (which over-counted by the gap). The granted count comes back in the
+-- result so the caller can tell staff when a chair was lost to the move.
+--
+-- Outside reservations need no work here: table_bookings_sync_outside_reservation already fires on
+-- AFTER UPDATE OF start_datetime, end_datetime, so re-windowing the booking row reconciles the
+-- garden hold on its own.
+--
+-- Additive. v05 is left in place and untouched so this migration can be applied before the code
+-- that calls v06 is deployed. It has no caller once that deploy lands and can be dropped later.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.move_table_booking_time_v06(
+  p_table_booking_id uuid,
+  p_booking_time time,
+  p_start_datetime timestamptz,
+  p_booking_end_datetime timestamptz,
+  p_assignment_end_datetime timestamptz
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated_booking uuid;
+  v_assignment_count integer := 0;
+  v_high_chairs_requested integer;
+  v_high_chairs_granted integer;
+  v_old_booking_time time;
+  v_old_start timestamptz;
+  v_old_booking_end timestamptz;
+BEGIN
+  IF p_booking_end_datetime <= p_start_datetime THEN
+    RAISE EXCEPTION 'invalid_booking_window'
+      USING ERRCODE = '22023',
+            DETAIL = 'booking end must be after start';
+  END IF;
+
+  -- The table is held for at least as long as the guest has it. A shorter occupancy window would
+  -- release the table while the party is still sitting at it.
+  IF p_assignment_end_datetime < p_booking_end_datetime THEN
+    RAISE EXCEPTION 'invalid_occupancy_window'
+      USING ERRCODE = '22023',
+            DETAIL = 'assignment end must not be before booking end';
+  END IF;
+
+  -- Read the pre-move state under the same transaction so the caller can audit true old values
+  -- without a second round trip that a concurrent write could invalidate.
+  SELECT booking_time, start_datetime, end_datetime, COALESCE(high_chair_count, 0)
+    INTO v_old_booking_time, v_old_start, v_old_booking_end, v_high_chairs_requested
+  FROM public.table_bookings
+  WHERE id = p_table_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_not_found');
+  END IF;
+
+  SELECT COUNT(*)
+    INTO v_assignment_count
+  FROM public.booking_table_assignments
+  WHERE table_booking_id = p_table_booking_id;
+
+  -- The occupancy window, gap included, goes to the assignments. The overlap trigger on this
+  -- table is what rejects a clash, so this statement is the one that can raise 23P01.
+  IF v_assignment_count > 0 THEN
+    UPDATE public.booking_table_assignments
+       SET start_datetime = p_start_datetime,
+           end_datetime   = p_assignment_end_datetime
+     WHERE table_booking_id = p_table_booking_id;
+
+    GET DIAGNOSTICS v_assignment_count = ROW_COUNT;
+  END IF;
+
+  -- The guest window, gap excluded, goes to the booking.
+  UPDATE public.table_bookings
+     SET booking_time   = p_booking_time,
+         start_datetime = p_start_datetime,
+         end_datetime   = p_booking_end_datetime,
+         updated_at     = now()
+   WHERE id = p_table_booking_id
+   RETURNING id INTO v_updated_booking;
+
+  IF v_updated_booking IS NULL THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_not_found');
+  END IF;
+
+  -- Re-grant over the guest window, because that is the window high chair contention is measured
+  -- on. Never blocks the move; a reduction is reported instead.
+  v_high_chairs_granted := public.reserve_high_chairs(
+    p_table_booking_id, v_high_chairs_requested, p_start_datetime, p_booking_end_datetime
+  );
+
+  RETURN jsonb_build_object(
+    'state', 'updated',
+    'assignment_count', v_assignment_count,
+    'old_booking_time', v_old_booking_time,
+    'old_start_datetime', v_old_start,
+    'old_end_datetime', v_old_booking_end,
+    'high_chairs_requested', v_high_chairs_requested,
+    'high_chairs_granted', v_high_chairs_granted
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.move_table_booking_time_v06 IS
+  'Re-times a table booking, keeping the guest window and the table occupancy window distinct. Supersedes move_table_booking_time_v05, which wrote one end time to both and so absorbed turnaround_gap_minutes into the guest booking.';
+
+-- Same lockdown as every other SECURITY DEFINER routine here: service_role only, never anon or
+-- authenticated. The FOH route reaches it through the admin client after its own permission check.
+REVOKE ALL ON FUNCTION public.move_table_booking_time_v06(uuid, time, timestamptz, timestamptz, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.move_table_booking_time_v06(uuid, time, timestamptz, timestamptz, timestamptz) TO service_role;
+
+COMMIT;

--- a/tasks/foh-change-booking-time-spec-2026-09-01.md
+++ b/tasks/foh-change-booking-time-spec-2026-09-01.md
@@ -1,0 +1,352 @@
+# FOH: change a booking's time on the iPad
+
+Spec, 2026-09-01. **Superseded in part: built, see section 8 for what changed after developer review.**
+
+
+---
+
+## 1. The problem, and why it happens
+
+The floor team cannot change a booking's time on `/table-bookings/foh`. There is
+no bug to fix in the sense of something that broke: **the screen has never had a
+non-drag route to a time change, and drag is switched off for the account the
+iPad uses.**
+
+Three findings, each independently sufficient to block them.
+
+### 1.1 Drag is disabled outright in kiosk mode
+
+`src/components/foh/DraggableBookingBlock.tsx:60`
+
+```ts
+const canDragThis =
+  styleVariant !== 'manager_kiosk' &&
+  canEdit && ...
+```
+
+`page.tsx:64` sets `styleVariant = 'manager_kiosk'` when the signed-in email is
+`manager@the-anchor.pub`. Verified against the live database: that account exists,
+holds the `foh_staff` role, and last signed in 2026-08-21. `foh_staff` grants
+`table_bookings: view, create, edit`, so `canEdit` is true and every other action
+works. Drag alone is off.
+
+This was deliberate from the first commit (`bdb7807c`), not a regression. The
+component comment records it as spec'd: "kiosk mode, canEdit, terminal statuses,
+private blocks, multi-table bookings".
+
+### 1.2 There is no other entry point
+
+`FohBookingDetailModal` offers six actions: Mark seated, Mark left, Mark no-show,
+Edit party size, Cancel booking, Flag walkout, plus Move to another table. No time
+action anywhere on the screen.
+
+The only caller of the working `PATCH /api/foh/bookings/[id]/time` endpoint is
+`useFohDrag.ts:240`. Kill drag and the endpoint is unreachable from the UI.
+
+### 1.3 Even outside kiosk mode, drag would not work reliably on a touchscreen
+
+`useFohDrag` uses dnd-kit's `PointerSensor`. dnd-kit requires draggable elements
+to set `touch-action: none`, otherwise the browser claims the gesture as a pan
+and fires `pointercancel`, aborting the drag. A repo-wide grep finds no
+`touch-action` on any FOH component, and the timeline sits inside
+`overflow-x-auto` with `min-w-[980px]`, so panning is always available to steal
+the gesture.
+
+So a manager signing in with their own (non-kiosk) account on the same iPad would
+also struggle. The fix must not assume kiosk mode is the only broken case.
+
+### 1.4 What they can reach today, and why it does not help
+
+`/table-bookings/[id]` has a full edit modal with date, time and duration. It is
+unreachable for this team: `requireBohTableBookingPermission` returns 403 for
+FOH-only users, and the chromeless kiosk layout has no navigation to it.
+
+---
+
+## 2. What already works, and should be reused unchanged
+
+- **`PATCH /api/foh/bookings/[id]/time`** is conflict-safe, but its duration handling
+  was wrong and had to be corrected first (finding F01, section 8). It read the
+  window from `booking_table_assignments`, which includes the turnaround gap, converts London
+  local time correctly through `fromZonedTime` (BST-safe), moves the booking row
+  and every assignment atomically via `move_table_booking_time_v05`, maps a
+  DB-trigger clash to a 409 with a readable message, and notifies the guest.
+- **Conflict enforcement is in the database**, in trigger
+  `enforce_booking_table_assignment_integrity_v05`. It rejects overlaps with live
+  bookings, private-booking blocks and communal event seating. A stale client
+  cannot double-book: the worst outcome is a 409.
+- **The tap-tile pattern is proven on the floor.** `move_table` shows 73 audited
+  uses in the last 60 days, most recent today at 12:17. Staff use big tap targets
+  happily. The time picker should look and behave like Move table.
+
+---
+
+## 3. Recommended change
+
+### 3.1 Entry point: a "Change time" action in the booking detail modal
+
+Add a seventh button to the action grid in `FohBookingDetailModal`, opening a
+dedicated modal. Same shape as Edit party size and Flag walkout, which are
+already sibling modals rendered from `FohScheduleClient`.
+
+Shown when `canEdit && !is_private_block && !isEventOnly` (the condition already
+wrapping `BookingActions`).
+
+Disabled, with a short reason line, when the booking is `cancelled`, `no_show` or
+`completed`, mirroring the existing `canDragThis` rule. Moving a departed or
+cancelled booking is never wanted and the guest notification would be wrong.
+
+### 3.2 The Change time modal
+
+Two ways to pick, in one modal, because the floor has two different needs.
+
+**Quick nudge row, at the top.** Four large buttons: `-30`, `-15`, `+15`, `+30`
+minutes, relative to the booking's current time. This covers the common case
+("they rang, running twenty minutes late") in one tap. Each button shows the
+resulting time underneath, for example `+15` over `19:45`. A nudge that lands on
+an unavailable or out-of-window time is disabled, not hidden, so the row does not
+reflow under the thumb.
+
+**Full grid, below.** All 15-minute slots across the service window, four
+columns, scrollable, auto-scrolled so the current time is visible on open.
+
+Per tile:
+- Current time: outlined and labelled `Now`, not tappable.
+- Free: tappable, table name shown is not needed (the booking keeps its table).
+- Taken: disabled and dimmed, with a one-word reason (`Taken`, `Private`,
+  `Event`).
+- Past the end of the timeline for this booking's duration: not rendered.
+
+Tapping a time applies it immediately. **No confirmation step**, matching Move
+table, and for the same reasons recorded in that component's comment: it is not
+destructive, it shows on the timeline at once, and it is undone by tapping the
+original time. The one exception is 3.4 below.
+
+**Off-grid current times exist.** Live data contains bookings at 20:19, 20:55,
+20:05. The modal must show such a time as the current value even though it is not
+on the 15-minute grid, and must not silently normalise it.
+
+### 3.3 Availability: compute it client-side, no new endpoint
+
+The FOH schedule payload already carries everything needed. `schedule.lanes[]`
+contains, per table, every occupied window on that table: real bookings, private
+blocks (`is_private_block`) and communal event blocks
+(`is_communal_event_block`), each with `start_datetime` and `end_datetime`. The
+booking's own tables come from `assigned_table_ids`.
+
+So: union the busy intervals across the booking's assigned tables, exclude the
+booking itself, and mark each candidate slot free or taken. Zero extra network
+calls, instant feedback on a busy iPad, no new API surface to secure.
+
+**The liveness filter must mirror the database exactly.** Verified live
+definition of `is_booking_live`:
+
+```
+status NOT IN ('cancelled','no_show')
+AND left_at IS NULL
+AND NOT (status IN ('pending_payment','pending_card_capture')
+         AND hold_expires_at IS NOT NULL
+         AND hold_expires_at <= now()
+         AND payment_status IS DISTINCT FROM 'completed')
+```
+
+All four fields (`status`, `left_at`, `hold_expires_at`, `payment_status`) are
+already on `FohBooking`. Put this in one exported helper, `isFohBookingLive`, in
+`foh/utils.ts`, unit-tested against each branch, and add a comment pointing at
+the SQL function so the two stay in step.
+
+Departed bookings are rendered on the timeline but do **not** block, per the
+trigger. Getting this wrong in either direction is the main correctness risk in
+this change.
+
+**Staleness is handled, not ignored.** Realtime already refreshes the schedule,
+`reloadSchedule` runs after every action, and the 409 from the endpoint is the
+backstop. On a 409, keep the modal open, show the endpoint's message, and refresh
+the schedule so the grid re-marks itself. This is exactly how drag already treats
+a 409 on move-table.
+
+**Bookings with no table** (unassigned, or outside seating) have no lane and
+therefore no conflicts. Show every in-window slot as free. The endpoint will not
+conflict either, because the RPC skips the assignment update when there are none.
+
+### 3.4 The guest notification is the one thing that needs a decision
+
+Every successful time change calls
+`sendTableBookingRescheduledNotificationIfAllowed`, which emails the guest first
+and falls back to SMS: *"your table booking has been updated to ... It's still
+confirmed"*, with a manage link.
+
+That is right for "the guest rang to move to 8pm". It is wrong, and slightly
+alarming, for "we nudged them fifteen minutes because the table is running late"
+while the guest is standing at the bar.
+
+Recommended: **suppress the notification when the booking is already seated**
+(`seated_at` is set), and otherwise show a checkbox in the modal, "Let the guest
+know", ticked by default. Staff keep control, the default stays safe, and nobody
+gets texted about a table they are already sitting at.
+
+This needs your call, see question 1.
+
+### 3.5 Touch targets
+
+The existing action buttons in the detail modal are `px-2 py-2.5 text-xs`, about
+38px tall. The FOH iPad standard already recorded on this project is a 44px
+minimum, and Move table's tiles correctly use `min-h-[3.5rem]` (56px).
+
+Bring the whole action grid up to `min-h-[44px]`, and use `min-h-[3.5rem]` for
+the new time tiles so they match Move table. This is a small change to existing
+buttons, in the same file, in the same change set as the new button that sits
+among them. Leaving a new 56px button in a row of 38px ones would look broken.
+
+### 3.6 Audit logging
+
+`PATCH /api/foh/bookings/[id]/time` writes no audit entry. `move-table` does,
+which is why the 73-use figure above exists at all. Add a `logAuditEvent` call
+with `operation_type: 'change_time'`, old and new `booking_time` /
+`start_datetime` / `end_datetime`, and `additional_info: { surface: 'foh' }`.
+
+Two reasons this belongs here and not in a follow-up: the workspace rule requires
+mutations to audit-log, and without it there is no way to answer "who moved this
+booking?" the first time the floor and a guest disagree.
+
+### 3.7 Fix the touch-drag path as well
+
+Drag stays as it is for desktop, but two small fixes make it work on touch for
+non-kiosk accounts, at near-zero risk:
+
+1. Add `touchAction: 'none'` to the draggable block's style when
+   `canDragThis`. Without it, touch drag cannot work at all.
+2. `timelineRef` is attached to the **header** track, which carries `px-1.5`/
+   `px-2` padding that the lane tracks do not. `snapToInterval` therefore
+   measures against a box up to 8px wider on each side than the lane the booking
+   actually sits in, skewing the snapped time. Attach the ref to a lane track, or
+   remove the padding difference.
+
+Kiosk mode stays drag-free. The tap path is the supported one there, and enabling
+drag on a kiosk the staff carry around invites accidental moves.
+
+---
+
+## 4. Explicitly out of scope
+
+- **Changing the date.** The endpoint pins the new time to the booking's existing
+  London date. FOH is a single-day screen; date changes stay a back-office job.
+- **Changing the duration.** The endpoint preserves it. "Extend this table by
+  half an hour" is a real floor need but a separate change, with its own
+  conflict rules.
+- **Enabling drag in kiosk mode.**
+- **Kitchen pacing / cut-off re-validation on a move.** The create flow checks
+  these; a staff-initiated move on the floor deliberately does not, the same way
+  move-table does not.
+
+---
+
+## 5. Files
+
+| File | Change |
+|---|---|
+| `foh/components/FohMiniModals.tsx` | New `FohChangeTimeModal`, alongside the party-size and walkout modals |
+| `foh/components/FohBookingDetailModal.tsx` | "Change time" button; `min-h-[44px]` on the action grid |
+| `foh/FohScheduleClient.tsx` | Modal state, availability memo, submit through the existing `runAction` |
+| `foh/utils.ts` | `isFohBookingLive`, `buildTimeChangeOptions` |
+| `foh/components/__tests__/` | Modal tests: availability marking, off-grid current time, disabled states |
+| `foh/utils.test.ts` | `isFohBookingLive` branches, slot generation and clamping |
+| `api/foh/bookings/[id]/time/route.ts` | Audit log; optional `notify` flag (question 1) |
+| `api/foh/bookings/[id]/time/route.test.ts` | Cover the above |
+| `components/foh/DraggableBookingBlock.tsx` | `touchAction: 'none'` |
+| `foh/components/FohTimeline.tsx` | `timelineRef` onto a lane track |
+
+No migration. No schema change. No new API route.
+
+**Complexity: 3 (M).** Roughly 6 files of real change plus tests, no schema, one
+existing integration.
+
+---
+
+## 6. Verification
+
+- `npx vitest run src/app/\(authenticated\)/table-bookings/foh src/app/api/foh/bookings`
+  (baseline today: 8 files, 55 tests, all passing)
+- `npm run lint`, `npx tsc --noEmit`, `npm run build`
+- Manual on an iPad against a preview deployment, signed in as
+  `manager@the-anchor.pub`: nudge a booking, hit a deliberate clash and confirm
+  the 409 message, confirm a seated booking is not notified, confirm the grid
+  re-marks after a refresh.
+
+---
+
+## 7. Low-priority hardening, noted not scheduled
+
+The time endpoint derives the target date via `getLondonDateIso(startDate)` from
+the booking's existing UTC start. If the service window ever crossed midnight, a
+booking at 00:30 would take the next calendar day as its base, so setting 23:45
+would land a day late. Confirmed dormant: `business_hours` closes at 22:00 every
+day of the week and the latest live booking in 90 days is 21:30. Worth a guard if
+late licences are ever introduced.
+
+---
+
+## 8. Amendment after developer review, 2026-09-01
+
+An independent developer review of this spec raised 30 findings. Each blocking one was
+checked against the production database rather than taken at face value. The outcome:
+
+### Upheld, and it changed the plan
+
+**The endpoint did not preserve the guest's booking duration.** This spec claimed it did.
+That was wrong. Since turn times were switched on, a booking carries two windows on purpose:
+`table_bookings` holds the guest's window, and `booking_table_assignments` holds the same
+window plus `turnaround_gap_minutes`. Production has `turn_times_enabled = true` and a
+15-minute gap, and 34 live bookings carry it. The route read the assignment window and
+`move_table_booking_time_v05` wrote that single end time back to both records, so a
+105-minute booking became a 120-minute booking row while `duration_minutes` still said 105.
+It also stretched the window `count_high_chairs_in_window` measures contention on.
+
+One correction to the review: it implied existing records are already damaged. They are not.
+No live booking carries the +15 signature, because v05's only caller was the drag path, which
+is off on the kiosk and needs a touch-action fix to work on any tablet. The defect was
+dormant. That does not make it less blocking: a working tap picker would have fired it on
+every use. No data repair is needed.
+
+Fixed by `supabase/migrations/20260901120000_move_table_booking_time_v06.sql`, which takes the
+two end times as separate arguments. So **"no migration" in section 5 was wrong**, and the
+backend must deploy before the UI.
+
+**Eligibility was client-only.** The route validated no state at all. Now enforced server-side
+as an allowlist (`confirmed`, `pending_payment`, `pending_card_capture`,
+`visited_waiting_for_review`, `review_clicked`), plus explicit refusals for a departed party
+and an event-linked booking.
+
+**Event-linked bookings.** 76 exist, none upcoming, so no live exposure, but the guard is
+cheap: an event diner's table is tied to their ticket and nothing here updates the event side.
+
+**One tap was not safe enough.** The owner's answer to the notification question was that every
+change must be communicated to the guest. That makes a mistap send a message, which the Move
+table precedent does not. Slot selection and applying are now two steps.
+
+**High chairs.** The move re-grants them and can silently reduce the count. The RPC now returns
+what was granted and the UI says so.
+
+**409 could not go through `runAction`.** Correct: that helper writes a page-level error the
+open modal hides. The time change uses its own submit path with modal-local error state.
+
+### Noted, not acted on
+
+- **Shared-account audit.** True: the kiosk is one shared login, so the audit identifies the
+  device, not the person. The stated goal is corrected to that rather than solved.
+- **Hidden-table assignments.** Zero exist in the last 30 days. Not built for.
+- **Server-produced availability.** Kept client-side: the data is already loaded and realtime
+  refreshed, the mirrored predicate is four lines with its own tests and a pointer to the SQL,
+  and the trigger stays the authority. Revisit if the two ever drift.
+
+### Owner decisions taken
+
+1. Every time change tells the guest. No opt-out, no seated suppression.
+2. Cancelled, no-show and completed bookings cannot be re-timed.
+3. Seated bookings **can** be re-timed, with a specific warning that it will free their table
+   for the old time. Flagged for confirmation.
+
+### Built
+
+12 files. 122 tests across the FOH surface, up from 55. Lint, types and production build clean.
+Migration is written and dry-run clean but **not applied**.

--- a/tasks/foh-change-booking-time-spec-developer-review-2026-09-01.md
+++ b/tasks/foh-change-booking-time-spec-developer-review-2026-09-01.md
@@ -1,0 +1,520 @@
+# Developer review: FOH change booking time specification
+
+Review date: 2026-09-01  
+Reviewed document: `tasks/foh-change-booking-time-spec-2026-09-01.md`  
+Audience: developer, product owner, and release owner  
+Original specification changed: no
+
+## 1. Overall assessment
+
+**Readiness: Not ready for implementation.**
+
+The discovery work is useful and the large-tile picker is a good direction, but the
+specification has material product and data-integrity gaps. The most serious issue
+is that the existing time endpoint does not preserve the guest booking duration
+when table turnaround time is enabled. It derives duration from the table assignment,
+which includes the turnaround hold, and then writes that longer end time back to the
+booking row. Reusing the endpoint more widely would increase the effect of that defect.
+
+The specification also combines two different jobs:
+
+1. A guest-requested reschedule, which should usually notify the guest and move the
+   booking and its resources.
+2. An internal floor delay, which should not rewrite the guest's agreed booking time
+   or move an already seated party's resource window.
+
+Those jobs need to be separated or the first release needs to support only the first.
+The release is also blocked by unresolved notification behaviour, missing server-side
+state guards, event-linked booking handling, and an availability/error contract that
+cannot be delivered through the proposed shared action helper as written.
+
+### Readiness score
+
+| Area | Rating | Summary |
+|---|---:|---|
+| Product behaviour | 2/5 | Main use cases are mixed together; notification and seated behaviour are unresolved. |
+| Functional detail | 2/5 | Important state, time-boundary, stale-data, and error journeys are missing. |
+| Data correctness | 1/5 | Existing endpoint confuses guest duration and table occupancy duration. |
+| Security and permissions | 3/5 | Authentication and edit permission exist, but business-state enforcement is client-only. |
+| Accessibility | 2/5 | Touch size is considered, but keyboard, screen-reader, focus, and error requirements are not. |
+| Delivery and operations | 2/5 | Test commands exist, but migration, rollout, monitoring, and realistic effort are incomplete. |
+
+### Review evidence
+
+The review checked the current specification against the FOH schedule UI, schedule
+API, time and move-table routes, booking/assignment database functions, notification
+helper, audit service, modal primitive, realtime reload path, and current tests.
+
+The stated test baseline was reproduced:
+
+```text
+8 test files passed
+55 tests passed
+```
+
+That baseline proves the current tests pass. It does not cover most of the behaviour
+proposed in this specification.
+
+## 2. Priority and status meanings
+
+- **P0:** Must be resolved before implementation starts or before the endpoint is reused.
+- **P1:** Must be resolved before release.
+- **P2:** Should be resolved for a reliable release; may be a closely tracked follow-up only with explicit acceptance.
+- **P3:** Low-risk future hardening.
+- **Confirmed issue:** A gap, contradiction, or risk confirmed in the specification or current code.
+- **Optional improvement:** A non-blocking way to simplify, improve, or future-proof the change.
+
+## 3. Finding summary
+
+| ID | Status | Priority | Type | Finding |
+|---|---|---:|---|---|
+| F01 | Confirmed issue | P0 | Data correctness | The endpoint does not preserve guest duration when turnaround time is enabled |
+| F02 | Confirmed issue | P0 | Product / data model | Guest rescheduling and internal floor delay are mixed together |
+| F03 | Confirmed issue | P0 | Integration | Event-linked table bookings are not safely excluded |
+| F04 | Confirmed issue | P0 | API / business rules | Eligible booking states are not defined or enforced by the server |
+| F05 | Confirmed issue | P0 | Notification | Notification policy is unresolved and can send inaccurate copy |
+| F06 | Confirmed issue | P1 | UX / safety | Immediate apply conflicts with notification and undo claims |
+| F07 | Confirmed issue | P1 | Error handling | The proposed 409 journey cannot use `runAction` unchanged |
+| F08 | Confirmed issue | P1 | Data / availability | The schedule payload is not always a complete view of database conflicts |
+| F09 | Confirmed issue | P1 | Data / multi-table | Client and server do not share one authoritative multi-table window |
+| F10 | Confirmed issue | P1 | API / validation | Service-window restrictions are client-only |
+| F11 | Confirmed issue | P1 | Functional requirement | The last valid arrival time is ambiguous |
+| F12 | Confirmed issue | P1 | Functional requirement | Past and historical time changes are undefined |
+| F13 | Confirmed issue | P1 | Functional detail | Slot and conflict calculation rules are incomplete |
+| F14 | Confirmed issue | P1 | Concurrency | Same-booking races and realtime changes can overwrite newer work |
+| F15 | Confirmed issue | P1 | Resource side effects | High-chair and outside-capacity effects are missing from the UX and contract |
+| F16 | Confirmed issue | P1 | Audit / security | A shared kiosk audit cannot identify the staff member |
+| F17 | Confirmed issue | P1 | Reliability / performance | Synchronous notification creates slow and uncertain outcomes |
+| F18 | Confirmed issue | P1 | API contract | Validation and response behaviour are incomplete |
+| F19 | Confirmed issue | P1 | Testing | The test plan does not cover the main risks |
+| F20 | Confirmed issue | P0 | Delivery / migration | “No migration” and the effort estimate are not credible after the duration finding |
+| F21 | Confirmed issue | P2 | Scope / regression | Touch-drag changes are separate scope and not near-zero risk |
+| F22 | Confirmed issue | P2 | Accessibility | Accessibility requirements stop at touch-target size |
+| F23 | Confirmed issue | P1 | Error handling | Offline, session expiry, refresh failure, and uncertain success are unspecified |
+| F24 | Confirmed issue | P2 | Monitoring | Release monitoring and operational measures are missing |
+| F25 | Confirmed issue | P1 | Delivery | There are no complete, testable acceptance criteria |
+| F26 | Optional improvement | P2 | Wording / usability | Use “Current booking time” instead of “Now” |
+| F27 | Optional improvement | P2 | Scope simplification | Keep the first release to guest-requested rescheduling |
+| F28 | Optional improvement | P3 | Time handling | Replace the cross-midnight guard with an explicit timestamp contract when needed |
+| F29 | Optional improvement | P2 | Architecture | Consider server-produced availability instead of duplicating database rules in the browser |
+| F30 | Optional improvement | P2 | Rollout | Use a short kiosk canary before general release |
+
+## 4. Detailed findings
+
+### F01. The endpoint does not preserve guest duration when turnaround time is enabled
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** Data correctness / database integration
+- **Relevant section:** 2, “What already works”; 3.2, “The Change time modal”; 5, “Files”
+- **Description:** The claim that `PATCH /api/foh/bookings/[id]/time` preserves duration is not correct for indoor bookings when turnaround time is enabled. Creation deliberately stores two different end times: `table_bookings.end_datetime` is the guest booking end, while `booking_table_assignments.end_datetime` includes the extra turnaround hold. The time route reads the assignment window, calculates one duration from it, and passes one new end time to `move_table_booking_time_v05`. That function writes the same end time to both the assignment rows and the booking row.
+- **Rationale:** `create_table_booking_v06` calculates `v_booking_end` and a later `v_occupancy_end`; it writes the first to `table_bookings` and the second to assignments. The current time route takes the assignment's later end and the RPC writes it back to both records. A 105-minute guest booking with a 15-minute turnaround therefore becomes a 120-minute booking row after a move, while `duration_minutes` remains 105. This also changes resource and reporting semantics.
+- **Impact:** Guest and assignment data become inconsistent. Reporting, later edits, notifications, high-chair windows, and future availability can use the wrong end time. Wider FOH use would increase the number of affected records.
+- **Recommended action:** Fix the backend before building the new UI. Introduce an atomic RPC that accepts distinct `p_booking_end_datetime` and `p_assignment_end_datetime`, or another transaction-safe design that preserves both windows. Load and validate `duration_minutes` from the booking row, derive the assignment hold separately, and return both final windows. Add a migration and database integration tests. Suggested replacement for section 2: “The endpoint is conflict-safe, but its duration handling must be corrected before reuse because assignment windows may include turnaround time.”
+- **Open questions:** Is turnaround time enabled in production now? Are any existing bookings already inconsistent after drag moves? Should a repair query be prepared for affected rows?
+
+### F02. Guest rescheduling and internal floor delay are mixed together
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** Product behaviour / data model
+- **Relevant section:** 3.2, “Quick nudge row”; 3.4, “The guest notification”
+- **Description:** The specification uses one mutation for a guest-requested reschedule and for an internal delay while a guest waits at the bar. These actions have different meanings. A reschedule changes the guest's agreed time and resource window. An internal delay records an operational problem and should not silently rewrite the original promise.
+- **Rationale:** Allowing a seated booking to move to a later start can produce a start time after `seated_at`, move its table hold away from a table it is already using, change punctuality/reporting data, and make the current table appear free. Suppressing a message does not fix those data problems.
+- **Impact:** The timeline can become operationally unsafe, reporting can be misleading, and staff may double-book a table occupied by an already seated party.
+- **Recommended action:** Decide which job this release solves. The safest first release is “guest requested a new arrival time” for unseated, active table bookings only. If internal delay tracking is required, specify a separate field/action such as expected seating time or delay status that does not rewrite the confirmed booking window.
+- **Open questions:** Is “running late” the guest running late, or the venue running late? Should already seated bookings ever be rescheduled? What report should retain the original promised time?
+
+### F03. Event-linked table bookings are not safely excluded
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** Integration / data integrity
+- **Relevant section:** 3.1, “Entry point”; 5, “Files”
+- **Description:** The stated `!isEventOnly` condition only clearly excludes synthetic communal and standing blocks in the current UI. A real `table_bookings` row linked to an event has a normal UUID and is rendered with derived event labels, but the schedule response does not expose `event_id` and the time route does not guard it.
+- **Rationale:** Event table reservations are linked to a separate event booking and event start. Moving only the table booking time can separate the table reservation from the ticketed event and leave the linked event booking unchanged.
+- **Impact:** Event capacity, guest communication, table allocation, and attendee data can disagree.
+- **Recommended action:** Explicitly define event-linked bookings as eligible or ineligible. The recommended safe rule is to exclude every booking with `event_id` or `event_booking_id` until an event-aware reschedule flow exists. Return a clear eligibility field in the schedule payload and enforce the same rule in the server transaction.
+- **Open questions:** Are staff expected to move the arrival time for event diners independently of the event? If yes, which event records and notifications must also change?
+
+### F04. Eligible booking states are not defined or enforced by the server
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** API / business rules / security defence-in-depth
+- **Relevant section:** 3.1; 3.3, “Liveness filter”; 3.4
+- **Description:** The UI rule mentions `cancelled`, `no_show`, and `completed`, but the current endpoint does not load or validate status at all. The rule also omits `left_at`, expired unpaid holds, and review-related statuses that can still appear on the schedule. `left_at` can be set without changing the raw status, so checking only `status` is insufficient.
+- **Rationale:** Client-side disabled buttons are not a business-rule boundary. An authenticated editor, stale client, or direct request can still mutate an ineligible booking. The liveness predicate says whether a booking holds resources; it is not automatically the same as whether staff may edit it.
+- **Impact:** Departed, expired, cancelled, event-linked, or otherwise closed bookings can be rewritten. The notification helper may also message some of them because it checks only a limited status list.
+- **Recommended action:** Define a server-side eligibility whitelist, not only a blacklist. Load `status`, `seated_at`, `left_at`, `hold_expires_at`, `payment_status`, and event linkage and enforce the decision atomically with the move. Return 409 with a stable error code and current booking snapshot when state changed.
+- **Open questions:** Are `pending_payment` bookings eligible? What about an expired unpaid hold, a seated booking, or `visited_waiting_for_review`? Should managers have an override distinct from normal FOH edit permission?
+
+### F05. Notification policy is unresolved and can send inaccurate copy
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** Notification / product decision
+- **Relevant section:** 3.4; 5, time route changes
+- **Description:** The specification explicitly leaves notification behaviour undecided. The current helper returns no delivery result and sends copy saying the booking is “still confirmed” for any non-terminal status, including `pending_payment`. It does not check `seated_at` or `left_at` itself.
+- **Rationale:** A checkbox cannot be implemented safely until the server contract defines who may suppress a transactional message, what the default is, how seated state is evaluated, and what the UI says when there is no deliverable channel. Client state can be stale and must not be the authority for seated suppression.
+- **Impact:** Guests may receive alarming or false messages, staff may assume a notification was sent when it was not, and direct API calls may bypass intended suppression rules.
+- **Recommended action:** Resolve this before coding. Add a strict boolean such as `notify_guest`, with a documented backwards-compatible default for the existing drag caller. Enforce forced suppression or rejection server-side based on the final eligibility rule. Change notification copy for non-confirmed states or exclude those states. Return `notification: requested | suppressed | sent | no_channel | failed` if the helper can support it, and audit the request and result separately.
+- **Open questions:** Is the default checked? Can staff untick it for any unseated booking? Is it always off for seated bookings? Should pending-payment bookings be moved or notified? Does “email first and SMS fallback” meet the business expectation?
+
+### F06. Immediate apply conflicts with notification and undo claims
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** UX / safety
+- **Relevant section:** 3.2, “Tapping a time applies it immediately”
+- **Description:** The no-confirmation rationale is borrowed from Move table, but the operations are not equivalent. Move table notifies nobody. A time change can message a guest, change resource windows, clamp high chairs, and affect reporting. The existing drag-time path also uses a confirmation modal, contrary to the stated consistency claim.
+- **Rationale:** A notification cannot be undone by tapping the original time. The original slot may also become unavailable before the attempted undo.
+- **Impact:** A single accidental tap can cause an external message and a hard-to-reverse operational change.
+- **Recommended action:** Use an explicit “Change time” action after slot selection, with the notification choice visible beside it. If one-tap apply is retained, notification should not be sent in the same unconfirmed tap and the accepted risk must be stated. Suggested wording: “Selecting a slot shows the proposed new time. Tap Change time to apply it.”
+- **Open questions:** Is the speed benefit of one tap worth the external-message risk? Should only quick nudges be one tap, or should all choices behave the same?
+
+### F07. The proposed 409 journey cannot use `runAction` unchanged
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Error handling / UI architecture
+- **Relevant section:** 3.3, “Staleness is handled”; 5, `FohScheduleClient.tsx`
+- **Description:** The specification requires a 409 to keep the time modal open, show the endpoint message inside the flow, refresh the schedule, and re-mark the grid. The existing `runAction` catches the error, writes a page-level error, does not reload after failure, and only returns `false`. A modal can remain open, but it has no error result to render. The page header error may be hidden behind the modal.
+- **Rationale:** The proposed behaviour needs the status code and payload, plus a refresh after conflict. `runAction` currently hides those details. It also treats a schedule reload failure after a successful mutation as an overall action failure.
+- **Impact:** Staff may see no useful conflict message, the grid stays stale, and retries can repeat a move that already succeeded.
+- **Recommended action:** Define a dedicated submit result or extend the helper to return typed mutation and refresh outcomes. The time modal needs local error/loading state, 409-specific reload, and a separate message for “time changed, but the refreshed schedule could not load.” Do not claim the existing helper can be reused unchanged.
+- **Open questions:** Should `runAction` be generalised for all FOH actions, or should this flow use a focused hook? Where should errors be announced to screen readers?
+
+### F08. The schedule payload is not always a complete view of database conflicts
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Data / availability / resilience
+- **Relevant section:** 3.3, “Availability: compute it client-side”
+- **Description:** The assertion that the schedule carries everything needed is too strong. The schedule exposes only assignments to currently visible, bookable tables. A booking assigned only to a hidden or now-unbookable table is presented as unassigned and does not include its real assignment IDs, while the endpoint still updates those assignment rows. Communal query failures are converted to an empty set, private mapping failures can silently omit blocks, and service-hours failures or closed days can fall back to 09:00–23:00.
+- **Rationale:** The database trigger remains a safe backstop, but the browser grid can knowingly present blocked times as free or use invented fallback hours. “No table” is not equivalent to “no visible lane.”
+- **Impact:** More failed taps, misleading availability, possible moves outside real hours, and poor recovery when schedule data is incomplete.
+- **Recommended action:** Either use server-produced availability or strengthen the schedule contract. Include all real assigned table IDs, an explicit `has_hidden_assignments`, service-window validity/closed state, and completeness flags for private and communal blocks. Disable time changes when authoritative availability data is incomplete, or clearly fall back to server validation on selection.
+- **Open questions:** Should a booking on a hidden table be editable from FOH? Is fallback service time acceptable for viewing only, but not for mutation? What should happen if one supporting schedule query fails?
+
+### F09. Client and server do not share one authoritative multi-table window
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Data / multi-table bookings
+- **Relevant section:** 3.3; 5, `utils.ts`
+- **Description:** Each lane copy of a multi-table booking receives the window of that lane's assignment. The time endpoint instead uses the earliest start and latest end across all assignment rows. The specification does not say which client value determines candidate duration or how different assignment windows are handled.
+- **Rationale:** If assignment rows differ because of old data or a partial previous operation, the browser can mark a slot free using a shorter window while the server moves a longer aggregate window and returns 409.
+- **Impact:** Incorrect disabled states, confusing conflicts, and inconsistent duration display for joined tables.
+- **Recommended action:** Return one authoritative booking window and one authoritative occupancy window with every booking, independent of the clicked lane. Validate that joined assignments share the expected window. Treat inconsistent assignment windows as an error requiring repair rather than silently stretching duration from earliest to latest.
+- **Open questions:** Is equality of joined-table assignment windows a database invariant today? If it is not, should the new RPC repair or reject inconsistent rows?
+
+### F10. Service-window restrictions are client-only
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** API validation / business rules
+- **Relevant section:** 3.2; 4, out-of-scope rules
+- **Description:** The route accepts any valid `HH:MM`. The UI intends to show only service-window slots, but a direct or stale request can move a booking to 03:00. The database RPC enforces table conflicts, not pub opening hours.
+- **Rationale:** The specification excludes kitchen pacing and cut-off revalidation, but it does not clearly exclude basic pub service-hour validation. A browser-only limit is not authoritative.
+- **Impact:** Invalid booking times can be stored through the authenticated endpoint.
+- **Recommended action:** State the intended server rule. Recommended: enforce that the arrival time is inside the effective pub service window, including special hours, while deliberately bypassing kitchen pacing and online cut-off rules. If managers may override hours, make that an explicit permission and audited override rather than an accidental API capability.
+- **Open questions:** Are moves on closed days allowed? Can a manager move a food booking outside kitchen hours? Is the special-hours configuration authoritative for staff moves?
+
+### F11. The last valid arrival time is ambiguous
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Functional requirement / time bounds
+- **Relevant section:** 3.2, “Full grid”; 4, kitchen cut-off out of scope
+- **Description:** The specification says to show all slots across the service window, but also says not to render a slot when the booking's duration runs past the end of the timeline. Creation validates arrival time and can allow a booking whose guest duration extends after closing. The timeline itself includes padding beyond the service close.
+- **Rationale:** “Service end,” “timeline end,” “guest booking end,” and “table occupancy end” are different boundaries. The current wording can produce different implementations.
+- **Impact:** Valid late arrivals may disappear, or invalid late moves may be allowed, depending on the developer's interpretation.
+- **Recommended action:** Define one rule with examples. A likely rule is: candidate start must be in the effective staff arrival window; the full occupancy window is used for table conflicts; it does not need to finish before pub close unless the product owner explicitly wants that new restriction.
+- **Open questions:** Should a 21:30 booking be offered when the pub closes at 22:00? Should food use kitchen close while drinks use pub close, despite the out-of-scope statement?
+
+### F12. Past and historical time changes are undefined
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Functional requirement / edge case
+- **Relevant section:** 3.2; 4
+- **Description:** The grid includes the whole service window and the FOH page can show other dates. The specification does not say whether staff can move today's booking into the past, edit a past service date, or restore an original time that is now earlier than the current clock.
+- **Rationale:** Creation rejects past times, but a floor correction may legitimately need to record an earlier actual time. Those are different business actions and need an explicit rule.
+- **Impact:** Developers may block valid corrections or permit historical data rewrites without an audit distinction.
+- **Recommended action:** Define date and clock rules. Recommended for the first release: allow active future or same-day unseated bookings; do not allow a new start earlier than the current time, except through a separate audited correction flow. Hide the action on historical dates.
+- **Open questions:** Is the feature for future bookings as well as today's floor? Is correcting a wrongly entered historical time required?
+
+### F13. Slot and conflict calculation rules are incomplete
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Functional detail / algorithm
+- **Relevant section:** 3.2–3.3
+- **Description:** The specification does not fully define the algorithm developers must match. Missing rules include half-open overlap boundaries, reason priority when several block types overlap, invalid/missing timestamps, duplicate copies of the same booking across lanes, hidden assignments, exact exclusion of the selected booking, and the reference time used for expired holds.
+- **Rationale:** The database uses half-open windows `[start, end)`. The client helper must use the same rule. `Date.now()` inside a helper makes unit tests and memoisation unstable; a supplied reference time is safer. Off-grid nudges also create candidates such as 20:34, not only grid-aligned values.
+- **Impact:** A slot can be marked incorrectly at boundaries or change state unexpectedly while the modal is open.
+- **Recommended action:** Add a normative algorithm and examples. Pass `referenceNow` into `isFohBookingLive`; deduplicate by booking/block ID; use `[start, end)`; fail closed on malformed blocking data; define a reason priority such as Private, Event, Taken; and run the same check for arbitrary quick-nudge times and 15-minute grid times.
+- **Open questions:** If a slot overlaps both a private block and a booking, which reason is shown? Should malformed schedule rows disable the whole modal or only affected slots?
+
+### F14. Same-booking races and realtime changes can overwrite newer work
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Concurrency / stale state
+- **Relevant section:** 3.3, “Staleness”; 5, `FohScheduleClient.tsx`
+- **Description:** The database protects tables from overlapping bookings, but it does not prevent two users from moving the same booking to different free times. The second request can overwrite the first. The selected booking context is also a snapshot and is not replaced when realtime reloads the schedule.
+- **Rationale:** Table-conflict locking solves a different race. The route does not send or compare an expected original window/version. The notification helper rereads after the update, so concurrent requests can also produce confusing messages about whichever time is current when each helper runs.
+- **Impact:** Last-write-wins data loss, misleading audit old values, and duplicate or contradictory guest notifications.
+- **Recommended action:** Include `expected_start_datetime` or `expected_updated_at` in the request and compare it inside the transaction. Return 409 with the current booking when it differs. Reconcile the selected modal booking from every schedule refresh, or close the modal when its booking becomes ineligible.
+- **Open questions:** Is last-write-wins acceptable for this venue? Can BOH and FOH edit the same booking during service?
+
+### F15. High-chair and outside-capacity effects are missing from the UX and contract
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Resource management / side effects
+- **Relevant section:** 2; 3.2–3.4; 5
+- **Description:** `move_table_booking_time_v05` re-runs high-chair allocation and can silently reduce the granted count. Updating an outside booking also moves its outside reservation, and the current reconciler deliberately records an oversubscription rather than blocking a staff move. The specification describes neither effect.
+- **Rationale:** These are material operational resources. A successful time change can therefore mean “time changed, but one or more high chairs were lost” or “garden capacity is now over the configured level.”
+- **Impact:** Staff and guests can be promised resources that are no longer available, with no visible warning.
+- **Recommended action:** Return final high-chair count and outside-capacity outcome from the server. If a resource grant changes, show a prominent result and include old/new values in the audit. Decide explicitly whether outside bookings should always appear free or whether the modal should at least warn about capacity pressure.
+- **Open questions:** Should a high-chair reduction block the move or require confirmation? Is intentional outside oversubscription acceptable for all FOH editors or managers only?
+
+### F16. A shared kiosk audit cannot identify the staff member
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Audit / accountability / security
+- **Relevant section:** 3.6, “Audit logging”
+- **Description:** The proposed audit records `auth.userId`, but the kiosk uses the shared `manager@the-anchor.pub` account. That can identify the device/account, not the person. The stated goal of answering “who moved this booking?” is therefore not met.
+- **Rationale:** Technical user identity and human operator identity are different on a shared floor device. The audit service also swallows insert failures, so audit presence is best effort rather than guaranteed.
+- **Impact:** Guest disputes cannot be attributed to an individual staff member, and the specification overstates audit assurance.
+- **Recommended action:** Either capture a staff/employee identifier through an existing authenticated floor identity mechanism or change the stated goal to “which account/device made the change.” Audit no-op attempts, expected/current version, old and new guest and occupancy windows, notification request/result, resource changes, and surface. Add monitoring for audit-write failures.
+- **Open questions:** Is individual attribution required? Can the existing clocked-in employee state provide reliable attribution without adding friction?
+
+### F17. Synchronous notification creates slow and uncertain outcomes
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Reliability / performance / integration
+- **Relevant section:** 2; 3.4; 6
+- **Description:** The endpoint waits for fresh booking/customer reads, manage-token generation, channel selection, email or SMS work, and notification audit before responding. The move itself commits before that work. A timeout or lost response can make the client report failure even though the booking moved and a message may have been sent.
+- **Rationale:** This is an external side effect after the database transaction. Retrying after an unknown outcome can cause another move or another message.
+- **Impact:** Slow iPad interactions, duplicate actions, duplicate notifications, and staff uncertainty during provider or network problems.
+- **Recommended action:** Prefer a durable notification outbox/job keyed by the time-change audit/event ID. If that is too large for this release, separate mutation success from notification outcome in the response, add idempotency/deduplication, use a bounded timeout, and always refresh after an uncertain network result before offering retry.
+- **Open questions:** What response-time target is acceptable on the floor? Is there an existing job/outbox pattern that can be reused? What notification rate limits currently apply to repeated changes?
+
+### F18. Validation and response behaviour are incomplete
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** API contract / robustness
+- **Relevant section:** 3.3–3.6; 5
+- **Description:** The request contract only defines `time`. It does not define notification choice, expected version, day offset, or actor identity. The route does not validate null/invalid booking windows or inconsistent assignment windows before date arithmetic. It does not return the updated booking, final windows, high chairs, notification state, or a true unchanged state.
+- **Rationale:** The existing UI helper can update local state only when a response includes a booking snapshot. A malformed window currently becomes a generic 500. Sending the current time still runs the RPC and updates data even though the UI hides that choice.
+- **Impact:** Poor recovery, unnecessary writes, ambiguous retries, and limited audit/UI feedback.
+- **Recommended action:** Publish a request and response schema with stable error codes. Validate the stored booking before mutation; return 422 for corrupt windows; return `state: unchanged` without mutation or notification; and return the final booking/resource snapshot on success and conflict.
+- **Open questions:** Should unchanged requests be audited? Is the existing drag caller required to adopt the new concurrency and notification fields immediately?
+
+### F19. The test plan does not cover the main risks
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Testing / quality
+- **Relevant section:** 5–6
+- **Description:** The current route test covers authentication, basic input validation, and one simple RPC success. It does not test conflicts, notification calls, audit, states, assignments missing/multiple, duration semantics, resource side effects, or error responses. Its comment says notification is covered in separate tests, but no direct tests of `sendTableBookingRescheduledNotificationIfAllowed` were found.
+- **Rationale:** The proposed verification list is command-oriented rather than risk-oriented. Mocking the RPC cannot prove trigger conflicts, locks, guest-versus-occupancy windows, or transaction behaviour.
+- **Impact:** The highest-risk defects can pass the stated suite and reach the iPad.
+- **Recommended action:** Add the following minimum coverage:
+  - Database integration tests for guest duration versus turnaround hold, joined tables, private/communal conflicts, same-booking concurrency, and high-chair/outside side effects.
+  - Route tests for every eligible/ineligible state, unchanged, notify on/off/forced off, no channel, conflict codes, audit values, corrupt data, and expected-version mismatch.
+  - Unit tests for half-open overlap, liveness with explicit time, off-grid nudges, multi-table union, reason priority, hidden/missing lanes, and cross-midnight guard behaviour.
+  - Component tests for focus, keyboard use, action visibility, double tap, loading, modal-local errors, 409 refresh, uncertain success, and checkbox reset.
+  - iPad Safari UAT for portrait/landscape, offline/slow network, session expiry, and deliberate realtime conflict.
+- **Open questions:** Is a local/preview Supabase integration environment available in CI? Who owns iPad UAT and signs it off?
+
+### F20. “No migration” and the effort estimate are not credible after the duration finding
+
+- **Status:** Confirmed issue
+- **Priority:** P0
+- **Type:** Delivery / migration / estimation
+- **Relevant section:** 5, “Files”; complexity statement
+- **Description:** Correct guest/occupancy duration handling likely requires a new or revised atomic database function, so “No migration” is no longer safe. The file table already lists ten files, while the text says roughly six files of real change. It also omits schedule contract/type changes, database integration tests, notification work, and possible repair tooling.
+- **Rationale:** The backend fix is a prerequisite, not optional hardening. Database function changes require migration ordering, permissions, generated types, environment rollout, and rollback planning.
+- **Impact:** Underestimation, incomplete implementation, and a frontend release against an unsafe backend.
+- **Recommended action:** Re-estimate after product decisions and the backend spike. Add the RPC migration, generated database types if applicable, schedule/type contract changes, data preflight/repair decision, and deployment sequence. Backend must deploy before the new button is enabled.
+- **Open questions:** What does complexity “3 (M)” mean in team planning terms? Is a repair required for old drag moves? Can UI and backend be feature-flagged independently?
+
+### F21. Touch-drag changes are separate scope and not near-zero risk
+
+- **Status:** Confirmed issue
+- **Priority:** P2
+- **Type:** Scope / regression risk
+- **Relevant section:** 3.7, “Fix the touch-drag path as well”
+- **Description:** Adding `touch-action: none` changes scrolling behaviour when a gesture starts on a booking. Moving the measurement ref changes both time and table drag calculations. Neither change is needed to deliver the supported kiosk tap flow.
+- **Rationale:** The timeline is horizontally scrollable. Preventing native touch handling over booking blocks can make panning harder, and measurement changes can alter every desktop drag snap.
+- **Impact:** Regression risk and extra iPad/desktop test scope in an already under-specified release.
+- **Recommended action:** Move touch-drag work to a separate ticket unless non-kiosk touch drag is an explicit acceptance criterion. If retained, add pan-versus-drag usability tests and regression tests for lane/table drag geometry.
+- **Open questions:** Is non-kiosk touch drag used in practice? Is it more valuable than shipping the tap flow safely?
+
+### F22. Accessibility requirements stop at touch-target size
+
+- **Status:** Confirmed issue
+- **Priority:** P2
+- **Type:** Accessibility
+- **Relevant section:** 3.2; 3.5
+- **Description:** The 44px/56px target sizes are good, but there are no requirements for keyboard navigation, focus placement, focus return, screen-reader labels, disabled reasons, current-time semantics, contrast, scroll-region labelling, or live error/loading announcements.
+- **Rationale:** A disabled dimmed tile with a one-word visual reason is not enough for assistive technology. Auto-scrolling should not move focus unexpectedly. “Now” can mean the current clock rather than the booking's stored time.
+- **Impact:** The modal may be unusable or confusing for keyboard and screen-reader users and may fail accessibility review.
+- **Recommended action:** Require semantic buttons, accessible names including proposed time and state, visible and screen-reader disabled reasons, `aria-current` or equivalent for the stored time, focus on the heading/current selection, focus return to Change time, an announced local error/status region, and keyboard-operable scrolling. Test with keyboard and VoiceOver on iPad.
+- **Open questions:** What accessibility standard is the project targeting? Should disabled slots remain focusable so their reason can be read, or should reasons be available in adjacent text?
+
+### F23. Offline, session expiry, refresh failure, and uncertain success are unspecified
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Error handling / user journeys
+- **Relevant section:** 3.3; 6
+- **Description:** Only a 409 is described. Missing journeys include 400 validation, 401 session expiry, 403 permission change, 404 deletion, 500, offline fetch failure, malformed response, mutation success followed by schedule refresh failure, modal close during request, and rapid double tap.
+- **Rationale:** The iPad is a mobile floor device and network interruption is a normal operating condition. The existing helper merges mutation and reload into one boolean, which cannot describe partial success.
+- **Impact:** Staff may retry completed work, leave the screen stale, or be unable to recover without a full reload.
+- **Recommended action:** Add an error matrix with user message, modal behaviour, refresh behaviour, and retry rule for each class. Disable all time controls while submitting. On unknown network outcome, keep the modal open, reload the booking/schedule, and show whether the requested time is already applied before enabling retry.
+- **Open questions:** What should happen when the kiosk session expires mid-service? Is there an offline banner or standard reconnect pattern to reuse?
+
+### F24. Release monitoring and operational measures are missing
+
+- **Status:** Confirmed issue
+- **Priority:** P2
+- **Type:** Monitoring / support
+- **Relevant section:** 3.6; 6
+- **Description:** Audit logging is proposed, but there is no monitoring plan for endpoint latency, error rate, conflict rate, notification failures, high-chair reductions, outside oversubscription, or client refresh failures.
+- **Rationale:** This change affects live floor allocation and guest communication. Audit rows help investigation but do not provide timely alerting or release health.
+- **Impact:** Regressions may be found only through a guest complaint or floor disruption.
+- **Recommended action:** Add structured logs and a short release dashboard/query for change count, 409 rate, 5xx rate, p95 response time, notification outcome, audit failures, and resource reductions. Define an owner and rollback threshold for the first week.
+- **Open questions:** Which existing monitoring system should receive these signals? Who reviews them after release?
+
+### F25. There are no complete, testable acceptance criteria
+
+- **Status:** Confirmed issue
+- **Priority:** P1
+- **Type:** Delivery / requirements quality
+- **Relevant section:** Whole specification; 6
+- **Description:** The verification section lists commands and a few manual checks, but it does not provide a full pass/fail contract covering eligible bookings, exact time bounds, event linkage, notification states, resource changes, concurrency, accessibility, and error recovery.
+- **Rationale:** Different developers and testers can reasonably implement different behaviour from the current prose.
+- **Impact:** Rework, disputed completion, and production-only edge cases.
+- **Recommended action:** Add Given/When/Then acceptance criteria after the open product decisions are made. Trace each P0/P1 finding to at least one automated or manual acceptance test.
+- **Open questions:** Who is the product approver? Who owns developer completion, QA, and floor sign-off?
+
+### F26. Use “Current booking time” instead of “Now”
+
+- **Status:** Optional improvement
+- **Priority:** P2
+- **Type:** Wording / usability
+- **Relevant section:** 3.2, current-time tile
+- **Description:** “Now” can be read as the current clock time, especially on a live floor screen.
+- **Rationale:** The tile represents the booking's stored time, which may be earlier or later than the actual current time.
+- **Impact:** Small but avoidable operator confusion.
+- **Recommended action:** Suggested wording: “Current” on the tile and “Current booking time” in its accessible name.
+- **Open questions:** None.
+
+### F27. Keep the first release to guest-requested rescheduling
+
+- **Status:** Optional improvement
+- **Priority:** P2
+- **Type:** Scope simplification
+- **Relevant section:** 3.2–3.4
+- **Description:** The safest small release is a slot picker for active, unseated, non-event bookings where the guest has asked to move. Internal delay tracking, seated moves, touch drag, and arbitrary custom minutes can follow separately.
+- **Rationale:** This removes the hardest notification and data-model contradictions while still solving the stated lack of a non-drag time change.
+- **Impact:** Smaller test surface, clearer staff training, and lower operational risk.
+- **Recommended action:** Rename the action internally as a guest reschedule, require a deliberate Apply step, and keep notification on by default subject to the final policy. Treat internal floor delay as a separate discovery item.
+- **Open questions:** Does this narrower release still solve the floor team's immediate need?
+
+### F28. Replace the cross-midnight guard with an explicit timestamp contract when needed
+
+- **Status:** Optional improvement
+- **Priority:** P3
+- **Type:** Time handling / future-proofing
+- **Relevant section:** 7, low-priority hardening
+- **Description:** The current request sends only `HH:MM`, so it cannot distinguish the first and next calendar day in a cross-midnight service. It is also ambiguous during a repeated daylight-saving clock hour.
+- **Rationale:** A guard can reject bad cases but cannot represent the intended date/day offset. The dormant risk is correctly noted, but the future fix needs a contract change rather than only a conditional check.
+- **Impact:** No current impact if verified hours always end at 22:00; future late licences would make midnight selections unsafe.
+- **Recommended action:** Keep an explicit guard now. If cross-midnight service is introduced, send an ISO local date plus time or an exact timestamp/day offset and validate it against the booking service date. Add DST tests.
+- **Open questions:** Is there a configuration alert when closing time moves past midnight?
+
+### F29. Consider server-produced availability instead of duplicating database rules in the browser
+
+- **Status:** Optional improvement
+- **Priority:** P2
+- **Type:** Architecture / simplification
+- **Relevant section:** 3.3
+- **Description:** Mirroring `is_booking_live` and every conflict source in browser code creates a permanent drift risk. A comment pointing at SQL and unit tests do not prove parity after a future migration.
+- **Rationale:** The server already owns authoritative time conversion, status, permissions, and database rules. Returning candidate availability on modal open costs one request but simplifies correctness and can expose stable reasons and completeness.
+- **Impact:** Slightly more network use, but less duplicated logic and fewer misleading client states.
+- **Recommended action:** Compare two explicit designs before implementation: (A) enriched, completeness-aware schedule data plus client calculation; or (B) a GET/availability response from the time route using server time and current database data. Choose based on measured iPad latency, not the assumption that any extra request is unacceptable.
+- **Open questions:** Can the server calculate all 15-minute candidates in one database round trip? What is the acceptable modal-open latency on the venue network?
+
+### F30. Use a short kiosk canary before general release
+
+- **Status:** Optional improvement
+- **Priority:** P2
+- **Type:** Rollout / risk control
+- **Relevant section:** 6
+- **Description:** The feature is primarily for one known kiosk account, which makes a short canary practical.
+- **Rationale:** Real iPad Safari, venue Wi-Fi, shared-account behaviour, and live floor timing are difficult to reproduce fully in automated tests.
+- **Impact:** Small rollout overhead with a high chance of catching usability or latency problems early.
+- **Recommended action:** Deploy backend first, enable the UI for the manager kiosk only for one or two services, review monitoring/audits, then enable it for other FOH editors. Keep a simple kill switch for the button.
+- **Open questions:** Who will be present for the canary and collect staff feedback?
+
+## 5. Required changes before implementation
+
+1. Separate guest rescheduling from internal venue delay, or explicitly limit the first release to guest rescheduling.
+2. Fix the guest-duration versus assignment-occupancy defect with an atomic backend design and migration.
+3. Define and enforce eligible states, including `left_at`, seated state, expired holds, event linkage, and review states.
+4. Decide notification defaults, suppression rules, copy, delivery reporting, and retry/deduplication.
+5. Define authoritative availability data, exact overlap rules, service bounds, late slots, past times, and incomplete-data behaviour.
+6. Add optimistic concurrency and reconcile the open modal with realtime changes.
+7. Specify resource side effects, audit identity/contents, API schemas, and the complete error matrix.
+8. Replace the current verification list with traceable acceptance criteria and database-backed tests.
+9. Re-estimate the work and add migration, deployment ordering, monitoring, rollback, and iPad sign-off.
+
+## 6. Unresolved decisions
+
+- Is this action a guest reschedule, an internal delay, or two separate actions?
+- May seated or departed bookings ever be changed?
+- Are pending-payment and expired-hold bookings eligible?
+- Are all event-linked table bookings excluded?
+- Is guest notification checked by default, optional, or mandatory for unseated bookings?
+- What must staff see when no message channel exists or delivery fails?
+- Are past times and past service dates editable?
+- Does a valid start only need to be before service close, or must the guest/resource window also finish before a boundary?
+- Are food moves allowed outside kitchen hours when kitchen pacing and cut-off checks are bypassed?
+- Should high-chair reduction block, warn, or silently continue?
+- Is outside-capacity oversubscription acceptable, and for which role?
+- Is shared-account audit sufficient, or is employee attribution required?
+- Is client-computed availability still preferred after the completeness and drift findings?
+- Is last-write-wins acceptable for simultaneous edits?
+
+## 7. Major risks
+
+1. **Data corruption:** booking end time can absorb the turnaround hold while `duration_minutes` stays unchanged.
+2. **Live floor conflict:** moving a seated booking can free a table that is physically occupied.
+3. **Integration drift:** event-linked table bookings can move away from their event.
+4. **Guest harm:** accidental, duplicate, alarming, or inaccurate notifications.
+5. **Stale overwrite:** two staff members can overwrite the same booking without warning.
+6. **Misleading availability:** hidden assignments or incomplete schedule data can display blocked slots as free.
+7. **Resource loss:** high-chair grants can be reduced without staff seeing it.
+8. **Unknown outcome:** the booking can move even when notification or refresh causes the client to report failure.
+9. **Weak accountability:** the shared kiosk account cannot identify the human operator.
+10. **Delivery underestimation:** the current scope and “no migration” assumption omit necessary backend work.
+
+## 8. Recommended next steps
+
+1. Hold a short product decision session to answer the unresolved decisions, led by the floor owner and booking-system owner.
+2. Run a backend spike against representative data to confirm turnaround settings, compare booking and assignment ends, count event-linked bookings, and check for existing inconsistencies caused by drag moves.
+3. Design and test the corrected atomic RPC and route contract first.
+4. Revise the specification with eligibility, notification, availability, error, concurrency, audit, resource, and acceptance rules.
+5. Re-review the revised specification before UI implementation.
+6. Build the UI only after the backend contract is stable, then complete automated tests and iPad preview UAT.
+7. Release through a kiosk canary with monitoring and a kill switch.
+

--- a/tests/api/fohTableBookingTimeNotification.test.ts
+++ b/tests/api/fohTableBookingTimeNotification.test.ts
@@ -13,6 +13,10 @@ vi.mock('@/lib/table-bookings/move-table', () => ({
   isAssignmentConflictError: vi.fn(() => false),
 }))
 
+vi.mock('@/app/actions/audit', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
 vi.mock('@/lib/table-bookings/bookings', () => ({
   sendTableBookingRescheduledNotificationIfAllowed: vi.fn().mockResolvedValue(undefined),
 }))
@@ -24,18 +28,46 @@ import { PATCH as patchTime } from '@/app/api/foh/bookings/[id]/time/route'
 const BOOKING_ID = '00000000-0000-4000-8000-000000000001'
 
 function buildSupabase() {
-  // One assignment window: 17:00–18:30 UTC → 18:00–19:30 London (BST) in July.
-  const assignmentEq = vi.fn().mockResolvedValue({
-    data: [{ start_datetime: '2026-07-20T17:00:00.000Z', end_datetime: '2026-07-20T18:30:00.000Z' }],
+  // Guest window 17:00-18:30 UTC, which is 18:00-19:30 London in July (BST). The assignment
+  // runs 15 minutes longer because a turnaround gap is configured; the route must keep those
+  // two windows apart rather than writing the longer one back to the booking.
+  const booking = {
+    id: BOOKING_ID,
+    status: 'confirmed',
+    booking_time: '18:00:00',
+    booking_date: '2026-07-20',
+    start_datetime: '2026-07-20T17:00:00.000Z',
+    end_datetime: '2026-07-20T18:30:00.000Z',
+    duration_minutes: 90,
+    seated_at: null,
+    left_at: null,
+    event_id: null,
+    high_chair_count: 0,
+  }
+
+  const rpc = vi.fn().mockResolvedValue({
+    data: { state: 'updated', assignment_count: 1, high_chairs_requested: 0, high_chairs_granted: 0 },
     error: null,
   })
-  const assignmentSelect = vi.fn().mockReturnValue({ eq: assignmentEq })
-  const rpc = vi.fn().mockResolvedValue({ data: { state: 'confirmed', assignment_count: 1 }, error: null })
 
   return {
     from: vi.fn((table: string) => {
+      if (table === 'table_bookings') {
+        return {
+          select: () => ({
+            eq: () => ({ maybeSingle: () => Promise.resolve({ data: booking, error: null }) }),
+          }),
+        }
+      }
       if (table === 'booking_table_assignments') {
-        return { select: assignmentSelect }
+        return {
+          select: () => ({
+            eq: () => Promise.resolve({
+              data: [{ start_datetime: '2026-07-20T17:00:00.000Z', end_datetime: '2026-07-20T18:45:00.000Z' }],
+              error: null,
+            }),
+          }),
+        }
       }
       throw new Error(`Unexpected table: ${table}`)
     }),
@@ -58,7 +90,7 @@ describe('FOH table-booking time move — customer notification', () => {
 
   it('notifies the customer when the time actually changes', async () => {
     const supabase = buildSupabase()
-    ;(requireFohPermission as unknown as vi.Mock).mockResolvedValue({ ok: true, supabase })
+    ;(requireFohPermission as unknown as vi.Mock).mockResolvedValue({ ok: true, userId: 'user-1', supabase })
 
     // Stored time is 18:00 London; move to 19:30.
     const response = await patchTime(jsonRequest({ time: '19:30' }) as any, {
@@ -74,7 +106,7 @@ describe('FOH table-booking time move — customer notification', () => {
 
   it('does not notify when the booking is dropped back on the same time', async () => {
     const supabase = buildSupabase()
-    ;(requireFohPermission as unknown as vi.Mock).mockResolvedValue({ ok: true, supabase })
+    ;(requireFohPermission as unknown as vi.Mock).mockResolvedValue({ ok: true, userId: 'user-1', supabase })
 
     // Stored time is 18:00 London; "move" to the same 18:00.
     const response = await patchTime(jsonRequest({ time: '18:00' }) as any, {


### PR DESCRIPTION
## What changed

Adds a **Change time** action to the FOH booking detail modal, with quick nudges either side of the current time and a 15-minute grid, built like Move table. Fixes a dormant data defect in the underlying endpoint first, and enforces eligibility server-side where it previously enforced nothing.

## Why

The floor team could not change a booking time at all. Three reasons, each sufficient on its own:

1. The iPad signs in as `manager@the-anchor.pub`, which puts the screen in kiosk mode, and `DraggableBookingBlock` disables drag entirely in kiosk mode.
2. Drag was the only caller of `PATCH /api/foh/bookings/[id]/time`, so with drag off the endpoint was unreachable.
3. Touch drag could not have worked regardless: dnd-kit needs `touch-action: none`, which no FOH component set, so the browser claimed the gesture as a pan of the timeline's horizontal scroller.

The back-office edit at `/table-bookings/[id]` has date, time and duration, but FOH-only users get a 403 from those routes and the chromeless layout has no link to it.

## The data defect, fixed first

Since turn times were switched on, a booking deliberately carries two windows: `table_bookings` holds the guest's window, and `booking_table_assignments` holds that plus `turnaround_gap_minutes`. Production has this enabled with a 15-minute gap, and 34 live bookings carry it.

The endpoint read the **assignment** window, and `move_table_booking_time_v05` wrote that single end time back to both records. A 105-minute booking became a 120-minute booking row while `duration_minutes` still said 105. It also stretched the window `count_high_chairs_in_window` measures contention on.

Nothing in production is damaged: v05's only caller was the drag path that does not work, and no live booking carries the signature. But a working picker would have fired it on every use, so `move_table_booking_time_v06` takes the two end times separately. v05 is left in place so the migration could be applied ahead of this deploy; it has no caller once this lands and can be dropped in a later tidy-up.

## Design notes

- **Two steps, not one.** Move table applies on a single tap because it notifies nobody. Every time change tells the guest, so a mistap would send a real message. Selecting a slot and applying it are separate.
- **Availability is computed client-side** from the schedule the page already holds, so there is no extra round trip on a busy iPad. The DB trigger stays the authority; a stale client earns a 409, which keeps the modal open, shows the message and refreshes the grid.
- **Seated parties can still be re-timed**, with an explicit warning that it tells the guest and frees their table for the old time. Owner decision.
- **Event-linked bookings are refused** in both UI and endpoint, so an event diner's table cannot drift from their ticket.

## Testing done

- [x] Automated: full suite green, 706 files / 5972 tests. The FOH surface went from 55 tests to 122. New coverage for the guest-versus-occupancy window split, BST conversion, eligibility refusals, half-open overlap, off-grid current times, block-reason priority, and the modal's disabled and error states.
- [x] Lint, `tsc --noEmit`, production build all clean.
- [x] Migration applied to production and verified: correct signature, `SECURITY DEFINER`, `service_role` only in its ACL, and `assert-anon-surface` passes all 9 checks.
- [ ] **Not verified in a browser.** The page needs the kiosk login, so the flow itself is untested against a real screen. Wants one real time change on the iPad after deploy.

## Complexity score

M

## Breaking changes

None. Additive migration; v05 untouched, so the currently deployed code kept working between the migration and this deploy.

## Migration risk

Low. One new function, no drops, no data changes. Already applied and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)