### PR TITLE
fix: restore reliable cross-app booking conversion reads

### DIFF
--- a/scripts/security/harden-integration-keys.ts
+++ b/scripts/security/harden-integration-keys.ts
@@ -1,0 +1,65 @@
+/** One-off approved API key cleanup. Dry-run unless RUN_API_KEY_HARDENING_MUTATION=true. */
+import { config } from 'dotenv'
+import { createClient } from '@supabase/supabase-js'
+import { assertScriptMutationAllowed } from '../../src/lib/script-mutation-safety'
+
+config({ path: '.env.local' })
+const mutate = process.env.RUN_API_KEY_HARDENING_MUTATION === 'true'
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+const secret = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!url || !secret || new URL(url).hostname !== 'tfcasgxopxegwrabvwat.supabase.co') {
+  throw new Error('Expected verified Anchor management production project')
+}
+const db = createClient(url, secret, { auth: { persistSession: false, autoRefreshToken: false } })
+type KeyState = { id: string; name: string; permissions: string[]; is_active: boolean; last_used_at: string | null; updated_at: string | null }
+const targets = [
+  { id: 'f48a6a54-f8d9-4f32-a9e2-85f31b22968c', name: 'cheersai', expected: ['read:menu', 'read:events', 'payments:capture', 'read:events:artwork'], permissions: ['read:menu', 'read:events', 'read:events:artwork'] },
+  { id: 'bad66673-de96-4830-8264-8d2debe55576', name: 'Musi Bingo', expected: ['*'], permissions: ['read:events'] },
+  { id: '2dc1c9f1-082f-4077-baf8-d5bd2ea0f19b', name: 'Music Bingo App', expected: ['*'] },
+  { id: '3cf3f43f-0645-4212-803d-cee1f162309b', name: 'Development API Key', expected: ['read:events', 'read:menu', 'write:bookings', 'payments:capture'] },
+  { id: 'f4043546-bd4a-48eb-af38-06c466547a82', name: 'Development API Key', expected: ['read:events', 'read:menu', 'read:business', 'read:table_bookings', 'write:table_bookings', 'create:bookings', 'read:customers', 'write:customers', 'payments:capture'] },
+  { id: '1c80c23c-e765-4148-8d82-2a5d05a9e93e', name: 'Development API Key', expected: ['read:events', 'read:menu', 'write:bookings', 'payments:capture'] },
+]
+function same(a: string[], b: string[]): boolean { return JSON.stringify([...a].sort()) === JSON.stringify([...b].sort()) }
+async function main(): Promise<void> {
+  const { data, error } = await db.from('api_keys').select('id,name,permissions,is_active,last_used_at,updated_at').in('id', targets.map(t => t.id))
+  if (error || data?.length !== targets.length) throw new Error('Cannot verify all six API keys')
+  const plans = targets.map(target => {
+    const before = (data as KeyState[]).find(row => row.id === target.id)!
+    const after = { permissions: target.permissions ?? before.permissions, is_active: Boolean(target.permissions) }
+    if (before.name !== target.name) throw new Error('API key identity changed')
+    if (same(before.permissions, after.permissions) && before.is_active === after.is_active) return { before, after, skip: true }
+    if (!before.is_active || !same(before.permissions, target.expected)) throw new Error('API key state changed since approval')
+    if (!target.permissions && before.last_used_at && before.last_used_at >= '2026-01-01') throw new Error('Dormant API key has recent use; stop for review')
+    return { before, after, skip: false }
+  })
+  for (const plan of plans) {
+    process.stdout.write(JSON.stringify({ id: plan.before.id, name: plan.before.name, before: { permissions: plan.before.permissions, is_active: plan.before.is_active }, after: plan.after, mode: mutate ? 'apply' : 'dry-run', alreadyApplied: plan.skip }) + '\n')
+  }
+  if (!mutate) return
+  assertScriptMutationAllowed({ scriptName: 'harden-integration-keys', envVar: 'RUN_API_KEY_HARDENING_MUTATION' })
+  for (const { before, after, skip } of plans) {
+    if (skip) continue
+    let change = db.from('api_keys').update(after).eq('id', before.id).eq('permissions', JSON.stringify(before.permissions)).eq('is_active', before.is_active)
+    change = before.updated_at ? change.eq('updated_at', before.updated_at) : change.is('updated_at', null)
+    if (!after.is_active) change = before.last_used_at ? change.eq('last_used_at', before.last_used_at) : change.is('last_used_at', null)
+    const result = await change.select('id,permissions,is_active,updated_at').single()
+    if (result.error || !result.data) throw new Error(`Conditional API key update failed for ${before.id}`)
+    const audit = await db.from('audit_logs').insert({
+      operation_type: 'update', resource_type: 'api_key', resource_id: before.id, operation_status: 'success',
+      old_values: { permissions: before.permissions, is_active: before.is_active }, new_values: after,
+      additional_info: { source: 'harden-integration-keys', reason: 'Owner-approved API connection remediation, 2026-09-05' },
+    })
+    if (audit.error) {
+      let rollback = db.from('api_keys').update({ permissions: before.permissions, is_active: before.is_active }).eq('id', before.id).eq('permissions', JSON.stringify(after.permissions)).eq('is_active', after.is_active)
+      rollback = result.data.updated_at ? rollback.eq('updated_at', result.data.updated_at) : rollback.is('updated_at', null)
+      const restored = await rollback.select('id').single()
+      throw new Error(`Audit failed for ${before.id}; rollback ${restored.error ? 'FAILED, manual review required' : 'completed'}`)
+    }
+    process.stdout.write(`Updated and audited ${before.name} (${before.id})\n`)
+  }
+  const verified = await db.from('api_keys').select('id,permissions,is_active').in('id', targets.map(t => t.id))
+  if (verified.error || !plans.every(p => verified.data?.some(row => row.id === p.before.id && row.is_active === p.after.is_active && same(row.permissions, p.after.permissions)))) throw new Error('Post-change verification failed')
+  process.stdout.write('All six key settings verified. No key material changed.\n')
+}
+main().catch(error => { console.error(error instanceof Error ? error.message : 'API key cleanup failed'); process.exitCode = 1 })

