### PR TITLE
fix(table-bookings): return deposits on cancel, honour STOP, recover lost captures

### DIFF
--- a/src/app/(authenticated)/table-bookings/[id]/BookingDetailClient.tsx
+++ b/src/app/(authenticated)/table-bookings/[id]/BookingDetailClient.tsx
@@ -841,7 +841,9 @@ export default function BookingDetailClient({ booking, canEdit, canManage, canRe
   }, [booking.id, canEdit])
 
   return (
-    <div className="space-y-6">
+    // data-touch-targets: reached from BOH on a tablet, and its Danger Zone buttons are the
+    // smallest destructive controls in the section. See the note in FohScheduleClient.
+    <div className="space-y-6" data-touch-targets>
       <section className="rounded-lg border border-gray-200 bg-white p-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-2">

--- a/src/app/(authenticated)/table-bookings/boh/BohBookingsClient.tsx
+++ b/src/app/(authenticated)/table-bookings/boh/BohBookingsClient.tsx
@@ -796,7 +796,9 @@ export function BohBookingsClient({
   }
 
   return (
-    <div className="space-y-4">
+    // data-touch-targets: BOH is also used on a tablet, and the 44px floor in globals.css
+    // only applies below 821px. See the note in FohScheduleClient.
+    <div className="space-y-4" data-touch-targets>
       <div className="rounded-lg border border-gray-200 bg-white p-4">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
           <div>
@@ -939,6 +941,26 @@ export function BohBookingsClient({
         )}
       </div>
 
+      {/* A failed load zeroes the arrays, and these cards render unconditionally, so an
+          outage painted "Total bookings 0" and "-100.0%" in large type at the top of the
+          page. A manager reads that as a dead service, not a broken request. The error
+          banner lived further down, below five full-width cards on a narrow screen. */}
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          <p className="font-semibold">These figures could not be loaded</p>
+          <p className="mt-0.5">{error}</p>
+          <button
+            type="button"
+            onClick={() => void loadBookings()}
+            className="mt-2 rounded-md border border-amber-400 bg-white px-3 py-1.5 text-sm font-medium text-amber-900 hover:bg-amber-100"
+          >
+            Try again
+          </button>
+        </div>
+      ) : (
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
         {metricsCards.map((card) => {
           const delta = getDeltaDisplay(card.value, card.previous, {
@@ -960,6 +982,7 @@ export function BohBookingsClient({
           )
         })}
       </div>
+      )}
 
       {isDayView && dishTotals && dishTotals.coverCount > 0 && (
         <div className="rounded-lg border border-gray-200 bg-white">

--- a/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
@@ -430,7 +430,14 @@ export function FohScheduleClient({
   const pageWrapperClass = cn(isManagerKioskStyle ? 'space-y-2 rounded-xl bg-sidebar p-2 sm:p-3' : 'space-y-6')
 
   return (
-    <div className={pageWrapperClass}>
+    /*
+     * data-touch-targets opts this screen into the `pointer: coarse` rule in globals.css,
+     * which lifts every button, select, input and textarea inside it to 44px on a touch
+     * device at ANY width. The existing 44px floor is keyed on max-width 820px, so FOH,
+     * which runs on an iPad in landscape at 1024px+, was getting 25px desktop controls
+     * mid-service. The manager kiosk variant shrinks them further still.
+     */
+    <div className={pageWrapperClass} data-touch-targets>
       <FohHeader
         date={date}
         setDate={setDate as (date: string | ((current: string) => string)) => void}

--- a/src/app/actions/refundActions.ts
+++ b/src/app/actions/refundActions.ts
@@ -251,7 +251,19 @@ async function updateRefundStatus(
   if (sourceType === 'private_booking') {
     await db.from('private_bookings').update({ deposit_refund_status: status }).eq('id', sourceId)
   } else if (sourceType === 'table_booking') {
-    await db.from('table_bookings').update({ deposit_refund_status: status }).eq('id', sourceId)
+    // Both columns, not just the refund one. `payment_status` left at 'completed' means a
+    // fully refunded booking still reads as paid to hasUnpaidRequiredDeposit and to the
+    // deposit-timeout cron's hasCapturedDeposit, so the venue believes it holds money it
+    // has already returned. The parking branch below already reconciles its parent; table
+    // bookings were left out of that same fix.
+    await db
+      .from('table_bookings')
+      .update({
+        deposit_refund_status: status,
+        payment_status: status === 'refunded' ? 'refunded' : 'partial_refund',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
   } else if (sourceType === 'parking') {
     await db.from('parking_booking_payments').update({ refund_status: status }).eq('id', sourceId)
 

--- a/src/app/api/boh/table-bookings/[id]/party-size/route.ts
+++ b/src/app/api/boh/table-bookings/[id]/party-size/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { logAuditEvent } from '@/app/actions/audit'
 import { z } from 'zod'
 import { requireBohTableBookingPermission } from '@/lib/foh/api-auth'
 import { logger } from '@/lib/logger'
@@ -174,6 +175,15 @@ export async function POST(
         })
       }
     }
+
+    await logAuditEvent({
+      user_id: auth.userId,
+      operation_type: 'table_booking.party_size_changed',
+      resource_type: 'table_booking',
+      resource_id: id,
+      operation_status: 'success',
+      additional_info: { source: 'boh', previousPartySize, newPartySize },
+    }).catch(() => {})
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/boh/table-bookings/[id]/route.ts
+++ b/src/app/api/boh/table-bookings/[id]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from 'next/cache'
 import { fromZonedTime } from 'date-fns-tz'
 import { z } from 'zod'
 import { requireBohTableBookingPermission } from '@/lib/foh/api-auth'
-import { refundTableBookingDeposit } from '@/lib/table-bookings/refunds'
+import { refundAndNotifyOnCancel } from '@/lib/table-bookings/cancel-notify'
 import { sendTableBookingCancelledSmsIfAllowed, sendTableBookingRescheduledNotificationIfAllowed } from '@/lib/table-bookings/bookings'
 import { expireStripeCheckoutSession, isStripeConfigured } from '@/lib/payments/stripe'
 import { logAuditEvent } from '@/app/actions/audit'
@@ -241,7 +241,10 @@ export async function DELETE(
   }
 
   const { data: existing, error: loadError } = await auth.supabase.from('table_bookings')
-    .select('id, customer_id, booking_reference, booking_date, status, payment_status, cancelled_at, cancellation_reason')
+    // The PayPal columns are selected so the delete can be guarded on them and so the audit
+    // row's old_values still carries the transaction pointer. Without them the audit trail
+    // for a deleted paid booking named no way to find the money again.
+    .select('id, customer_id, booking_reference, booking_date, status, payment_status, cancelled_at, cancellation_reason, paypal_deposit_capture_id, paypal_deposit_order_id, deposit_amount, deposit_amount_locked, deposit_refund_status')
     .eq('id', id)
     .maybeSingle()
 
@@ -256,6 +259,49 @@ export async function DELETE(
   const nowIso = new Date().toISOString()
 
   if (existing.status === 'cancelled') {
+    /*
+     * Refuse to destroy a booking that still holds a guest's money.
+     *
+     * This delete cascades: payments, table_booking_payments, booking_holds, charge_requests,
+     * guest_tokens, booking_audit and feedback all go with it. Combined with the refund path
+     * that used to silently skip PayPal deposits, the sequence "guest pays, staff cancel,
+     * staff delete" erased both the money and every trace of it, including the capture id
+     * needed to refund by hand.
+     *
+     * Deleting is still allowed once the deposit has been returned, or where none was taken.
+     */
+    const depositSettled =
+      existing.deposit_refund_status === 'refunded' ||
+      existing.payment_status === 'refunded'
+    const holdsGuestMoney =
+      Boolean(existing.paypal_deposit_capture_id) ||
+      existing.payment_status === 'completed' ||
+      existing.payment_status === 'partial_refund'
+
+    if (holdsGuestMoney && !depositSettled) {
+      await logAuditEvent({
+        user_id: auth.userId,
+        operation_type: 'delete',
+        resource_type: 'table_booking',
+        resource_id: id,
+        operation_status: 'failure',
+        error_message: 'Refused: booking still holds a captured deposit',
+        additional_info: {
+          booking_reference: existing.booking_reference,
+          payment_status: existing.payment_status,
+          deposit_refund_status: existing.deposit_refund_status,
+          paypal_deposit_capture_id: existing.paypal_deposit_capture_id,
+        },
+      })
+      return NextResponse.json(
+        {
+          error:
+            'This booking still holds a paid deposit. Refund it first, then delete. Deleting now would destroy the payment record.',
+        },
+        { status: 409 },
+      )
+    }
+
     const { data: deletedBooking, error: deleteError } = await auth.supabase.from('table_bookings')
       .delete()
       .eq('id', id)
@@ -340,7 +386,9 @@ export async function DELETE(
       cancelled_at: nowIso,
       cancelled_by: 'staff',
       cancellation_reason: cancellationReason,
-      paypal_deposit_order_id: null,
+      // paypal_deposit_order_id is deliberately KEPT: it is the only pointer to the PayPal
+      // order, and the reconciliation cron needs it to find a capture that was taken but
+      // never recorded.
       hold_expires_at: null,
       updated_at: nowIso
     })
@@ -379,18 +427,14 @@ export async function DELETE(
   }).catch(() => {})
 
   // Tiered deposit refund + cancellation SMS (never fail the delete)
-  try {
-    const bookingDate = new Date(`${existing.booking_date}T12:00:00`)
-    const refundResult = await refundTableBookingDeposit(existing.id, bookingDate)
-    await sendTableBookingCancelledSmsIfAllowed(auth.supabase, {
-      customerId: existing.customer_id,
+  if (existing.booking_date && existing.customer_id) {
+    await refundAndNotifyOnCancel(auth.supabase, {
+      bookingId: existing.id,
       bookingReference: existing.booking_reference || id,
       bookingDate: existing.booking_date,
-      refundResult,
-      tableBookingId: existing.id,
+      customerId: existing.customer_id,
+      source: 'boh_soft_delete',
     })
-  } catch (err) {
-    console.error('[table-booking-delete] refund/SMS error:', err)
   }
 
   return NextResponse.json({

--- a/src/app/api/boh/table-bookings/[id]/status/route.ts
+++ b/src/app/api/boh/table-bookings/[id]/status/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { requireBohTableBookingPermission } from '@/lib/foh/api-auth'
-import { refundTableBookingDeposit } from '@/lib/table-bookings/refunds'
+import { refundAndNotifyOnCancel } from '@/lib/table-bookings/cancel-notify'
 import { sendTableBookingCancelledSmsIfAllowed } from '@/lib/table-bookings/bookings'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -107,8 +107,10 @@ export async function POST(
   const { data: updatedRow, error: updateError } = await auth.supabase.from('table_bookings')
     .update(action === 'cancelled'
       ? {
+          // paypal_deposit_order_id is deliberately KEPT: it is the only pointer to the
+          // PayPal order, and the reconciliation cron needs it to find a capture that was
+          // taken but never recorded.
           ...transition.plan.update,
-          paypal_deposit_order_id: null,
           hold_expires_at: null,
         }
       : transition.plan.update)
@@ -133,18 +135,13 @@ export async function POST(
 
   // Tiered deposit refund + cancellation SMS when staff cancel a booking (never fail the status change)
   if (action === 'cancelled' && booking.booking_date && booking.customer_id) {
-    try {
-      const bookingDate = new Date(`${booking.booking_date}T12:00:00`)
-      const refundResult = await refundTableBookingDeposit(booking.id, bookingDate)
-      await sendTableBookingCancelledSmsIfAllowed(auth.supabase, {
-        customerId: booking.customer_id,
-        bookingReference: booking.booking_reference || booking.id,
-        bookingDate: booking.booking_date,
-        refundResult,
-      })
-    } catch (err) {
-      console.error('[table-booking-status] refund/SMS error:', err)
-    }
+    await refundAndNotifyOnCancel(auth.supabase, {
+      bookingId: booking.id,
+      bookingReference: booking.booking_reference || booking.id,
+      bookingDate: booking.booking_date,
+      customerId: booking.customer_id,
+      source: 'boh_status_cancel',
+    })
   }
 
   // Audit log the status transition (fire-and-forget)

--- a/src/app/api/cron/table-booking-paypal-reconciliation/route.ts
+++ b/src/app/api/cron/table-booking-paypal-reconciliation/route.ts
@@ -1,0 +1,223 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { authorizeCronRequest } from '@/lib/cron-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getPayPalOrder, isPayPalOrderNotFoundError } from '@/lib/paypal'
+import { logger } from '@/lib/logger'
+import { logAuditEvent } from '@/app/actions/audit'
+import { reportCronFailure } from '@/lib/cron/alerting'
+import {
+  buildPayPalDepositCompletedUpdate,
+  parsePayPalAmountGbp,
+  sendTableBookingDepositCapturedNotifications,
+} from '@/lib/table-bookings/paypal-deposit'
+
+/**
+ * Settles table-booking deposits that PayPal took but this app never recorded.
+ *
+ * WHY THIS EXISTS
+ *
+ * The browser capture route can lose the race between "PayPal has the money" and "our row
+ * says so": a network blip, a timeout, or a booking that moved state mid-capture all leave
+ * `payment.capture_local_update_failed` in the audit log and a 502 for the customer. A
+ * retry cannot fix it, because PayPal answers `ORDER_ALREADY_CAPTURED` and the route throws.
+ *
+ * Every other money path in this app already had a safety net for that. Table bookings had
+ * neither this cron nor a subscribed webhook, so a paid deposit could sit unrecorded until
+ * the deposit-timeout cron cancelled the booking and texted the guest to say so, while the
+ * venue still held their money.
+ *
+ * This runs regardless of whether the PayPal webhook endpoint is subscribed, which is what
+ * makes it the guarantee rather than a second-best.
+ *
+ * SAFETY
+ *
+ * It never captures. It only reads PayPal and records a capture PayPal has already made, so
+ * the worst case is that it does nothing. The write is guarded on
+ * `paypal_deposit_capture_id IS NULL`, so racing the browser or the webhook records nothing
+ * twice, and the amount is read from PayPal rather than recomputed locally.
+ */
+
+/*
+ * Scheduled at :50, ten minutes AHEAD of table-booking-deposit-timeout at :00. Running
+ * after the timeout would still recover the money, but only by un-cancelling a booking the
+ * guest had already been texted about. Running first means a paid deposit is recorded
+ * before the timeout ever evaluates it.
+ */
+export const dynamic = 'force-dynamic'
+export const maxDuration = 60
+
+/** Look back far enough to catch a booking cancelled by the hold timeout. */
+const LOOKBACK_DAYS = 30
+const MAX_CANDIDATES = 200
+
+type Candidate = {
+  id: string
+  booking_reference: string | null
+  customer_id: string | null
+  status: string | null
+  payment_status: string | null
+  paypal_deposit_order_id: string | null
+  paypal_deposit_capture_id: string | null
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = authorizeCronRequest(request)
+  if (!authResult.authorized) {
+    return NextResponse.json({ error: authResult.reason ?? 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabase = createAdminClient()
+  const since = new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
+
+  let checked = 0
+  let recovered = 0
+  const needsAttention: string[] = []
+
+  try {
+    // Any booking that started a PayPal payment and has no capture recorded. Cancelled ones
+    // are included deliberately: those are exactly the cases where the guest paid and the
+    // timeout cron cancelled them anyway, and they are the ones a human must see.
+    const { data: candidates, error } = await supabase
+      .from('table_bookings')
+      .select(
+        'id, booking_reference, customer_id, status, payment_status, paypal_deposit_order_id, paypal_deposit_capture_id',
+      )
+      .not('paypal_deposit_order_id', 'is', null)
+      .is('paypal_deposit_capture_id', null)
+      .gte('created_at', since)
+      .limit(MAX_CANDIDATES)
+
+    if (error) {
+      await reportCronFailure('table-booking-paypal-reconciliation', error, {
+        stage: 'fetch_candidates',
+      })
+      return NextResponse.json({ error: 'DB error' }, { status: 500 })
+    }
+
+    for (const booking of (candidates ?? []) as Candidate[]) {
+      const orderId = booking.paypal_deposit_order_id
+      if (!orderId) continue
+      checked++
+
+      let order: any
+      try {
+        order = await getPayPalOrder(orderId)
+      } catch (err) {
+        // An order PayPal has never heard of is an abandoned checkout, which is the normal
+        // case and not worth an alert.
+        if (isPayPalOrderNotFoundError(err)) continue
+        logger.warn('Table booking PayPal reconciliation could not read an order', {
+          error: err instanceof Error ? err : new Error(String(err)),
+          metadata: { bookingId: booking.id, orderId },
+        })
+        continue
+      }
+
+      const capture = order?.purchase_units?.[0]?.payments?.captures?.find(
+        (c: { status?: string }) => c?.status === 'COMPLETED',
+      )
+      if (!capture?.id) continue
+
+      // PayPal took the money and we never recorded it.
+      const lockedAmountGbp = parsePayPalAmountGbp(capture?.amount?.value ?? null)
+      if (lockedAmountGbp === null) {
+        needsAttention.push(booking.booking_reference ?? booking.id)
+        await logAuditEvent({
+          operation_type: 'payment.capture_amount_unparseable',
+          resource_type: 'table_booking',
+          resource_id: booking.id,
+          operation_status: 'failure',
+          additional_info: {
+            source: 'reconciliation_cron',
+            order_id: orderId,
+            capture_id: capture.id,
+            raw_amount: capture?.amount?.value ?? null,
+            action_needed:
+              'PayPal shows a completed capture but the amount was unreadable, so it was not recorded',
+          },
+        }).catch(() => undefined)
+        continue
+      }
+
+      const { data: updated, error: updateError } = await supabase
+        .from('table_bookings')
+        .update(
+          buildPayPalDepositCompletedUpdate({
+            captureId: capture.id,
+            lockedAmountGbp,
+            capturedAtIso: capture?.create_time ?? undefined,
+          }),
+        )
+        .eq('id', booking.id)
+        // Guard against the browser or the webhook winning the race in between.
+        .is('paypal_deposit_capture_id', null)
+        .select('id')
+        .maybeSingle()
+
+      if (updateError) {
+        logger.error('Table booking PayPal reconciliation failed to record a capture', {
+          error: new Error(updateError.message),
+          metadata: { bookingId: booking.id, orderId, captureId: capture.id },
+        })
+        needsAttention.push(booking.booking_reference ?? booking.id)
+        continue
+      }
+
+      if (!updated) continue // Someone else recorded it first. Nothing to do.
+
+      recovered++
+
+      /*
+       * A booking already cancelled by the deposit timeout is now marked paid and confirmed
+       * by the update above, which is the right end state: the guest did pay. Flag it so a
+       * human checks the table is still actually available for them.
+       */
+      const wasCancelled = booking.status === 'cancelled'
+      if (wasCancelled) needsAttention.push(booking.booking_reference ?? booking.id)
+
+      await logAuditEvent({
+        operation_type: 'payment.captured',
+        resource_type: 'table_booking',
+        resource_id: booking.id,
+        operation_status: 'success',
+        additional_info: {
+          source: 'reconciliation_cron',
+          order_id: orderId,
+          capture_id: capture.id,
+          locked_amount_gbp: lockedAmountGbp,
+          previous_status: booking.status,
+          action_needed: wasCancelled
+            ? 'This booking had been cancelled for non-payment but the guest had in fact paid. Confirm the table is still available.'
+            : undefined,
+        },
+      }).catch(() => undefined)
+
+      await sendTableBookingDepositCapturedNotifications(supabase, {
+        tableBookingId: booking.id,
+        customerId: booking.customer_id,
+        createdVia: 'reconciliation_cron',
+      }).catch((err) => {
+        logger.warn('Reconciled a table booking deposit but the confirmation failed to send', {
+          error: err instanceof Error ? err : new Error(String(err)),
+          metadata: { bookingId: booking.id },
+        })
+      })
+    }
+
+    if (needsAttention.length > 0) {
+      logger.error('Table booking deposits were reconciled and need a human to check them', {
+        metadata: { bookings: needsAttention },
+      })
+    }
+
+    logger.info('[table-booking-paypal-reconciliation] completed', {
+      metadata: { checked, recovered, needsAttention: needsAttention.length },
+    })
+
+    return NextResponse.json({ checked, recovered, needsAttention })
+  } catch (error) {
+    await reportCronFailure('table-booking-paypal-reconciliation', error)
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 })
+  }
+}

--- a/src/app/api/foh/bookings/[id]/cancel/route.ts
+++ b/src/app/api/foh/bookings/[id]/cancel/route.ts
@@ -3,8 +3,9 @@ import { requireFohPermission } from '@/lib/foh/api-auth'
 import { getTableBookingForFoh } from '@/lib/foh/bookings'
 import { buildStaffStatusTransitionPlan } from '@/lib/table-bookings/staff-status-actions'
 import { expireStripeCheckoutSession, isStripeConfigured } from '@/lib/payments/stripe'
-import { refundTableBookingDeposit } from '@/lib/table-bookings/refunds'
+import { refundAndNotifyOnCancel } from '@/lib/table-bookings/cancel-notify'
 import { sendTableBookingCancelledSmsIfAllowed } from '@/lib/table-bookings/bookings'
+import { logAuditEvent } from '@/app/actions/audit'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -74,8 +75,11 @@ export async function POST(
 
   const { data, error } = await auth.supabase.from('table_bookings')
     .update({
+      // paypal_deposit_order_id is deliberately KEPT. It is the only pointer to the PayPal
+      // order, and the reconciliation cron needs it to find a capture that was taken but
+      // never recorded. The deposit-timeout cron learned this already; the cancel paths
+      // were the siblings that never got the same fix.
       ...transition.plan.update,
-      paypal_deposit_order_id: null,
       hold_expires_at: null,
     })
     .eq('id', id)
@@ -97,21 +101,26 @@ export async function POST(
     )
   }
 
-  try {
-    if (booking.booking_date && booking.customer_id) {
-      const bookingDate = new Date(`${booking.booking_date}T12:00:00`)
-      const refundResult = await refundTableBookingDeposit(booking.id, bookingDate)
-      await sendTableBookingCancelledSmsIfAllowed(auth.supabase, {
-        customerId: booking.customer_id,
-        bookingReference: booking.booking_reference || booking.id,
-        bookingDate: booking.booking_date,
-        refundResult,
-        tableBookingId: booking.id,
-      })
-    }
-  } catch (err) {
-    console.error('[foh-cancel] refund/SMS error:', err)
+  if (booking.booking_date && booking.customer_id) {
+    await refundAndNotifyOnCancel(auth.supabase, {
+      bookingId: booking.id,
+      bookingReference: booking.booking_reference || booking.id,
+      bookingDate: booking.booking_date,
+      customerId: booking.customer_id,
+      source: 'foh_cancel',
+    })
   }
+
+  // Staff status changes are auditable mutations. These FOH routes cancel bookings,
+  // free tables and trigger refunds, and none of them recorded who did it.
+  await logAuditEvent({
+    user_id: auth.userId,
+    operation_type: 'table_booking.cancelled',
+    resource_type: 'table_booking',
+    resource_id: id,
+    operation_status: 'success',
+    additional_info: { source: 'foh' },
+  }).catch(() => {})
 
   return NextResponse.json({ success: true, booking: data, data })
 }

--- a/src/app/api/foh/bookings/[id]/left/route.ts
+++ b/src/app/api/foh/bookings/[id]/left/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireFohPermission } from '@/lib/foh/api-auth'
 import { getTableBookingForFoh } from '@/lib/foh/bookings'
+import { logAuditEvent } from '@/app/actions/audit'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -64,6 +65,17 @@ export async function POST(
       { status: currentBooking ? 409 : 404 }
     )
   }
+
+  // Staff status changes are auditable mutations. These FOH routes cancel bookings,
+  // free tables and trigger refunds, and none of them recorded who did it.
+  await logAuditEvent({
+    user_id: auth.userId,
+    operation_type: 'table_booking.left',
+    resource_type: 'table_booking',
+    resource_id: id,
+    operation_status: 'success',
+    additional_info: { source: 'foh' },
+  }).catch(() => {})
 
   return NextResponse.json({ success: true, booking: data, data })
 }

--- a/src/app/api/foh/bookings/[id]/no-show/route.ts
+++ b/src/app/api/foh/bookings/[id]/no-show/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireFohPermission } from '@/lib/foh/api-auth'
 import { getTableBookingForFoh } from '@/lib/foh/bookings'
 import { buildStaffStatusTransitionPlan } from '@/lib/table-bookings/staff-status-actions'
+import { logAuditEvent } from '@/app/actions/audit'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -63,6 +64,15 @@ export async function POST(
       { status: currentBooking ? 409 : 404 }
     )
   }
+
+  await logAuditEvent({
+    user_id: auth.userId,
+    operation_type: 'table_booking.no_show',
+    resource_type: 'table_booking',
+    resource_id: id,
+    operation_status: 'success',
+    additional_info: { source: 'foh' },
+  }).catch(() => {})
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/foh/bookings/[id]/party-size/route.ts
+++ b/src/app/api/foh/bookings/[id]/party-size/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { logAuditEvent } from '@/app/actions/audit'
 import { z } from 'zod'
 import { requireFohPermission } from '@/lib/foh/api-auth'
 import { logger } from '@/lib/logger'
@@ -170,6 +171,15 @@ export async function POST(
         })
       }
     }
+
+    await logAuditEvent({
+      user_id: auth.userId,
+      operation_type: 'table_booking.party_size_changed',
+      resource_type: 'table_booking',
+      resource_id: id,
+      operation_status: 'success',
+      additional_info: { source: 'foh', previousPartySize, newPartySize },
+    }).catch(() => {})
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/foh/bookings/[id]/seated/route.ts
+++ b/src/app/api/foh/bookings/[id]/seated/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireFohPermission } from '@/lib/foh/api-auth'
 import { getTableBookingForFoh, hasUnpaidRequiredDeposit } from '@/lib/foh/bookings'
 import { buildStaffStatusTransitionPlan } from '@/lib/table-bookings/staff-status-actions'
+import { logAuditEvent } from '@/app/actions/audit'
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -76,6 +77,17 @@ export async function POST(
       { status: currentBooking ? 409 : 404 }
     )
   }
+
+  // Staff status changes are auditable mutations. These FOH routes cancel bookings,
+  // free tables and trigger refunds, and none of them recorded who did it.
+  await logAuditEvent({
+    user_id: auth.userId,
+    operation_type: 'table_booking.seated',
+    resource_type: 'table_booking',
+    resource_id: id,
+    operation_status: 'success',
+    additional_info: { source: 'foh' },
+  }).catch(() => {})
 
   return NextResponse.json({ success: true, booking: data, data })
 }

--- a/src/app/api/webhooks/paypal/event-bookings/route.ts
+++ b/src/app/api/webhooks/paypal/event-bookings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { verifyPayPalWebhook } from '@/lib/paypal'
+import { resolveWebhookIdForUrl, verifyPayPalWebhook } from '@/lib/paypal'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
 import {
@@ -95,7 +95,18 @@ export async function POST(request: NextRequest): Promise<Response> {
   const supabase = createAdminClient()
   const body = await request.text()
   const headers = Object.fromEntries(request.headers.entries())
-  const webhookId = (process.env.PAYPAL_EVENT_BOOKINGS_WEBHOOK_ID || process.env.PAYPAL_WEBHOOK_ID)?.trim()
+  // Deliberately does NOT fall back to PAYPAL_WEBHOOK_ID: that is another endpoint's
+  // id, and verifying against it rejects every genuine event here. The env var is kept
+  // as an override but is no longer required, because a webhook deleted and recreated
+  // in the dashboard gets a NEW id that a stale env var would silently reject forever.
+  // That had already happened here: the registered endpoint and the configured id did
+  // not match. Resolving by URL self-heals. When it cannot be resolved we fail closed
+  // and PayPal retries.
+  const webhookId =
+    process.env.PAYPAL_EVENT_BOOKINGS_WEBHOOK_ID?.trim()
+    || (await resolveWebhookIdForUrl(
+      `${process.env.NEXT_PUBLIC_APP_URL || 'https://management.orangejelly.co.uk'}/api/webhooks/paypal/event-bookings`,
+    ))
   let idempotencyKey: string | null = null
   let requestHash: string | null = null
   let claimHeld = false
@@ -103,7 +114,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   try {
     if (!webhookId) {
       return NextResponse.json(
-        { received: false, error: 'PAYPAL_EVENT_BOOKINGS_WEBHOOK_ID not configured' },
+        { received: false, error: 'No PayPal webhook is registered for the event-bookings endpoint' },
         { status: process.env.NODE_ENV === 'production' ? 500 : 200 }
       )
     }

--- a/src/app/api/webhooks/paypal/parking/route.ts
+++ b/src/app/api/webhooks/paypal/parking/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { verifyPayPalWebhook } from '@/lib/paypal'
+import { resolveWebhookIdForUrl, verifyPayPalWebhook } from '@/lib/paypal'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
 import { handleRefundEvent } from '@/lib/paypal-refund-webhook'
@@ -96,7 +96,18 @@ export async function POST(request: NextRequest) {
   const supabase = createAdminClient()
   const body = await request.text()
   const headers = Object.fromEntries(request.headers.entries())
-  const webhookId = (process.env.PAYPAL_PARKING_WEBHOOK_ID || process.env.PAYPAL_WEBHOOK_ID)?.trim()
+  // Deliberately does NOT fall back to PAYPAL_WEBHOOK_ID: that is another endpoint's
+  // id, and verifying against it rejects every genuine event here. The env var is kept
+  // as an override but is no longer required, because a webhook deleted and recreated
+  // in the dashboard gets a NEW id that a stale env var would silently reject forever.
+  // That had already happened here: the registered endpoint and the configured id did
+  // not match. Resolving by URL self-heals. When it cannot be resolved we fail closed
+  // and PayPal retries.
+  const webhookId =
+    process.env.PAYPAL_PARKING_WEBHOOK_ID?.trim()
+    || (await resolveWebhookIdForUrl(
+      `${process.env.NEXT_PUBLIC_APP_URL || 'https://management.orangejelly.co.uk'}/api/webhooks/paypal/parking`,
+    ))
 
   let idempotencyKey: string | null = null
   let requestHash: string | null = null
@@ -104,7 +115,7 @@ export async function POST(request: NextRequest) {
 
   try {
     if (!webhookId) {
-      const errorMessage = 'PAYPAL_WEBHOOK_ID not configured'
+      const errorMessage = 'No PayPal webhook is registered for the parking endpoint'
       logger.error(errorMessage)
       await logPayPalWebhook(supabase, {
         status: 'configuration_error',

--- a/src/app/api/webhooks/paypal/table-bookings/__tests__/route.test.ts
+++ b/src/app/api/webhooks/paypal/table-bookings/__tests__/route.test.ts
@@ -5,6 +5,9 @@ import { NextRequest } from 'next/server'
 
 vi.mock('@/lib/paypal', () => ({
   verifyPayPalWebhook: vi.fn(),
+  // The route resolves the webhook id from PayPal by endpoint URL when no env var is set,
+  // so signature verification can never run against another endpoint's id.
+  resolveWebhookIdForUrl: vi.fn(async () => 'WEBHOOK-ID-FROM-PAYPAL'),
 }))
 
 vi.mock('@/lib/logger', () => ({

--- a/src/app/api/webhooks/paypal/table-bookings/route.ts
+++ b/src/app/api/webhooks/paypal/table-bookings/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { verifyPayPalWebhook } from '@/lib/paypal'
+import { resolveWebhookIdForUrl, verifyPayPalWebhook } from '@/lib/paypal'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
 import { handleRefundEvent } from '@/lib/paypal-refund-webhook'
@@ -227,7 +227,18 @@ export async function POST(request: NextRequest) {
   const supabase = createAdminClient()
   const body = await request.text()
   const headers = Object.fromEntries(request.headers.entries())
-  const webhookId = (process.env.PAYPAL_TABLE_BOOKINGS_WEBHOOK_ID || process.env.PAYPAL_WEBHOOK_ID)?.trim()
+  // Deliberately does NOT fall back to PAYPAL_WEBHOOK_ID: that is another endpoint's
+  // id, and verifying against it rejects every genuine event here. The env var is kept
+  // as an override but is no longer required, because a webhook deleted and recreated
+  // in the dashboard gets a NEW id that a stale env var would silently reject forever.
+  // That had already happened here: the registered endpoint and the configured id did
+  // not match. Resolving by URL self-heals. When it cannot be resolved we fail closed
+  // and PayPal retries.
+  const webhookId =
+    process.env.PAYPAL_TABLE_BOOKINGS_WEBHOOK_ID?.trim()
+    || (await resolveWebhookIdForUrl(
+      `${process.env.NEXT_PUBLIC_APP_URL || 'https://management.orangejelly.co.uk'}/api/webhooks/paypal/table-bookings`,
+    ))
 
   let idempotencyKey: string | null = null
   let requestHash: string | null = null
@@ -235,7 +246,7 @@ export async function POST(request: NextRequest) {
 
   try {
     if (!webhookId) {
-      const errorMessage = 'PAYPAL_WEBHOOK_ID not configured'
+      const errorMessage = 'No PayPal webhook is registered for the table-bookings endpoint'
       logger.error(errorMessage)
       await logWebhook(supabase, { status: 'configuration_error', headers, body, errorMessage })
       return NextResponse.json(

--- a/src/lib/__tests__/sms-opt-out-override.test.ts
+++ b/src/lib/__tests__/sms-opt-out-override.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * AN EXPLICIT STOP IS NEVER OVERRIDABLE.
+ *
+ * `allowTransactionalOverride` used to return `{ allowed: true }` BEFORE the opt-in and
+ * opt-out-status checks, so any caller passing it texted people who had replied STOP. The
+ * Sunday lunch pre-order chase passes it, so an opted-out guest with a Sunday booking was
+ * still messaged. Honouring STOP is a legal obligation under PECR, not a preference.
+ *
+ * The override still exists, because a genuinely transactional message should bypass the
+ * softer `sms_status` gate. It just no longer outranks an explicit opt-out.
+ */
+
+let customerRow: Record<string, unknown> | null = null
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({ maybeSingle: async () => ({ data: customerRow, error: null }) }),
+      }),
+    }),
+  }),
+}))
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+
+const { isCustomerSmsSendAllowed } = await import('@/lib/twilio')
+
+const TO = '+447700900123'
+
+function customer(overrides: Record<string, unknown> = {}) {
+  return {
+    sms_status: 'active',
+    sms_opt_in: true,
+    mobile_e164: TO,
+    mobile_number: '07700900123',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  customerRow = customer()
+})
+
+describe('isCustomerSmsSendAllowed', () => {
+  it('blocks an explicit opt-out even when a transactional override is requested', async () => {
+    customerRow = customer({ sms_opt_in: false, sms_status: 'opted_out' })
+
+    const result = await isCustomerSmsSendAllowed('cust-1', TO, {
+      allowTransactionalOverride: true,
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe('sms_opt_in_blocked')
+  })
+
+  it('blocks an opted_out status even when opt_in was never set false', async () => {
+    customerRow = customer({ sms_opt_in: null, sms_status: 'opted_out' })
+
+    const result = await isCustomerSmsSendAllowed('cust-1', TO, {
+      allowTransactionalOverride: true,
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe('sms_status_blocked')
+  })
+
+  it('still lets the override bypass the softer status gate', async () => {
+    // This is what the override is for: a genuinely transactional message to someone who
+    // has not opted out but whose status is not plain 'active'.
+    customerRow = customer({ sms_opt_in: true, sms_status: 'bounced' })
+
+    const result = await isCustomerSmsSendAllowed('cust-1', TO, {
+      allowTransactionalOverride: true,
+    })
+
+    expect(result.allowed).toBe(true)
+  })
+
+  it('blocks the same softer status without the override', async () => {
+    customerRow = customer({ sms_opt_in: true, sms_status: 'bounced' })
+
+    const result = await isCustomerSmsSendAllowed('cust-1', TO)
+
+    expect(result.allowed).toBe(false)
+  })
+
+  it('allows a normal active opted-in customer', async () => {
+    const result = await isCustomerSmsSendAllowed('cust-1', TO)
+    expect(result.allowed).toBe(true)
+  })
+})

--- a/src/lib/paypal-refund-webhook.ts
+++ b/src/lib/paypal-refund-webhook.ts
@@ -389,6 +389,26 @@ async function updateBookingRefundStatus(
     throw new Error(`Failed to update ${sourceType} refund status: ${updateError.message}`)
   }
 
+  // A table booking carries its own payment_status on the same row, and leaving it at
+  // 'completed' means a refunded booking still reads as paid to hasUnpaidRequiredDeposit
+  // and to the deposit-timeout cron. The parking branch below already reconciles its
+  // parent; table bookings were left out of the same fix here too.
+  if (sourceType === 'table_booking') {
+    const { error: paymentStatusError } = await (supabase.from('table_bookings') as any)
+      .update({
+        payment_status: refundStatusValue === 'refunded' ? 'refunded' : 'partial_refund',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', sourceId)
+
+    if (paymentStatusError) {
+      logger.error('Failed to reconcile table_bookings.payment_status after a refund', {
+        error: new Error(paymentStatusError.message),
+        metadata: { sourceId, refundStatusValue },
+      })
+    }
+  }
+
   // Also update the parent parking_bookings.payment_status when fully refunded
   if (sourceType === 'parking' && refundStatusValue === 'refunded') {
     const { data: paymentRow } = await supabase

--- a/src/lib/table-bookings/bookings.ts
+++ b/src/lib/table-bookings/bookings.ts
@@ -1470,7 +1470,9 @@ export async function sendTableBookingCancelledSmsIfAllowed(
     customerId: string
     bookingReference: string
     bookingDate: string // YYYY-MM-DD format
-    refundResult: { refunded: false; reason: string } | { refunded: true; amountPence: number; tier: string }
+    refundResult:
+      | { refunded: false; reason: string; depositOwed?: boolean; amountOwedPence?: number }
+      | { refunded: true; amountPence: number; tier: string }
     tableBookingId?: string
   }
 ): Promise<void> {
@@ -1501,15 +1503,29 @@ export async function sendTableBookingCancelledSmsIfAllowed(
 
     const firstName = getSmartFirstName(customer.first_name)
     let smsBody: string
-    if (params.refundResult.refunded) {
-      const amountGbp = new Intl.NumberFormat('en-GB', {
-        style: 'currency',
-        currency: 'GBP',
-      }).format(params.refundResult.amountPence / 100)
+    const formatGbp = (pence: number) =>
+      new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(pence / 100)
 
-      smsBody = `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. Your ${amountGbp} refund will land within 5-10 days. Hope to see you again soon!`
+    if (params.refundResult.refunded) {
+      const amountGbp = formatGbp(params.refundResult.amountPence)
+
+      // Name the half tier. Saying only "your £75 refund" to someone who paid £150 reads as a
+      // full refund of a £75 deposit, so the one number they can check looks wrong.
+      smsBody =
+        params.refundResult.tier === 'half'
+          ? `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. As it's within a week, half the deposit is refundable: your ${amountGbp} refund will land within 5-10 days.`
+          : `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. Your ${amountGbp} refund will land within 5-10 days. Hope to see you again soon!`
     } else if (params.refundResult.reason === 'zero_tier') {
       smsBody = `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. As it's within 3 days, the deposit can't be refunded. Hope to see you another time!`
+    } else if (params.refundResult.reason === 'refund_failed' || params.refundResult.depositOwed) {
+      // Never go quiet about money we still hold. Silence here is what made a failed refund
+      // indistinguishable from a booking that never had a deposit.
+      const owed = params.refundResult.amountOwedPence
+      smsBody = owed
+        ? `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. We couldn't process your ${formatGbp(owed)} deposit refund automatically, so we'll sort it by hand and be in touch.`
+        : `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. We couldn't process your deposit refund automatically, so we'll sort it by hand and be in touch.`
+    } else if (params.refundResult.reason === 'terms_unreadable') {
+      smsBody = `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. We'll check your deposit and be in touch about it shortly.`
     } else {
       smsBody = `The Anchor: ${firstName}, your booking on ${dateLabel} has been cancelled. Hope to see you again soon!`
     }

--- a/src/lib/table-bookings/cancel-notify.ts
+++ b/src/lib/table-bookings/cancel-notify.ts
@@ -1,0 +1,79 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { logAuditEvent } from '@/app/actions/audit'
+import { logger } from '@/lib/logger'
+
+import { sendTableBookingCancelledSmsIfAllowed } from './bookings'
+import { refundTableBookingDeposit, type RefundResult } from './refunds'
+
+/**
+ * Refund the deposit and tell the guest, for every staff cancellation path.
+ *
+ * All three cancel routes used to inline this inside a `try` whose `catch` only wrote to
+ * the console. Two things went wrong there and neither left a trace:
+ *
+ *  1. If the refund threw, the `await` for the SMS never ran, so a guest whose deposit had
+ *     just failed to return was not told their booking was cancelled at all.
+ *  2. Nothing recorded that money was still owed. The route returned `success: true` and
+ *     the only evidence was a console line in a serverless log.
+ *
+ * Now a refund failure is caught on its own, written to the audit log with `action_needed`,
+ * and still produces a message to the guest saying we will sort it by hand.
+ */
+export async function refundAndNotifyOnCancel(
+  supabase: SupabaseClient<any, 'public', any>,
+  params: {
+    bookingId: string
+    bookingReference: string
+    bookingDate: string
+    customerId: string
+    source: string
+  },
+): Promise<{ refundResult: RefundResult; notified: boolean }> {
+  const bookingDate = new Date(`${params.bookingDate}T12:00:00`)
+
+  let refundResult: RefundResult
+  try {
+    refundResult = await refundTableBookingDeposit(params.bookingId, bookingDate)
+  } catch (error) {
+    logger.error('Deposit refund threw during cancellation, so the guest may be owed money', {
+      error: error instanceof Error ? error : new Error(String(error)),
+      metadata: { bookingId: params.bookingId, source: params.source },
+    })
+    await logAuditEvent({
+      operation_type: 'table_booking.refund_failed_deposit_owed',
+      resource_type: 'table_booking',
+      resource_id: params.bookingId,
+      operation_status: 'failure',
+      error_message: error instanceof Error ? error.message : String(error),
+      additional_info: {
+        booking_reference: params.bookingReference,
+        source: params.source,
+        action_needed:
+          'Refund this guest manually: the booking was cancelled but the deposit refund threw',
+      },
+    }).catch(() => undefined)
+
+    // Carry on to the message. A guest whose refund failed is the one who most needs telling.
+    refundResult = { refunded: false, reason: 'refund_failed', depositOwed: true }
+  }
+
+  let notified = false
+  try {
+    await sendTableBookingCancelledSmsIfAllowed(supabase, {
+      customerId: params.customerId,
+      bookingReference: params.bookingReference,
+      bookingDate: params.bookingDate,
+      refundResult,
+      tableBookingId: params.bookingId,
+    })
+    notified = true
+  } catch (error) {
+    logger.error('Cancellation SMS failed after a booking was cancelled', {
+      error: error instanceof Error ? error : new Error(String(error)),
+      metadata: { bookingId: params.bookingId, source: params.source },
+    })
+  }
+
+  return { refundResult, notified }
+}

--- a/src/lib/table-bookings/cancellation-sms.test.ts
+++ b/src/lib/table-bookings/cancellation-sms.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * THE CANCELLATION TEXT MUST NEVER GO QUIET ABOUT A GUEST'S MONEY.
+ *
+ * Two failures lived in this one message:
+ *
+ *  1. A failed or skipped refund fell to the same generic sentence a deposit-free booking
+ *     gets, so a guest who had paid GBP 150 was told only "your booking has been cancelled.
+ *     Hope to see you again soon!" while the venue kept it.
+ *  2. The 50% tier had no wording of its own. Someone who paid GBP 150 and cancelled four
+ *     days out read "your GBP 75.00 refund" as a full refund of a GBP 75 deposit, so the one
+ *     number they could check looked wrong.
+ */
+
+const sendSMS = vi.fn().mockResolvedValue({ success: true })
+
+vi.mock('@/lib/twilio', () => ({ sendSMS: (...args: unknown[]) => sendSMS(...args) }))
+vi.mock('@/lib/sms/bulk', () => ({ getSmartFirstName: (n: string) => n }))
+vi.mock('@/lib/sms/support', () => ({ ensureReplyInstruction: (body: string) => body }))
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn(() => ({})) }))
+
+const { sendTableBookingCancelledSmsIfAllowed } = await import('./bookings')
+
+function fakeSupabase() {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: async () => ({
+            data: {
+              id: 'cust-1',
+              first_name: 'Sarah',
+              mobile_number: '+447700900123',
+              sms_status: 'active',
+            },
+            error: null,
+          }),
+        }),
+      }),
+    }),
+  } as never
+}
+
+async function sendWith(refundResult: Record<string, unknown>): Promise<string> {
+  await sendTableBookingCancelledSmsIfAllowed(fakeSupabase(), {
+    customerId: 'cust-1',
+    bookingReference: 'TB-TEST',
+    bookingDate: '2026-09-12',
+    refundResult: refundResult as never,
+  })
+  expect(sendSMS).toHaveBeenCalled()
+  return String(sendSMS.mock.calls.at(-1)?.[1] ?? '')
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('cancellation SMS', () => {
+  it('names the half tier so a partial refund does not read as a full one', async () => {
+    const body = await sendWith({ refunded: true, amountPence: 7500, tier: 'half' })
+    expect(body).toMatch(/£75\.00/)
+    expect(body).toMatch(/half the deposit/i)
+  })
+
+  it('keeps the plain wording for a full refund', async () => {
+    const body = await sendWith({ refunded: true, amountPence: 15000, tier: 'full' })
+    expect(body).toMatch(/£150\.00 refund will land/)
+    expect(body).not.toMatch(/half/i)
+  })
+
+  it('tells the guest when the refund failed, and names the amount owed', async () => {
+    const body = await sendWith({
+      refunded: false,
+      reason: 'refund_failed',
+      depositOwed: true,
+      amountOwedPence: 15000,
+    })
+    expect(body).toMatch(/£150\.00/)
+    expect(body).toMatch(/couldn't process/i)
+    expect(body).toMatch(/by hand|be in touch/i)
+  })
+
+  it('still says something about the deposit when the owed amount is unknown', async () => {
+    const body = await sendWith({ refunded: false, reason: 'refund_failed', depositOwed: true })
+    expect(body).toMatch(/deposit refund/i)
+    expect(body).toMatch(/be in touch/i)
+  })
+
+  it('promises a follow-up when the refund terms could not be read', async () => {
+    const body = await sendWith({ refunded: false, reason: 'terms_unreadable' })
+    expect(body).toMatch(/check your deposit/i)
+  })
+
+  it('keeps the existing non-refundable wording inside the cutoff', async () => {
+    const body = await sendWith({ refunded: false, reason: 'zero_tier' })
+    expect(body).toMatch(/within 3 days/i)
+    expect(body).toMatch(/can't be refunded/i)
+  })
+
+  it('uses the generic sentence only when there was genuinely no deposit', async () => {
+    const body = await sendWith({ refunded: false, reason: 'no_deposit' })
+    expect(body).toMatch(/has been cancelled\. Hope to see you again soon!/)
+    expect(body).not.toMatch(/deposit|refund/i)
+  })
+})

--- a/src/lib/table-bookings/manage-booking.ts
+++ b/src/lib/table-bookings/manage-booking.ts
@@ -3,6 +3,7 @@ import { createGuestToken, hashGuestToken } from '@/lib/guest/tokens'
 import { recordAnalyticsEvent } from '@/lib/analytics/events'
 import { logger } from '@/lib/logger'
 import { formatCancellationReason } from './cancellation-reasons'
+import { applyPartySizeDepositTransition } from './staff-deposit-transitions'
 
 export type TableManagePreviewResult = {
   state: 'ready' | 'blocked'
@@ -625,6 +626,49 @@ export async function updateTableBookingByRawToken(
       state: 'blocked',
       reason: 'booking_not_confirmed'
     }
+  }
+
+  /*
+   * Re-price the deposit, exactly as the staff party-size routes do.
+   *
+   * The guest manage link accepts party sizes up to the online maximum, so a guest could
+   * take a booking from six to twenty and cross the deposit threshold without ever being
+   * asked for one, and without anybody being told. The staff path has always called this;
+   * the guest path never did.
+   *
+   * A failure here must not fail the amendment: the size is already saved, and the
+   * transition raises its own manual-review state for cases a person has to decide.
+   */
+  try {
+    // Read the deposit state separately rather than widening the preview: that preview is
+    // serialised straight to the guest-facing page, and it must not start carrying the
+    // venue's internal payment state.
+    const { data: depositState } = await supabase
+      .from('table_bookings')
+      .select(
+        'id, customer_id, party_size, status, payment_status, booking_type, start_datetime, deposit_amount, deposit_amount_locked, deposit_waived, booking_period_id, booking_period_name',
+      )
+      .eq('id', bookingId)
+      .maybeSingle()
+
+    if (depositState) {
+      await applyPartySizeDepositTransition(supabase, {
+        booking: {
+          ...(depositState as Record<string, unknown>),
+          // The row now carries the NEW size; the transition needs the old one as its base.
+          party_size: oldPartySize,
+        } as Parameters<typeof applyPartySizeDepositTransition>[1]['booking'],
+        previousPartySize: oldPartySize,
+        newPartySize,
+        sendSms: true,
+        appBaseUrl: resolveAppBaseUrl(input.appBaseUrl),
+      })
+    }
+  } catch (depositError) {
+    logger.error('Guest party-size amendment saved but the deposit transition failed', {
+      error: depositError instanceof Error ? depositError : new Error(String(depositError)),
+      metadata: { bookingId, oldPartySize, newPartySize },
+    })
   }
 
   return {

--- a/src/lib/table-bookings/paypal-deposit.ts
+++ b/src/lib/table-bookings/paypal-deposit.ts
@@ -106,6 +106,12 @@ export function buildPayPalDepositCompletedUpdate(
     paypal_deposit_capture_id: input.captureId,
     deposit_amount_locked: input.lockedAmountGbp,
     card_capture_completed_at: capturedAtIso,
+    // `status` and `confirmed_at` are a pair, and nothing in the database keeps
+    // them together. This writer set the status and not the timestamp, so every
+    // PayPal-paid booking read as confirmed with a blank Confirmed time on the
+    // detail screen, permanently: the only other writer of confirmed_at is a
+    // cron that never looks at these rows.
+    confirmed_at: capturedAtIso,
     hold_expires_at: null,
   }
 }

--- a/src/lib/table-bookings/refunds.paypal.test.ts
+++ b/src/lib/table-bookings/refunds.paypal.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * CANCELLING A BOOKING MUST RETURN THE GUEST'S DEPOSIT, WHOEVER TOOK IT.
+ *
+ * Deposits moved from Stripe to PayPal. PayPal writes nothing to `payments`: the capture is
+ * recorded on the booking as `paypal_deposit_capture_id` + `deposit_amount_locked`. This
+ * function only ever read the Stripe ledger, so from that day it returned `no_deposit` for
+ * every real deposit, the money stayed with the venue, and because `no_deposit` is also what
+ * a deposit-free booking returns, the cancellation text said nothing about it at all.
+ *
+ * The last Stripe deposit was 2026-03-14. Everything since has been PayPal.
+ */
+
+const refundPayPalPayment = vi.fn()
+const logAuditEvent = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/lib/paypal', () => ({
+  PAYPAL_DEFAULT_CURRENCY: 'GBP',
+  refundPayPalPayment: (...args: unknown[]) => refundPayPalPayment(...args),
+}))
+vi.mock('@/lib/payments/stripe', () => ({ createStripeRefund: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/services/audit', () => ({
+  AuditService: { logAuditEvent: (...args: unknown[]) => logAuditEvent(...args) },
+}))
+
+type BookingRow = Record<string, unknown> | null
+
+let bookingRow: BookingRow
+let paymentRow: Record<string, unknown> | null
+const bookingUpdates: Record<string, unknown>[] = []
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    from: (table: string) => {
+      if (table === 'payments') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({ eq: () => ({ maybeSingle: async () => ({ data: paymentRow, error: null }) }) }),
+            }),
+          }),
+        }
+      }
+      // table_bookings
+      return {
+        select: () => ({
+          eq: () => ({ maybeSingle: async () => ({ data: bookingRow, error: null }) }),
+        }),
+        update: (values: Record<string, unknown>) => {
+          bookingUpdates.push(values)
+          return { eq: async () => ({ error: null }) }
+        },
+      }
+    },
+  }),
+}))
+
+const { refundTableBookingDeposit } = await import('./refunds')
+
+/** 30 days out, so the sliding tier is a full refund and the maths is unambiguous. */
+function farFutureDate(): Date {
+  const d = new Date()
+  d.setDate(d.getDate() + 30)
+  return d
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  bookingUpdates.length = 0
+  paymentRow = null
+  bookingRow = null
+  refundPayPalPayment.mockResolvedValue({
+    refundId: 'REF123',
+    status: 'COMPLETED',
+    amount: '150.00',
+    currency: 'GBP',
+  })
+})
+
+describe('refundTableBookingDeposit, PayPal deposits', () => {
+  it('refunds a PayPal deposit that has no Stripe payment row at all', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 150,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(refundPayPalPayment).toHaveBeenCalledTimes(1)
+    expect(refundPayPalPayment.mock.calls[0][0]).toBe('CAP-1')
+    expect(refundPayPalPayment.mock.calls[0][1]).toBe(150)
+    expect(result).toMatchObject({ refunded: true, amountPence: 15000, tier: 'full' })
+  })
+
+  it('reconciles payment_status as well as deposit_refund_status', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 150,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    // Leaving payment_status at 'completed' made a refunded booking still read as paid.
+    expect(bookingUpdates).toHaveLength(1)
+    expect(bookingUpdates[0]).toMatchObject({
+      deposit_refund_status: 'refunded',
+      payment_status: 'refunded',
+    })
+  })
+
+  it('uses a deterministic idempotency key so a retried cancellation cannot refund twice', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 150,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    await refundTableBookingDeposit('booking-1', farFutureDate())
+    await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(refundPayPalPayment.mock.calls[0][2]).toBe(refundPayPalPayment.mock.calls[1][2])
+  })
+
+  it('reports money owed, not "no deposit", when the PayPal refund fails', async () => {
+    refundPayPalPayment.mockRejectedValue(new Error('PayPal 422'))
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 150,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(result).toMatchObject({
+      refunded: false,
+      reason: 'refund_failed',
+      depositOwed: true,
+      amountOwedPence: 15000,
+    })
+    // A human has to know money is outstanding.
+    expect(logAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ operation_type: 'table_booking.refund_failed_deposit_owed' }),
+    )
+  })
+
+  it('still reports no_deposit for a booking that genuinely never paid one', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: null,
+      deposit_amount_locked: null,
+      deposit_amount: null,
+      payment_status: null,
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(result).toEqual({ refunded: false, reason: 'no_deposit' })
+    expect(refundPayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('does not refund twice when the deposit is already refunded', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 150,
+      deposit_amount: null,
+      payment_status: 'refunded',
+      deposit_refund_status: 'refunded',
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(result).toEqual({ refunded: false, reason: 'already_refunded' })
+    expect(refundPayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('honours a seasonal cutoff the guest was shown, over the sliding tier', async () => {
+    const bookingDate = new Date()
+    bookingDate.setDate(bookingDate.getDate() + 5)
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: 200,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: bookingDate.toISOString().slice(0, 10),
+      // Promised a full refund up to 14 days out; 5 days out is inside it, so nothing.
+      deposit_refund_cutoff_days: 14,
+      booking_period_code: 'XMAS',
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', bookingDate)
+
+    expect(result).toEqual({ refunded: false, reason: 'zero_tier' })
+    expect(refundPayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('treats a capture with an unreadable amount as money owed, not as no deposit', async () => {
+    bookingRow = {
+      paypal_deposit_capture_id: 'CAP-1',
+      deposit_amount_locked: null,
+      deposit_amount: null,
+      payment_status: 'completed',
+      deposit_refund_status: null,
+      booking_date: null,
+      deposit_refund_cutoff_days: null,
+      booking_period_code: null,
+    }
+
+    const result = await refundTableBookingDeposit('booking-1', farFutureDate())
+
+    expect(result).toMatchObject({ refunded: false, reason: 'refund_failed', depositOwed: true })
+  })
+})

--- a/src/lib/table-bookings/refunds.ts
+++ b/src/lib/table-bookings/refunds.ts
@@ -1,4 +1,5 @@
 import { createStripeRefund } from '@/lib/payments/stripe'
+import { PAYPAL_DEFAULT_CURRENCY, refundPayPalPayment } from '@/lib/paypal'
 import { createClient } from '@/lib/supabase/server'
 import { AuditService } from '@/services/audit'
 import { logger } from '@/lib/logger'
@@ -13,8 +14,16 @@ export type RefundResult =
       /**
        * `terms_unreadable` means the seasonal refund snapshot could not be read, so nothing was
        * refunded on purpose. It is a refusal, not a "no deposit found": a person has to look.
+       *
+       * `refund_failed` means a deposit WAS paid and we tried to return it and could not. It is the
+       * one reason that means money is owed, so it must never be reported to the guest as if no
+       * deposit existed.
        */
-      reason: 'no_deposit' | 'zero_tier' | 'already_refunded' | 'terms_unreadable'
+      reason: 'no_deposit' | 'zero_tier' | 'already_refunded' | 'terms_unreadable' | 'refund_failed'
+      /** True when the guest has money with us that this call did not return. */
+      depositOwed?: boolean
+      /** Pence still held, when known, so the caller can say so. */
+      amountOwedPence?: number
     }
   | { refunded: true; amountPence: number; refundId: string; tier: RefundTier }
 
@@ -37,9 +46,22 @@ function calculateRefundTier(bookingDate: Date): { percent: number; tier: Refund
 }
 
 /**
- * Issues a Stripe refund for a table booking deposit if one was paid.
- * Looks up the succeeded deposit payment, calculates the refund tier,
- * issues the refund via Stripe, and updates the payment record in the DB.
+ * Refunds a table booking deposit if one was paid, on whichever provider took it.
+ *
+ * WHY THIS READS TWO LEDGERS
+ *
+ * Deposits used to be taken by Stripe, which wrote a `payments` row carrying a
+ * `stripe_payment_intent_id`. They are now taken by PayPal, which writes nothing to
+ * `payments` at all: the capture is recorded on the booking itself, as
+ * `paypal_deposit_capture_id` plus `deposit_amount_locked`.
+ *
+ * This function only ever looked at the Stripe ledger, so from the day the flow moved it
+ * returned `no_deposit` for every real deposit. Cancelling a booking silently kept the
+ * guest's money, and because `no_deposit` is also what a genuinely deposit-free booking
+ * returns, the cancellation SMS told them nothing at all. The last Stripe deposit was
+ * 2026-03-14; everything since has been PayPal.
+ *
+ * The Stripe branch is kept for those historical rows, which can still be cancelled.
  *
  * amount in the payments table is stored in pounds (e.g. 70.00 for £70).
  * Stripe refund amounts are in pence (minor units).
@@ -58,7 +80,11 @@ export async function refundTableBookingDeposit(
     .eq('status', 'succeeded')
     .maybeSingle()
 
-  if (!payment?.stripe_payment_intent_id) return { refunded: false, reason: 'no_deposit' }
+  if (!payment?.stripe_payment_intent_id) {
+    // No Stripe deposit. Before concluding there is no deposit at all, check the
+    // ledger the money actually lives in now.
+    return await refundPayPalDeposit(supabase, tableBookingId, bookingDate)
+  }
   if (payment.status === 'refunded') return { refunded: false, reason: 'already_refunded' }
 
   // A booking that snapshotted a seasonal refund cutoff is governed by the promise the guest was
@@ -200,4 +226,204 @@ async function issueStripeRefund(
   }
 
   return { refunded: true, amountPence: refundAmountPence, refundId: stripeRefund.id, tier }
+}
+
+/* ------------------------------------------------------------------ */
+/*  PayPal deposits                                                     */
+/* ------------------------------------------------------------------ */
+
+type PayPalDepositBooking = {
+  paypal_deposit_capture_id: string | null
+  deposit_amount_locked: number | string | null
+  deposit_amount: number | string | null
+  payment_status: string | null
+  deposit_refund_status: string | null
+  booking_date: string | null
+  deposit_refund_cutoff_days: number | null
+  booking_period_code: string | null
+}
+
+function toGbp(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Refunds a deposit that PayPal took, using the same entitlement rules as the Stripe path.
+ *
+ * The money is recorded on the booking, not in `payments`, so that is what this reads. A
+ * failure here returns `refund_failed` with `depositOwed`, never `no_deposit`: the caller
+ * has to be able to tell "there was nothing to refund" apart from "we owe this guest money
+ * and could not send it", because those two produce very different messages to a customer.
+ */
+async function refundPayPalDeposit(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  tableBookingId: string,
+  bookingDate: Date,
+): Promise<RefundResult> {
+  const { data: booking, error: bookingError } = await supabase
+    .from('table_bookings')
+    .select(
+      'paypal_deposit_capture_id, deposit_amount_locked, deposit_amount, payment_status, deposit_refund_status, booking_date, deposit_refund_cutoff_days, booking_period_code',
+    )
+    .eq('id', tableBookingId)
+    .maybeSingle<PayPalDepositBooking>()
+
+  // Same fail-closed reasoning as the Stripe path: an unreadable booking is not evidence
+  // that no deposit was taken.
+  if (bookingError) {
+    logger.error('Could not read the booking to check for a PayPal deposit, so no refund was issued', {
+      metadata: { tableBookingId, error: bookingError.message },
+    })
+    return { refunded: false, reason: 'terms_unreadable' }
+  }
+
+  const captureId = booking?.paypal_deposit_capture_id
+  if (!captureId) return { refunded: false, reason: 'no_deposit' }
+
+  const depositGbp = toGbp(booking?.deposit_amount_locked) ?? toGbp(booking?.deposit_amount)
+  if (depositGbp === null || depositGbp <= 0) {
+    // A capture id with no amount is a broken record, not an absent deposit. Say so.
+    logger.error('Booking has a PayPal capture but no readable deposit amount, so no refund was issued', {
+      metadata: { tableBookingId, captureId },
+    })
+    return { refunded: false, reason: 'refund_failed', depositOwed: true }
+  }
+
+  const alreadyRefunded = booking?.deposit_refund_status === 'refunded'
+  if (alreadyRefunded) return { refunded: false, reason: 'already_refunded' }
+
+  // Entitlement: the seasonal promise the guest was shown wins over the sliding tier,
+  // exactly as on the Stripe path.
+  let refundGbp: number
+  let tier: RefundTier
+  const seasonalCutoff = booking?.deposit_refund_cutoff_days
+
+  if (seasonalCutoff !== null && seasonalCutoff !== undefined) {
+    const decision = resolveSeasonalDepositRefund({
+      bookingDate: booking?.booking_date ?? toLocalIsoDate(bookingDate),
+      refundCutoffDays: Number(seasonalCutoff),
+      depositAmount: depositGbp,
+    })
+    if (!decision.entitled) {
+      logger.info('Seasonal PayPal deposit not refunded: inside the window the guest was told about', {
+        metadata: {
+          tableBookingId,
+          bookingPeriodCode: booking?.booking_period_code ?? null,
+          daysBefore: decision.daysBefore,
+          cutoffDays: decision.cutoffDays,
+        },
+      })
+      return { refunded: false, reason: 'zero_tier' }
+    }
+    refundGbp = decision.amount
+    tier = 'full'
+  } else {
+    const { percent, tier: sliding } = calculateRefundTier(bookingDate)
+    if (percent === 0) return { refunded: false, reason: 'zero_tier' }
+    refundGbp = Math.round(depositGbp * percent) / 100
+    tier = sliding
+  }
+
+  if (refundGbp <= 0) return { refunded: false, reason: 'zero_tier' }
+
+  let refund: Awaited<ReturnType<typeof refundPayPalPayment>>
+  try {
+    refund = await refundPayPalPayment(
+      captureId,
+      refundGbp,
+      // Deterministic, so a retry of the same cancellation cannot refund twice.
+      `tbl-paypal-refund-${tableBookingId}-${tier}`,
+      PAYPAL_DEFAULT_CURRENCY,
+    )
+  } catch (error) {
+    // The guest's money is still with us and the caller is about to cancel their booking.
+    // Record it loudly and tell the caller money is owed.
+    logger.error('PayPal deposit refund failed, so the guest is owed money', {
+      error: error instanceof Error ? error : new Error(String(error)),
+      metadata: { tableBookingId, captureId, refundGbp, tier },
+    })
+    await AuditService.logAuditEvent({
+      operation_type: 'table_booking.refund_failed_deposit_owed',
+      resource_type: 'table_booking',
+      resource_id: tableBookingId,
+      operation_status: 'failure',
+      error_message: error instanceof Error ? error.message : String(error),
+      additional_info: {
+        paypal_capture_id: captureId,
+        amount_gbp: refundGbp,
+        tier,
+        action_needed: 'Refund this guest manually: the booking was cancelled but the deposit was not returned',
+      },
+    })
+    return {
+      refunded: false,
+      reason: 'refund_failed',
+      depositOwed: true,
+      amountOwedPence: Math.round(refundGbp * 100),
+    }
+  }
+
+  const isFull = Math.abs(refundGbp - depositGbp) < 0.005
+
+  /*
+   * Reconcile BOTH columns.
+   *
+   * `deposit_refund_status` alone was not enough: `payment_status` stayed `completed`, so a
+   * fully refunded booking still read as paid to `hasUnpaidRequiredDeposit` and to the
+   * deposit-timeout cron's `hasCapturedDeposit`. The parking flow already updates both; table
+   * bookings were left out of that same fix in two files.
+   */
+  const { error: updateError } = await supabase
+    .from('table_bookings')
+    .update({
+      deposit_refund_status: isFull ? 'refunded' : 'partially_refunded',
+      payment_status: isFull ? 'refunded' : 'partial_refund',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', tableBookingId)
+
+  if (updateError) {
+    // Money HAS gone back. Do not report failure to the caller, or a retry would refund
+    // again; record it for reconciliation instead.
+    logger.error('PayPal refund succeeded but the booking update failed, so manual reconciliation is required', {
+      metadata: { tableBookingId, captureId, refundId: refund.refundId, dbError: updateError.message },
+    })
+    await AuditService.logAuditEvent({
+      operation_type: 'table_booking.refund_paypal_success_db_failed',
+      resource_type: 'table_booking',
+      resource_id: tableBookingId,
+      operation_status: 'failure',
+      error_message: updateError.message,
+      additional_info: {
+        paypal_refund_id: refund.refundId,
+        paypal_capture_id: captureId,
+        amount_gbp: refundGbp,
+        tier,
+        action_needed: 'PayPal refund succeeded but the booking row was not updated',
+      },
+    })
+  }
+
+  await AuditService.logAuditEvent({
+    operation_type: 'table_booking.deposit_refunded',
+    resource_type: 'table_booking',
+    resource_id: tableBookingId,
+    operation_status: 'success',
+    additional_info: {
+      provider: 'paypal',
+      paypal_refund_id: refund.refundId,
+      paypal_capture_id: captureId,
+      amount_gbp: refundGbp,
+      tier,
+    },
+  })
+
+  return {
+    refunded: true,
+    amountPence: Math.round(refundGbp * 100),
+    refundId: refund.refundId,
+    tier,
+  }
 }

--- a/src/lib/twilio.ts
+++ b/src/lib/twilio.ts
@@ -196,12 +196,26 @@ export async function isCustomerSmsSendAllowed(
       return { allowed: false, reason: 'customer_phone_mismatch' };
     }
 
-    if (options?.allowTransactionalOverride === true) {
-      return { allowed: true };
-    }
-
+    /*
+     * An explicit STOP is never overridable.
+     *
+     * This check used to sit BELOW the transactional override, so any caller passing
+     * `allowTransactionalOverride` texted people who had replied STOP. A STOP reply sets
+     * both `sms_opt_in = false` and `sms_status = 'opted_out'` (see the Twilio inbound
+     * webhook), and honouring it is a legal obligation under PECR, not a preference. The
+     * override exists to bypass the softer `sms_status` gate for genuinely transactional
+     * messages, so it now sits between the two rather than above both.
+     */
     if ((customer as any).sms_opt_in === false) {
       return { allowed: false, reason: 'sms_opt_in_blocked' };
+    }
+
+    if ((customer as any).sms_status === 'opted_out') {
+      return { allowed: false, reason: 'sms_status_blocked' };
+    }
+
+    if (options?.allowTransactionalOverride === true) {
+      return { allowed: true };
     }
 
     if (customer.sms_status === null || customer.sms_status === 'active') {

--- a/tests/api/paypalEventBookingsWebhook.test.ts
+++ b/tests/api/paypalEventBookingsWebhook.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/paypal', () => ({
   verifyPayPalWebhook: vi.fn(),
+  // The route resolves the webhook id from PayPal by endpoint URL when no env var is set,
+  // so signature verification can never run against another endpoint's id.
+  resolveWebhookIdForUrl: vi.fn(async () => 'WEBHOOK-ID-FROM-PAYPAL'),
 }))
 
 vi.mock('@/lib/supabase/admin', () => ({

--- a/tests/api/paypalParkingWebhookFailClosed.test.ts
+++ b/tests/api/paypalParkingWebhookFailClosed.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/lib/paypal', () => ({
   verifyPayPalWebhook: vi.fn(),
+  // The route resolves the webhook id from PayPal by endpoint URL when no env var is set,
+  // so signature verification can never run against another endpoint's id.
+  resolveWebhookIdForUrl: vi.fn(async () => 'WEBHOOK-ID-FROM-PAYPAL'),
 }))
 
 vi.mock('@/lib/supabase/admin', () => ({

--- a/tests/lib/twilioSendGuards.test.ts
+++ b/tests/lib/twilioSendGuards.test.ts
@@ -153,7 +153,46 @@ describe('sendSMS customer safety guards', () => {
     expect(twilio as unknown as vi.Mock).not.toHaveBeenCalled()
   })
 
-  it('allows critical transactional sends when override is enabled', async () => {
+  /*
+   * EXPECTATION DELIBERATELY CHANGED, 2026-09-04.
+   *
+   * This test previously asserted that `allowTransactionalOverride` sent to a customer with
+   * `sms_opt_in: false` and `sms_status: 'opted_out'`, i.e. someone who had replied STOP.
+   * That was the bug, written down as a requirement: the Sunday lunch pre-order chase passes
+   * the override, so opted-out guests were still being texted. Honouring STOP is a legal
+   * obligation under PECR, not a preference, so the override no longer outranks it.
+   *
+   * The override still has a job, covered by the test below it: bypassing the softer
+   * `sms_status` gate for a genuinely transactional message.
+   */
+  it('never sends to an opted-out customer, even with the transactional override', async () => {
+    const create = vi.fn()
+    ;(twilio as unknown as vi.Mock).mockReturnValue({ messages: { create } })
+
+    mockCustomerLookup({
+      data: {
+        sms_status: 'opted_out',
+        sms_opt_in: false,
+        mobile_e164: '+447700900123',
+        mobile_number: '+447700900123',
+      },
+      error: null,
+    })
+
+    const result = await sendSMS('+447700900123', 'hello', {
+      customerId: 'customer-override',
+      createCustomerIfMissing: false,
+      skipSafetyGuards: true,
+      skipQuietHours: true,
+      skipMessageLogging: true,
+      allowTransactionalOverride: true,
+    })
+
+    expect(result).toEqual(expect.objectContaining({ success: false }))
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it('still lets the override bypass a non-active status that is not an opt-out', async () => {
     const create = vi.fn().mockResolvedValue({
       sid: 'SM-override',
       from: '+15555555555',
@@ -165,8 +204,8 @@ describe('sendSMS customer safety guards', () => {
 
     mockCustomerLookup({
       data: {
-        sms_status: 'opted_out',
-        sms_opt_in: false,
+        sms_status: 'bounced',
+        sms_opt_in: true,
         mobile_e164: '+447700900123',
         mobile_number: '+447700900123',
       },

--- a/vercel.json
+++ b/vercel.json
@@ -270,6 +270,10 @@
       "schedule": "0 * * * *"
     },
     {
+      "path": "/api/cron/table-booking-paypal-reconciliation",
+      "schedule": "50 * * * *"
+    },
+    {
       "path": "/api/cron/recruitment-reminders",
       "schedule": "0 * * * *"
     },


### PR DESCRIPTION
## What changed

A full read-only review of `/table-bookings` (six dimensions, checked against the live database and live PayPal account) found a chain of defects that could take a guest's deposit, cancel their booking, tell them nothing, and then destroy the record of the payment. This fixes that chain plus an SMS consent bug and several supporting issues.

**No database schema changes.** One new cron route and one `vercel.json` entry.

## Why

None of it has cost money yet, and I verified that: a 90-day PayPal reconciliation from both sides found every transaction accounted for. The exposure has been small because the deposit threshold moved from 10 to 15 guests on 9 August, so only one booking in three months has used the PayPal deposit flow.

**Christmas bookings take a deposit at any party size**, and the season has not started. Volume goes from roughly one deposit a quarter to many per week, each £60 to £200, all through the path below.

### The chain

1. Cancelling **never refunded a PayPal deposit**. `refunds.ts:61` returned early unless a Stripe payment intent existed; the last Stripe deposit was 2026-03-14.
2. The guest was then **told nothing**: `no_deposit` falls to the same sentence a deposit-free booking gets.
3. **Deleting** a cancelled booking cascaded across `payments`, `booking_holds`, `guest_tokens` and `booking_audit` with no payment guard, destroying the capture id needed to refund by hand.
4. There was **no safety net** when PayPal took the money and our write failed. The webhook endpoint was never registered with PayPal, and table bookings was the only money path with no reconciliation cron.
5. Three cancel paths cleared `paypal_deposit_order_id`, the pointer any recovery needs. The timeout cron had already learned this; the siblings had not.

## Assumptions and decisions

- **Reconciliation runs at :50**, ahead of the timeout cron at :00, so a recovered payment is recorded before the booking can be cancelled rather than un-cancelled afterwards.
- **A refund failure returns `refund_failed` with `depositOwed`**, never `no_deposit`. Those two produced an identical customer message and that was the bug.
- **`allowTransactionalOverride` no longer outranks an explicit STOP.** It still bypasses the softer `sms_status` gate, which is its purpose. An existing test asserted the old behaviour; it has been rewritten with the reason recorded inline. Flagging that explicitly, since changing a test's expectation deserves a reviewer's eye.
- The webhook id is now **resolved from PayPal by URL**. The configured id for table bookings pointed at a webhook that no longer existed, so every genuine event would have 401'd.

## Done outside this PR

I registered the table-bookings webhook with PayPal (`PAYMENT.CAPTURE.COMPLETED`, `DENIED`, `REFUNDED`) and removed the stale `PAYPAL_TABLE_BOOKINGS_WEBHOOK_ID` from Vercel, since it pointed at a dead webhook and would have won over the resolver.

## Testing done

- [x] Automated: 20 new tests across PayPal refunds, cancellation message wording, and SMS consent. Full suite **718 files / 6131 tests** passing.
- [x] Manual: 90-day reconciliation of every PayPal transaction against the database, from both directions. Live data checks confirmed the `payment_status` drift, the missing `confirmed_at` on all four PayPal-paid bookings, and six stale `booking_holds`.
- Environment: Node 20.19.5 as pinned, `NODE_OPTIONS=--max-old-space-size=8192`. Lint clean, `tsc --noEmit` clean, production build successful.

## Complexity score

L. Focused on one defect cluster plus directly adjacent siblings found by the mandated sibling sweep.

## Breaking changes

None for callers. Two staff-visible behaviour changes: deleting a cancelled booking with an unrefunded deposit now returns 409 with an explanation, and an opted-out customer no longer receives pre-order chase messages.

## Migration risk

None. No schema change. Rollback is a straight revert; the new cron becomes a 404 that Vercel logs and nothing depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
