### PR TITLE
feat: support date-specific rugby screening bookings

### DIFF
--- a/src/app/api/business/screening-hours/route.ts
+++ b/src/app/api/business/screening-hours/route.ts
@@ -1,0 +1,30 @@
+import type { NextRequest } from 'next/server'
+import { createApiResponse, createErrorResponse } from '@/lib/api/auth'
+import { applyDistributedRateLimit } from '@/lib/distributed-rate-limit'
+import { getScreeningHours, validateScreeningDates } from '@/lib/business-hours/screening-hours'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: NextRequest): Promise<Response> {
+  try {
+    const limited = await applyDistributedRateLimit(request, {
+      prefix: 'screening-hours', window: '1 m', localWindowMs: 60_000, max: 60,
+    })
+    if (limited) {
+      limited.headers.set('Cache-Control', 'no-store')
+      return limited
+    }
+    let dates: string[]
+    try {
+      const parameters = request.nextUrl.searchParams
+      if (parameters.getAll('dates').length !== 1) throw new Error('Provide dates once')
+      dates = validateScreeningDates((parameters.get('dates') ?? '').split(','))
+    } catch {
+      return createErrorResponse('Provide 1 to 31 real dates between today and 12 months ahead', 'VALIDATION_ERROR', 400, undefined, 'private')
+    }
+    return createApiResponse(await getScreeningHours(dates), 200, {}, 'GET', 'private')
+  } catch {
+    console.error('[Screening hours] Operating hours dependency unavailable')
+    return createErrorResponse('Operating hours are temporarily unavailable', 'HOURS_UNAVAILABLE', 503, undefined, 'private')
+  }
+}

--- a/src/app/api/table-bookings/route.ts
+++ b/src/app/api/table-bookings/route.ts
@@ -10,10 +10,11 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import {
   getIdempotencyKey,
   claimIdempotencyKey,
+  lookupIdempotencyKey,
   persistIdempotencyResponse,
   releaseIdempotencyClaim
 } from '@/lib/api/idempotency'
-import { computeTableBookingRequestHash } from '@/lib/table-bookings/booking-idempotency'
+import { computeTableBookingRequestHash, canonicalFixtureBookingNotes } from '@/lib/table-bookings/booking-idempotency'
 import { formatPhoneForStorage } from '@/lib/utils'
 import { ensureCustomerForPhone } from '@/lib/sms/customers'
 import { recordAnalyticsEvent } from '@/lib/analytics/events'