--- a/src/app/api/marketing/event-booking-conversions/route.ts
+++ b/src/app/api/marketing/event-booking-conversions/route.ts
@@ -1,13 +1,22 @@
 import { NextRequest } from 'next/server'
 import { z } from 'zod'
 
-import { withApiAuth, createApiResponse, createErrorResponse } from '@/lib/api/auth'
+import { withApiAuth, createApiResponse, createErrorResponse, createCorsPreflightResponse } from '@/lib/api/auth'
 import { createAdminClient } from '@/lib/supabase/admin'
+import type { Database } from '@/types/database.generated'
 
 const QuerySchema = z.object({
-  event_ids: z.string().trim().min(1, 'event_ids is required'),
+  event_ids: z.string().transform((value) => value.split(',').map((id) => id.trim()))
+    .pipe(z.array(z.string().uuid('event_ids must contain valid UUIDs')).min(1).max(100))
+    .transform((ids) => [...new Set(ids)]),
   since: z.string().datetime().optional(),
 })
+
+// Seating is recorded by seated_at, not a booking status. Review transitions
+// must retain the completed visit as conversion evidence.
+const CONVERTED_STATUSES = [
+  'confirmed', 'completed', 'visited_waiting_for_review', 'review_clicked',
+] satisfies Database['public']['Enums']['table_booking_status'][]
 
 type BookingConversionRow = {
   id: string
@@ -32,25 +41,19 @@ export async function GET(request: NextRequest) {
         parsed.error.issues[0]?.message || 'Invalid query string',
         'VALIDATION_ERROR',
         400,
-        { issues: parsed.error.issues }
+        { issues: parsed.error.issues },
+        'private'
       )
     }
 
     const eventIds = parsed.data.event_ids
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean)
-
-    if (eventIds.length === 0 || eventIds.length > 100) {
-      return createErrorResponse('event_ids must contain 1 to 100 ids', 'VALIDATION_ERROR', 400)
-    }
 
     const supabase = createAdminClient()
     let query = supabase
       .from('table_bookings')
       .select('id, event_id, event_booking_id, party_size, status, source, created_at')
       .in('event_id', eventIds)
-      .in('status', ['confirmed', 'seated', 'completed'])
+      .in('status', CONVERTED_STATUSES)
       .order('created_at', { ascending: true })
 
     if (parsed.data.since) {
@@ -60,7 +63,8 @@ export async function GET(request: NextRequest) {
     const { data, error } = await query
 
     if (error) {
-      return createErrorResponse('Failed to load event booking conversions', 'DATABASE_ERROR', 500)
+      console.error('[marketing-conversions] Booking query failed', { code: error.code })
+      return createErrorResponse('Failed to load event booking conversions', 'DATABASE_ERROR', 500, undefined, 'private')
     }
 
     const conversions = ((data ?? []) as BookingConversionRow[])
@@ -78,10 +82,10 @@ export async function GET(request: NextRequest) {
     return createApiResponse({
       conversions,
       count: conversions.length,
-    })
-  }, ['read:events'], request)
+    }, 200, {}, 'GET', 'private')
+  }, ['read:events'], request, { cacheMode: 'private' })
 }
 
-export async function OPTIONS() {
-  return createApiResponse({}, 200)
+export async function OPTIONS(request: NextRequest) {
+  return createCorsPreflightResponse({ request, methods: 'GET, OPTIONS' })
 }

--- a/tasks/fix-function/2026-09-05-api-connections/base-commit.txt
+++ b/tasks/fix-function/2026-09-05-api-connections/base-commit.txt
@@ -1,0 +1,5 @@
+{
+  "source": "/Users/peterpitcher/Cursor/OJ-AnchorManagementTools",
+  "base_commit": "759f1471357ae3a7d5e5b59f51bc4593e8aba2c8",
+  "dirty": " M src/app/api/cron/oj-projects-billing/route.ts\n M tasks/todo.md\n?? docs/design/brief-orange-jelly.md\n?? docs/design/brief-the-anchor.md\n?? docs/design/pdf-branding-audit.md\n?? docs/design/pdf-house-style-brief.md\n?? docs/design/sample-pack.zip\n?? docs/design/sample-pack/\n?? scripts/design/\n?? src/lib/invoices/__tests__/delivery-state.test.ts\n?? src/lib/invoices/delivery-state.ts\n?? src/lib/oj-projects/__tests__/billing-run-guard.test.ts\n?? src/lib/oj-projects/billing-run-guard.ts\n?? tasks/plan-2026-09-05-anchor-booking-growth.md\n?? tasks/seo-powerhouse/\n"
+}

--- a/tasks/fix-function/2026-09-05-api-connections/defect-log.md
+++ b/tasks/fix-function/2026-09-05-api-connections/defect-log.md
@@ -1,0 +1,18 @@
+# Defects
+
+| ID | Type / severity / confidence | Evidence and impact | Root cause / sibling check | Fix / approval | Acceptance / status |
+|---|---|---|---|---|---|
+| FF-001 | Bug / High / High | Live conversion GET 500, SQL 22P02 | Invalid seated enum; review statuses also excluded. Checked marketing callers and event engagement transitions. | Typed valid conversion statuses, approved | 11 route regressions passed; deploy GET pending |
+| FF-002 | Data risk / Medium / High | Booking IDs emitted with public cache policy | Generic public response default; checked guarded error responses | Private no-store response and guard, approved | Real response/guard cache-header regressions passed |
+| FF-003 | Validation / Medium / High | Arbitrary event IDs passed to UUID database filter | Only non-empty string validation | UUID list/date validation, approved | Malformed UUID/list/date regressions passed |
+| FF-004 | Security / Medium / High | Production api_keys inventory | Broad and dormant credentials; match deployed consumers | Least scopes and revoke confirmed dormant credentials, approved | Applied six settings updates and six audit records; scoped Music Bingo events and Cheers events/specials/artwork return 200 |
+
+## Verification
+
+- Lint and non-incremental typecheck passed.
+- Full coverage suite passed: 720 files, 6,185 tests passed, 2 skipped. Coverage: lines 51.35%, branches 42.44%, functions 60.8%, statements 52.84%, above required floors.
+- Clean Next.js production build passed, using non-production placeholder credentials and communication suspension flags.
+- API key script dry-run inspected all six expected identities and scopes before application. Conditional updates prevented overwriting concurrent changes, including renewed use of dormant credentials. Post-change reads verified every state and all six audit entries. Repeated dry-run detects all six as already applied.
+- Deployed Music Bingo token matched the configured local token without printing either. Both brands' live overrides were checked; neither uses the dormant duplicate. Cheers required read scopes remain intact.
+- Deliberately left unchanged: active website key, separate Website integration key used in August, already revoked test keys, booking/payment writes, database schema and Quiz/Cash apps. No migration required.
+- One focused sibling review covered event status transitions, invalid input, response caching and conversion consumer validation. Final production verification is recorded separately after deployment.

--- a/tasks/fix-function/2026-09-05-api-connections/discovery.md
+++ b/tasks/fix-function/2026-09-05-api-connections/discovery.md
@@ -1,0 +1,9 @@
+# API connection remediation
+
+Four independently deployable changes cover Management, Website, CheersAI and Music Bingo. Quiz Night and Cash Bingo remain standalone by design. Complexity: L across repositories, M or smaller per repository.
+
+Production proof: marketing conversion GET returned 500. The live table_booking_status enum rejects seated (22P02). Review lifecycle statuses represent completed visits and must remain conversion evidence. Booking identifiers must not enter shared caches. Malformed UUIDs must return 400 before database access.
+
+Live API keys: CheersAI has unused payments:capture; Music Bingo feed needs only read:events. Three old development keys and a never-used Music Bingo key remain active. Verify current production consumers before reducing scopes or deactivating dormant credentials. No schema migration required for application fixes.
+
+Original checkout and dirty paths are recorded in base-commit.txt. No original checkout files are edited.

--- a/tasks/fix-function/2026-09-05-api-connections/todo.md
+++ b/tasks/fix-function/2026-09-05-api-connections/todo.md
@@ -1,0 +1,9 @@
+# Remediation plan
+
+- [x] Record baselines and verify production failure.
+- [x] Trace conversion query, lifecycle siblings and cache/validation paths.
+- [x] Fix and run targeted tests.
+- [x] Verify current key consumers and apply least permissions.
+- [x] Run lint, typecheck, tests and clean build.
+- [x] Review parallel changes and rediscover related issues.
+- [ ] Commit, merge, push, verify production and tidy task branches.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -165,3 +165,7 @@ social links are corrected. Its information page still shows
 the current owner session. Its support request is prepared and awaits the visible
 reCAPTCHA and Submit. Bing remains locked pending verification. Paid placements
 remain excluded.
+
+## API connections, 5 September 2026
+
+See `tasks/fix-function/2026-09-05-api-connections/todo.md` for the isolated remediation run, verified fixes and production rollout.

--- a/tests/api/marketingEventBookingConversionsRoute.test.ts
+++ b/tests/api/marketingEventBookingConversionsRoute.test.ts
@@ -1,71 +1,97 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { Constants } from '@/types/database.generated'
 
 const fromMock = vi.fn()
+const result: { data: unknown[] | null; error: { code: string } | null } = { data: [], error: null }
+const gteMock = vi.fn(() => Promise.resolve(result))
+const orderMock = vi.fn(() => ({ ...result, gte: gteMock }))
+const statusMock = vi.fn((column: string, statuses: string[]) => {
+  for (const status of statuses) {
+    if (!(Constants.public.Enums.table_booking_status as readonly string[]).includes(status)) {
+      throw new Error(`Invalid live booking status: ${status}`)
+    }
+  }
+  return { order: orderMock }
+})
+const idsMock = vi.fn(() => ({ in: statusMock }))
 
-vi.mock('@/lib/supabase/admin', () => ({
-  createAdminClient: () => ({
-    from: fromMock,
-  }),
-}))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => ({ from: fromMock }) }))
+vi.mock('@/lib/api/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api/auth')>()
+  return {
+    ...actual,
+    withApiAuth: vi.fn((handler: (request: Request) => Promise<Response>, _permissions: string[], request: Request) => handler(request)),
+  }
+})
 