@@ -63,6 +64,7 @@ type SmsSafetyMeta = Awaited<ReturnType<typeof sendTableBookingCreatedSmsIfAllow
 type NotificationChannelMeta = TableBookingNotificationChannel
 
 const CreateTableBookingSchema = z.object({
+  fixture_id: z.string().uuid().optional(),
   phone: z.string().trim().min(7).max(32),
   first_name: z.string().trim().min(1).max(100).optional(),
   last_name: z.string().trim().max(100).optional(),
@@ -336,7 +338,15 @@ export async function POST(request: NextRequest) {
       return createErrorResponse('Invalid JSON body', 'VALIDATION_ERROR', 400)
     }
 
-    const parsed = CreateTableBookingSchema.safeParse(body)
+    const replayOnly = req.headers.get('X-Idempotency-Replay-Only') === 'true'
+    if (replayOnly && authState !== 'authenticated') {
+      return createErrorResponse('API key required for booking recovery', 'UNAUTHORIZED', 401)
+    }
+    // The envelope makes an older server reject a recovery probe before it can create a booking.
+    const candidate = replayOnly && body && typeof body === 'object' && 'replay_request' in body
+      ? (body as { replay_request: unknown }).replay_request
+      : replayOnly ? null : body
+    const parsed = CreateTableBookingSchema.safeParse(candidate)
     if (!parsed.success) {
       return createErrorResponse(
         parsed.error.issues[0]?.message || 'Invalid table booking payload',
@@ -347,6 +357,14 @@ export async function POST(request: NextRequest) {
     }
 
     const payload = parsed.data
+    if ((replayOnly || payload.fixture_id) && authState !== 'authenticated') {
+      return createErrorResponse('API key required for fixture booking recovery', 'UNAUTHORIZED', 401)
+    }
+    if (payload.fixture_id) {
+      try { canonicalFixtureBookingNotes(payload.fixture_id, payload.notes || '') } catch {
+        return createErrorResponse('Fixture notes do not match fixture ID', 'VALIDATION_ERROR', 400)
+      }
+    }
 
     let normalizedPhone: string
     try {
@@ -383,6 +401,7 @@ export async function POST(request: NextRequest) {
       party_size: payload.party_size,
       purpose: payload.purpose,
       notes: payload.notes,
+      fixture_id: payload.fixture_id,
       dietary_requirements: payload.dietary_requirements,
       allergies: payload.allergies,
       high_chair_count: payload.high_chair_count,
@@ -399,7 +418,16 @@ export async function POST(request: NextRequest) {
     })
 
     const supabase = createAdminClient()
-    const idempotencyState = await claimIdempotencyKey(supabase, idempotencyKey, requestHash)
+    const idempotencyState = replayOnly
+      ? await lookupIdempotencyKey(supabase, idempotencyKey, requestHash)
+      : await claimIdempotencyKey(supabase, idempotencyKey, requestHash)
+
+    if (idempotencyState.state === 'new' && replayOnly) {
+      return createErrorResponse('No previous booking attempt found', 'IDEMPOTENCY_KEY_NOT_FOUND', 404)
+    }
+    if (idempotencyState.state === 'replay' && (idempotencyState.response as { state?: string })?.state === 'processing') {
+      return createErrorResponse('This request is already being processed. Please retry shortly.', 'IDEMPOTENCY_KEY_IN_PROGRESS', 409)
+    }
 
     if (idempotencyState.state === 'conflict') {
       return createErrorResponse(

--- a/src/lib/business-hours/screening-contract.ts
+++ b/src/lib/business-hours/screening-contract.ts
@@ -1,0 +1,16 @@
+export type ServiceWindow = { startAt: string; endAt: string }
+export type ScreeningDayHours = {
+  date: string
+  state: 'open' | 'closed' | 'unknown'
+  regularOpensAt: string | null
+  bar: ServiceWindow | null
+  kitchen: ServiceWindow[]
+  kitchenState: 'known' | 'unknown'
+  hasSpecialHours: boolean
+  fingerprint: string
+}
+export type ScreeningHoursResponse = {
+  schemaVersion: 1
+  timezone: 'Europe/London'
+  days: ScreeningDayHours[]
+}

--- a/src/lib/business-hours/screening-hours.ts
+++ b/src/lib/business-hours/screening-hours.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'node:crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { loadPublishedVersions } from './effective'
+import { resolveForDates } from './resolve'
+import { resolveKitchenWindows } from './kitchen-windows'
+import { getTodayIsoDate, isValidIsoDate, parseLondonDateTimeLocalToIso, shiftIsoDate } from '@/lib/dateUtils'
+import type { BusinessHours, SpecialHours } from '@/types/business-hours'
+import type { ScreeningDayHours, ScreeningHoursResponse, ServiceWindow } from './screening-contract'
+
+type OperatingRow = Pick<BusinessHours, 'opens' | 'closes' | 'is_closed' | 'is_kitchen_closed' | 'kitchen_opens' | 'kitchen_closes' | 'schedule_config'>
+const CLOCK = /^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/
+
+export function validateScreeningDates(dates: string[], today = getTodayIsoDate()): string[] {
+  const unique = [...new Set(dates)].sort()
+  const [year, month, day] = today.split('-').map(Number)
+  const targetYear = year + 1
+  const lastDay = new Date(Date.UTC(targetYear, month, 0)).getUTCDate()
+  const latest = `${targetYear}-${String(month).padStart(2, '0')}-${String(Math.min(day, lastDay)).padStart(2, '0')}`
+  if (!unique.length || unique.length > 31 || dates.length > 100 || unique.some(date => !isValidIsoDate(date) || date < today || date > latest)) {
+    throw new Error('Provide 1 to 31 real dates between today and 12 months ahead')
+  }
+  return unique
+}
+
+function instant(date: string, time: string | null): string | null {
+  return time && CLOCK.test(time) ? parseLondonDateTimeLocalToIso(`${date}T${time}`) : null
+}
+
+function windowFor(date: string, opens: string | null, closes: string | null): ServiceWindow | null {
+  const startAt = instant(date, opens)
+  if (!startAt || !closes || !CLOCK.test(closes)) return null
+  // Closing in the small hours is the next calendar day, including DST changes.
+  const overnight = closes.slice(0, 5) <= opens!.slice(0, 5)
+  if (overnight && closes.slice(0, 5) > '06:00') return null
+  const endAt = instant(overnight ? shiftIsoDate(date, 1)! : date, closes)
+  return endAt && endAt > startAt ? { startAt, endAt } : null
+}
+
+/** Complete overrides: null kitchen bounds and empty sittings never inherit weekly values. */
+export function projectScreeningDay(date: string, regular: OperatingRow, special?: OperatingRow): ScreeningDayHours {
+  if (!isValidIsoDate(date)) throw new Error('Invalid operating date')
+  const row = special ?? regular
+  const bar = row.is_closed === true ? null : windowFor(date, row.opens, row.closes)
+  if (row.is_closed !== true && !bar) throw new Error('Opening hours are unknown')
+  const kitchenClosed = row.is_closed === true || row.is_kitchen_closed === true || (row.kitchen_opens === null && row.kitchen_closes === null)
+  const validBounds = windowFor(date, row.kitchen_opens, row.kitchen_closes)
+  const validSittings = row.schedule_config == null || (Array.isArray(row.schedule_config) && row.schedule_config.every(sitting => sitting && windowFor(date, sitting.starts_at, sitting.ends_at)))
+  const kitchenState = kitchenClosed || (validBounds && validSittings) ? 'known' : 'unknown'
+  const kitchen = kitchenClosed || kitchenState === 'unknown' ? [] : resolveKitchenWindows(row).flatMap(service => {
+    const window = windowFor(date, service.opens, service.closes)
+    if (!window || !bar) return []
+    const startAt = window.startAt > bar.startAt ? window.startAt : bar.startAt
+    const endAt = window.endAt < bar.endAt ? window.endAt : bar.endAt
+    return endAt > startAt ? [{ startAt, endAt }] : []
+  })
+  const projection: Omit<ScreeningDayHours, 'fingerprint'> = {
+    date,
+    state: row.is_closed ? 'closed' : 'open',
+    regularOpensAt: regular.is_closed ? null : instant(date, regular.opens),
+    bar,
+    kitchen,
+    kitchenState,
+    hasSpecialHours: Boolean(special),
+  }
+  return { ...projection, fingerprint: createHash('sha256').update(JSON.stringify(projection)).digest('hex') }
+}
+
+export async function getScreeningHours(dates: string[]): Promise<ScreeningHoursResponse> {
+  const requested = validateScreeningDates(dates)
+  const db = createAdminClient()
+  const versions = await loadPublishedVersions(db)
+  const regular = resolveForDates(versions, requested)
+  const { data: specials, error } = await db.from('special_hours')
+    .select('date, opens, closes, kitchen_opens, kitchen_closes, is_closed, is_kitchen_closed, schedule_config')
+    .in('date', requested)
+  if (error || !Array.isArray(specials)) throw new Error('Special hours could not be read')
+  const overrides = new Map<string, SpecialHours>()
+  for (const row of specials as SpecialHours[]) {
+    if (overrides.has(row.date)) throw new Error('Duplicate special hours')
+    overrides.set(row.date, row)
+  }
+  return {
+    schemaVersion: 1,
+    timezone: 'Europe/London',
+    days: requested.map(date => {
+      const row = regular.get(date)
+      if (!row) throw new Error('Published opening hours are missing')
+      return projectScreeningDay(date, row, overrides.get(date))
+    }),
+  }
+}

--- a/src/lib/table-bookings/booking-idempotency.test.ts
+++ b/src/lib/table-bookings/booking-idempotency.test.ts
@@ -166,3 +166,19 @@ describe('computeTableBookingRequestHash with a pre-order', () => {
     )
   })
 })
+
+describe('fixture booking intent', () => {
+  const fixture_id = '10000000-0000-4000-8000-000000000001'
+  const notes = `Nations Championship: Italy v South Africa [${fixture_id}]\nNear the screen`
+  const original = makeFields({ fixture_id, notes })
+  it('keeps the same hash after a trusted fixture label refresh', () => {
+    expect(computeTableBookingRequestHash({ ...original, notes: `Nations Championship: Updated teams [${fixture_id}]\nNear the screen` })).toBe(computeTableBookingRequestHash(original))
+    expect(computeTableBookingRequestHash({ ...original, notes: `Nations Championship: [${fixture_id}]\nNear the screen` })).toBe(computeTableBookingRequestHash(original))
+  })
+  it.each([{ date: '2026-11-08' }, { time: '13:00:00' }, { party_size: 5 }, { phone: '+447700900222' }, { first_name: 'Different' }, { notes: notes + ' please' }])('keeps changed customer intent conflicting: %p', changes => {
+    expect(computeTableBookingRequestHash({ ...original, ...changes })).not.toBe(computeTableBookingRequestHash(original))
+  })
+  it('does not normalise fixture labels without an explicit ID', () => {
+    expect(computeTableBookingRequestHash(makeFields({ notes }))).not.toBe(computeTableBookingRequestHash(makeFields({ notes: notes.replace('Italy', 'France') })))
+  })
+})

--- a/src/lib/table-bookings/booking-idempotency.ts
+++ b/src/lib/table-bookings/booking-idempotency.ts
@@ -17,6 +17,7 @@ export type TableBookingIdempotencyFields = {
   time: string
   party_size: number
   purpose: string
+  fixture_id?: string
   notes?: string | null
   dietary_requirements?: string[] | null
   allergies?: string[] | null
@@ -72,6 +73,13 @@ function preorderHashPayload(
  * field that changes what is booked varies the hash, so a retry with a changed
  * intent is a conflict rather than a silent replay of the earlier booking.
  */
+export function canonicalFixtureBookingNotes(fixtureId: string, notes: string): string {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(fixtureId)) throw new Error('Invalid fixture ID')
+  const [prefix, ...customerNotes] = notes.split('\n')
+  if (!prefix.startsWith('Nations Championship: ') || !prefix.endsWith(`[${fixtureId}]`)) throw new Error('Fixture notes do not match fixture ID')
+  return [`Nations Championship: [${fixtureId}]`, ...customerNotes].join('\n')
+}
+
 export function computeTableBookingRequestHash(fields: TableBookingIdempotencyFields): string {
   return computeIdempotencyRequestHash({
     phone: fields.phone,
@@ -82,7 +90,8 @@ export function computeTableBookingRequestHash(fields: TableBookingIdempotencyFi
     time: fields.time,
     party_size: fields.party_size,
     purpose: fields.purpose,
-    notes: fields.notes || null,
+    fixture_id: fields.fixture_id || undefined,
+    notes: fields.fixture_id ? canonicalFixtureBookingNotes(fields.fixture_id, fields.notes || '') : fields.notes || null,
     dietary_requirements: fields.dietary_requirements ?? null,
     allergies: fields.allergies ?? null,
     // Vary the idempotency key when the chair/outside request changes so a

--- a/tests/api/business/screening-hours.test.ts
+++ b/tests/api/business/screening-hours.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+const { query, load, limit } = vi.hoisted(() => ({ query: vi.fn(), load: vi.fn(), limit: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => ({ from: () => ({ select: () => ({ in: query }) }) }) }))
+vi.mock('@/lib/business-hours/effective', () => ({ loadPublishedVersions: load }))
+vi.mock('@/lib/distributed-rate-limit', () => ({ applyDistributedRateLimit: limit }))
+import { GET } from '@/app/api/business/screening-hours/route'
+const request = (params: string) => new NextRequest(`https://management.orangejelly.co.uk/api/business/screening-hours${params}`)
+beforeEach(() => {
+  vi.useFakeTimers(); vi.setSystemTime(new Date('2026-09-05T08:00:00Z'))
+  limit.mockReset().mockResolvedValue(null)
+  query.mockReset().mockResolvedValue({ data: [], error: null })
+  load.mockReset().mockResolvedValue([{ effectiveFrom: '2026-01-01', rows: [{ day_of_week: 6, opens: '12:00', closes: '23:00', kitchen_opens: null, kitchen_closes: null, is_closed: false }] }])
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks() })
+it('serves the real resolver through the exact GET with a no-store envelope', async () => {
+  const response = await GET(request('?dates=2026-11-07'))
+  expect(response.status).toBe(200)
+  expect(response.headers.get('Cache-Control')).toBe('no-store')
+  expect(response.headers.has('ETag')).toBe(false)
+  expect(await response.json()).toMatchObject({ success: true, data: { schemaVersion: 1, timezone: 'Europe/London', days: [{ date: '2026-11-07', state: 'open', bar: { startAt: '2026-11-07T12:00:00.000Z' } }] } })
+})
+it.each(['', '?dates=2026-02-30', '?dates=2026-09-04', '?dates=2028-01-01', '?dates=2026-11-07&dates=2026-11-08'])('rejects invalid request %s before hours reads', async params => {
+  const response = await GET(request(params))
+  expect(response.status).toBe(400)
+  expect(response.headers.get('Cache-Control')).toBe('no-store')
+  expect(load).not.toHaveBeenCalled()
+})
+it('returns 503 when exact-date exceptions fail, never weekly fallback', async () => {
+  query.mockRejectedValue(new Error('credentials must not be echoed'))
+  const response = await GET(request('?dates=2026-11-07'))
+  expect(response.status).toBe(503)
+  expect(response.headers.get('Cache-Control')).toBe('no-store')
+  expect(await response.json()).toMatchObject({ success: false, error: { code: 'HOURS_UNAVAILABLE' } })
+  expect(console.error).toHaveBeenCalledWith('[Screening hours] Operating hours dependency unavailable')
+})
+it('preserves the rate limiter response and does not query hours', async () => {
+  limit.mockResolvedValue(NextResponse.json({ error: 'Too many requests' }, { status: 429, headers: { 'Retry-After': '60' } }))
+  const response = await GET(request('?dates=2026-11-07'))
+  expect(response.status).toBe(429)
+  expect(response.headers.get('Retry-After')).toBe('60')
+  expect(response.headers.get('Cache-Control')).toBe('no-store')
+  expect(load).not.toHaveBeenCalled()
+})

--- a/tests/api/tableBookingStructuredPersistence.test.ts
+++ b/tests/api/tableBookingStructuredPersistence.test.ts
@@ -60,6 +60,7 @@ vi.mock('@/lib/api/auth', () => ({
 }))
 
 vi.mock('@/lib/api/idempotency', () => ({
+  lookupIdempotencyKey: vi.fn(),
   claimIdempotencyKey: vi.fn().mockResolvedValue({ state: 'claimed' }),
   computeIdempotencyRequestHash: vi.fn(() => 'hash'),
   getIdempotencyKey: vi.fn(() => 'idem-1'),
@@ -291,5 +292,51 @@ describe('POST /api/table-bookings — structured persistence', () => {
 
     expect(response.status).toBeLessThan(500)
     expect(saveSundayPreorderByBookingId).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('fixture replay-only booking recovery', () => {
+  const fixtureId = '10000000-0000-4000-8000-000000000001'
+  async function recover(state: unknown, fields = {}, replayHeader = true) {
+    const { lookupIdempotencyKey } = await import('@/lib/api/idempotency')
+    vi.mocked(lookupIdempotencyKey).mockResolvedValue(state as Awaited<ReturnType<typeof lookupIdempotencyKey>>)
+    const request = buildRequest({ replay_request: { phone: '+447000000000', date: '2026-11-07', time: '12:00', party_size: 2, purpose: 'food', fixture_id: fixtureId, notes: `Nations Championship: [${fixtureId}]\nNear the screen`, ...fields } })
+    if (replayHeader) request.headers.set('X-Idempotency-Replay-Only', 'true')
+    const supabase = buildSupabase()
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const response = await POST(request as Parameters<typeof POST>[0])
+    const { claimIdempotencyKey } = await import('@/lib/api/idempotency')
+    expect(claimIdempotencyKey).not.toHaveBeenCalled()
+    expect(ensureCustomerForPhone).not.toHaveBeenCalled()
+    expect(supabase.rpc).not.toHaveBeenCalled()
+    expect(supabase.from).not.toHaveBeenCalled()
+    return response
+  }
+  beforeEach(() => { vi.clearAllMocks() })
+  it('rejects the envelope as a normal creation request with zero writes', async () => {
+    expect((await recover({ state: 'new' }, {}, false)).status).toBe(400)
+  })
+  it('returns NOT_FOUND with zero claims or booking writes', async () => {
+    expect((await recover({ state: 'new' })).status).toBe(404)
+  })
+  it.each(['confirmed', 'pending_payment'])('returns stored %s response without creating', async state => {
+    const response = await recover({ state: 'replay', response: { success: true, data: { state, booking_reference: 'ORIGINAL' }, meta: { status_code: 201 } } })
+    expect(response.status).toBe(201)
+    expect(await response.json()).toMatchObject({ data: { state, booking_reference: 'ORIGINAL' } })
+  })
+  it('does not reclaim a processing request', async () => {
+    expect((await recover({ state: 'replay', response: { state: 'processing' } })).status).toBe(409)
+  })
+  it('does not disclose a different intent', async () => {
+    expect((await recover({ state: 'conflict' })).status).toBe(409)
+  })
+  it('requires an authenticated API key before replay', async () => {
+    const { getApiKeyAuthState } = await import('@/lib/api/auth')
+    vi.mocked(getApiKeyAuthState).mockResolvedValueOnce('anonymous')
+    expect((await recover({ state: 'replay', response: { data: { state: 'confirmed' } } })).status).toBe(401)
+  })
+  it('rejects notes belonging to another fixture', async () => {
+    expect((await recover({ state: 'new' }, { notes: 'Nations Championship: [10000000-0000-4000-8000-000000000002]' })).status).toBe(400)
   })
 })

--- a/tests/lib/business-hours/screening-hours.test.ts
+++ b/tests/lib/business-hours/screening-hours.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+const { db, query, load } = vi.hoisted(() => {
+  const query = vi.fn()
+  return { query, db: { from: vi.fn(() => ({ select: vi.fn(() => ({ in: query })) })) }, load: vi.fn() }
+})
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => db }))
+vi.mock('@/lib/business-hours/effective', () => ({ loadPublishedVersions: load }))
+import { getScreeningHours, projectScreeningDay, validateScreeningDates } from '@/lib/business-hours/screening-hours'
+
+const day = { day_of_week: 6, opens: '12:00', closes: '23:00', kitchen_opens: '12:00', kitchen_closes: '21:00', is_closed: false, is_kitchen_closed: false, schedule_config: null }
+const sitting = (starts_at: string, ends_at: string) => ({ name: 'service', starts_at, ends_at, capacity: 10, booking_type: 'regular' })
+beforeEach(() => {
+  vi.useFakeTimers(); vi.setSystemTime(new Date('2026-09-05T08:00:00Z'))
+  load.mockResolvedValue([{ effectiveFrom: '2026-01-01', rows: [day] }])
+  query.mockReset().mockResolvedValue({ data: [], error: null })
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe('strict screening hours', () => {
+  it('does not invent regular opening when exceptions cannot be read', async () => {
+    query.mockRejectedValue(new Error('database unavailable'))
+    await expect(getScreeningHours(['2026-11-07'])).rejects.toThrow()
+  })
+  it.each([{ data: null, error: null }, { data: [], error: { message: 'failed' } }])('rejects missing or failed exception reads', async result => {
+    query.mockResolvedValue(result)
+    await expect(getScreeningHours(['2026-11-07'])).rejects.toThrow()
+  })
+  it('uses complete existing special overrides without inheriting kitchen', async () => {
+    query.mockResolvedValue({ data: [{ ...day, date: '2026-11-07', opens: '15:00', kitchen_opens: null, kitchen_closes: null }], error: null })
+    const result = await getScreeningHours(['2026-11-07', '2026-11-07'])
+    expect(result.days).toHaveLength(1)
+    expect(result.days[0]).toMatchObject({ regularOpensAt: '2026-11-07T12:00:00.000Z', bar: { startAt: '2026-11-07T15:00:00.000Z' }, kitchen: [], kitchenState: 'known', hasSpecialHours: true })
+    expect(load).toHaveBeenCalledWith(db)
+    expect(query).toHaveBeenCalledWith('date', ['2026-11-07'])
+  })
+  it('honours future published versions and rejects absent weekdays', async () => {
+    load.mockResolvedValue([{ effectiveFrom: '2026-01-01', rows: [day] }, { effectiveFrom: '2026-11-01', rows: [{ ...day, opens: '14:00' }] }])
+    expect((await getScreeningHours(['2026-11-07'])).days[0].bar?.startAt).toBe('2026-11-07T14:00:00.000Z')
+    await expect(getScreeningHours(['2026-11-08'])).rejects.toThrow('missing')
+  })
+  it('preserves split kitchen gaps and empty sittings fallback', () => {
+    expect(projectScreeningDay('2026-11-07', { ...day, schedule_config: [sitting('12:00', '15:00'), sitting('16:00', '22:00')] }).kitchen).toEqual([
+      { startAt: '2026-11-07T12:00:00.000Z', endAt: '2026-11-07T15:00:00.000Z' },
+      { startAt: '2026-11-07T16:00:00.000Z', endAt: '2026-11-07T21:00:00.000Z' },
+    ])
+    expect(projectScreeningDay('2026-11-07', { ...day, schedule_config: [] }).kitchen).toHaveLength(1)
+  })
+  it('distinguishes closed pub, closed kitchen and unknown kitchen', () => {
+    expect(projectScreeningDay('2026-11-07', { ...day, is_closed: true })).toMatchObject({ state: 'closed', bar: null, kitchen: [] })
+    expect(projectScreeningDay('2026-11-07', { ...day, is_kitchen_closed: true })).toMatchObject({ state: 'open', kitchen: [], kitchenState: 'known' })
+    expect(projectScreeningDay('2026-11-07', { ...day, kitchen_closes: 'broken' })).toMatchObject({ state: 'open', kitchen: [], kitchenState: 'unknown' })
+    expect(() => projectScreeningDay('2026-11-07', { ...day, opens: null })).toThrow()
+  })
+  it('handles BST and overnight DST changes independently of host zone', () => {
+    expect(projectScreeningDay('2026-07-04', day).bar?.startAt).toBe('2026-07-04T11:00:00.000Z')
+    expect(projectScreeningDay('2026-10-24', { ...day, closes: '02:00' }).bar).toEqual({ startAt: '2026-10-24T11:00:00.000Z', endAt: '2026-10-25T02:00:00.000Z' })
+    expect(projectScreeningDay('2026-11-07', { ...day, opens: '20:00', closes: '02:00', kitchen_opens: '20:00', kitchen_closes: '01:00' }).kitchen[0].endAt).toBe('2026-11-08T01:00:00.000Z')
+  })
+  it('fingerprints operational facts, not retrieval time', () => {
+    const first = projectScreeningDay('2026-11-07', day)
+    vi.setSystemTime(new Date('2026-09-06T08:00:00Z'))
+    expect(projectScreeningDay('2026-11-07', day).fingerprint).toBe(first.fingerprint)
+    expect(projectScreeningDay('2026-11-07', { ...day, closes: '22:00' }).fingerprint).not.toBe(first.fingerprint)
+  })
+  it('runs in the requested host timezone', () => {
+    expect(process.env.TZ).toBe(process.env.SCREENING_TEST_TZ ?? 'Europe/London')
+  })
+  it('clamps leap days at the twelve-month horizon', () => {
+    expect(validateScreeningDates(['2025-02-28'], '2024-02-29')).toEqual(['2025-02-28'])
+    expect(() => validateScreeningDates(['2025-03-01'], '2024-02-29')).toThrow()
+    expect(validateScreeningDates(['2024-03-01'], '2023-03-01')).toEqual(['2024-03-01'])
+  })
+  it('validates real dates and bounded planning horizon', () => {
+    for (const dates of [[], ['2026-02-30'], ['2026-09-04'], ['2028-01-01']]) expect(() => validateScreeningDates(dates)).toThrow()
+    expect(() => validateScreeningDates(Array.from({ length: 32 }, (_, i) => i < 30 ? `2026-11-${String(i + 1).padStart(2, '0')}` : `2026-12-0${i - 29}`))).toThrow()
+    expect(validateScreeningDates(['2027-09-05'])).toEqual(['2027-09-05'])
+  })
+})

--- a/vitest.screening.config.ts
+++ b/vitest.screening.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+import base from './vitest.config'
+export default mergeConfig(base, defineConfig({
+  test: {
+    include: ['tests/lib/business-hours/screening-hours.test.ts', 'tests/api/business/screening-hours.test.ts'],
+    env: { TZ: process.env.SCREENING_TEST_TZ ?? 'Europe/London' },
+  },
+}))


### PR DESCRIPTION
## What changed
The Nations Championship page can read the pub's existing opening and kitchen hours for each match date. Booking recovery checks an existing attempt without creating another booking, including when the fixture name or screening status has changed after a lost response.

## Why
This supports game-specific table bookings on the paired Anchor website while keeping opening times unchanged and preventing duplicate bookings on retries. The paired website consumes the strict hours endpoint and sends the authenticated recovery envelope.

## Testing done
- Full local lint, clean type check, test suite and cold production build on Node 20.
- Focused hours tests under London and UTC, including special hours and unavailable data.
- Booking recovery tests cover missing keys, processing, conflicts, mutable team labels and ordinary booking hash compatibility.
- The paired website's isolated browser test completed a booking and recovered a lost response after cancellation with no second booking creation.

## Complexity score
M

## Breaking changes
None. Ordinary booking behaviour is preserved. Existing deployments reject the new recovery envelope before creating anything. The website rollout follows this release.

## Migration risk
None. No Management database migration or operating-hours change.