-vi.mock('@/lib/api/auth', () => ({
-  withApiAuth: vi.fn((handler: (request: Request, apiKey: unknown) => Promise<Response>, permissions: string[], request: Request) => {
-    return handler(request, { id: 'api-key-1', permissions })
-  }),
-  createApiResponse: (data: unknown, status = 200) =>
-    Response.json({ success: true, data }, { status }),
-  createErrorResponse: (message: string, code: string, status = 400, details?: unknown) =>
-    Response.json({ success: false, error: { message, code, details } }, { status }),
-}))
+import { withApiAuth } from '@/lib/api/auth'
+import { GET, OPTIONS } from '@/app/api/marketing/event-booking-conversions/route'
 
-import { GET } from '@/app/api/marketing/event-booking-conversions/route'
+const eventId = '5cdadf74-97c1-4ec0-b495-d369a7304494'
+const booking = {
+  id: 'table-booking-1', event_id: eventId, event_booking_id: 'booking-1',
+  party_size: 4, status: 'confirmed', source: 'brand_site', created_at: '2026-05-04T12:00:00.000Z',
+}
+function request(query = `event_ids=${eventId}&since=2026-05-01T00:00:00.000Z`) {
+  return new NextRequest(`https://management.example.com/api/marketing/event-booking-conversions?${query}`)
+}
 
 describe('GET /api/marketing/event-booking-conversions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    result.data = [booking]
+    result.error = null
+    fromMock.mockReturnValue({ select: vi.fn(() => ({ in: idsMock })) })
   })
 
-  it('returns confirmed table bookings as marketing conversion truth', async () => {
-    const gteMock = vi.fn().mockResolvedValue({
-      data: [
-        {
-          id: 'table-booking-1',
-          event_id: 'event-1',
-          event_booking_id: 'booking-1',
-          party_size: 4,
-          status: 'confirmed',
-          source: 'brand_site',
-          created_at: '2026-05-04T12:00:00.000Z',
-        },
-      ],
-      error: null,
-    })
-    const orderMock = vi.fn().mockReturnValue({ gte: gteMock })
-    const secondInMock = vi.fn().mockReturnValue({ order: orderMock })
-    const firstInMock = vi.fn().mockReturnValue({ in: secondInMock })
-    const selectMock = vi.fn().mockReturnValue({ in: firstInMock })
-    fromMock.mockReturnValue({ select: selectMock })
-
-    const response = await GET(new Request(
-      'https://management.example.com/api/marketing/event-booking-conversions?event_ids=event-1&since=2026-05-01T00:00:00.000Z'
-    ) as any)
+  it('returns booking evidence with valid database statuses including completed review journeys', async () => {
+    const response = await GET(request())
     const payload = await response.json()
-
     expect(response.status).toBe(200)
-    expect(fromMock).toHaveBeenCalledWith('table_bookings')
-    expect(firstInMock).toHaveBeenCalledWith('event_id', ['event-1'])
-    expect(secondInMock).toHaveBeenCalledWith('status', ['confirmed', 'seated', 'completed'])
+    expect(idsMock).toHaveBeenCalledWith('event_id', [eventId])
+    expect(statusMock).toHaveBeenCalledWith('status', ['confirmed', 'completed', 'visited_waiting_for_review', 'review_clicked'])
     expect(gteMock).toHaveBeenCalledWith('created_at', '2026-05-01T00:00:00.000Z')
-    expect(payload.data.conversions).toEqual([
-      {
-        booking_id: 'booking-1',
-        table_booking_id: 'table-booking-1',
-        event_id: 'event-1',
-        booking_type: 'event',
-        tickets: 4,
-        source: 'brand_site',
-        occurred_at: '2026-05-04T12:00:00.000Z',
-      },
-    ])
+    expect(payload.data.conversions).toEqual([{
+      booking_id: 'booking-1', table_booking_id: booking.id, event_id: eventId,
+      booking_type: 'event', tickets: 4, source: 'brand_site', occurred_at: booking.created_at,
+    }])
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    expect(response.headers.has('ETag')).toBe(false)
+    expect(withApiAuth).toHaveBeenCalledWith(expect.any(Function), ['read:events'], expect.any(Request), { cacheMode: 'private' })
+  })
+
+  it('returns an empty success when there are no qualifying bookings, including without since', async () => {
+    result.data = []
+    const response = await GET(request(`event_ids=${eventId}`))
+    expect(await response.json()).toEqual({ success: true, data: { conversions: [], count: 0 } })
+  })
+
+  it('deduplicates valid event IDs', async () => {
+    await GET(request(`event_ids=${eventId},${eventId}`))
+    expect(idsMock).toHaveBeenCalledWith('event_id', [eventId])
+  })
+
+  it.each(['', 'event_ids=', 'event_ids=not-a-uuid', `event_ids=${eventId},`, `event_ids=${Array(101).fill(eventId).join(',')}`, `event_ids=${eventId}&since=bad-date`])(
+    'rejects malformed inputs before querying: %s', async (query) => {
+      const response = await GET(request(query))
+      expect(response.status).toBe(400)
+      expect(fromMock).not.toHaveBeenCalled()
+      expect(response.headers.get('Cache-Control')).toBe('no-store')
+    },
+  )
+
+  it('reports database failure instead of successful zero conversions', async () => {
+    result.data = null
+    result.error = { code: '22P02' }
+    const response = await GET(request())
+    expect(response.status).toBe(500)
+    expect((await response.json()).error.code).toBe('DATABASE_ERROR')
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('advertises only supported methods in preflight', async () => {
+    const response = await OPTIONS(request())
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET, OPTIONS')
   })
 })


### PR DESCRIPTION
The booking conversion API returned HTTP 500 because it queried a status absent from the live database. It now uses valid confirmed/completed lifecycle states, validates event IDs before querying and keeps booking identifiers out of shared caches.

Includes the guarded operational key-cleanup script already run with owner approval: removed unused payment access from CheersAI, limited Music Bingo to event reads and disabled four dormant keys. All six changes have audit records and post-change verification. No schema migration.

Validation: lint, non-incremental typecheck, 720 test files (6,185 passed, 2 skipped), coverage above all floors, and a clean production build. Scoped live consumer reads still return 200. Production conversion smoke check follows deployment. Complexity M, backwards-compatible response shape; malformed IDs now return 400 instead of database failure.
