### PR TITLE
feat: retain event requests and Christmas course choices

### DIFF
--- a/src/app/(authenticated)/table-bookings/[id]/BookingDetailClient.tsx
+++ b/src/app/(authenticated)/table-bookings/[id]/BookingDetailClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ChristmasCourseFields } from '@/components/features/table-bookings/ChristmasCourseFields'
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import toast from 'react-hot-toast'
@@ -384,6 +385,7 @@ export default function BookingDetailClient({ booking, canEdit, canManage, canRe
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [partySizeEditOpen, setPartySizeEditOpen] = useState(false)
+  const [christmasCourseCounts, setChristmasCourseCounts] = useState<number[] | undefined>(undefined)
   const [partySizeEditValue, setPartySizeEditValue] = useState('')
   const [partySizeEditSendSms, setPartySizeEditSendSms] = useState(true)
   const [partySizeMoveTableId, setPartySizeMoveTableId] = useState('')
@@ -715,6 +717,7 @@ export default function BookingDetailClient({ booking, canEdit, canManage, canRe
         }>(`/api/boh/table-bookings/${booking.id}/party-size`, {
           body: {
             party_size: nextSize,
+            christmas_course_counts: christmasCourseCounts,
             send_sms: partySizeEditSendSms,
             ...(selectedMoveTable
               ? {
@@ -1537,6 +1540,7 @@ export default function BookingDetailClient({ booking, canEdit, canManage, canRe
               className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-200"
             />
           </div>
+          <ChristmasCourseFields bookingId={booking.id} partySize={Number(partySizeEditValue)} onChange={setChristmasCourseCounts} />
           {partySizeNeedsLargerTable && (
             <div className="rounded-md border border-amber-200 bg-amber-50 p-3">
               <p className="text-sm text-amber-900">

--- a/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx
@@ -65,6 +65,7 @@ export function FohScheduleClient({
   const [showCancelBookingConfirmation, setShowCancelBookingConfirmation] = useState(false)
   const [showNoShowConfirmation, setShowNoShowConfirmation] = useState(false)
   const [partySizeEditOpen, setPartySizeEditOpen] = useState(false)
+  const [christmasCourseCounts, setChristmasCourseCounts] = useState<number[] | undefined>(undefined)
   const [partySizeEditValue, setPartySizeEditValue] = useState('')
   const [partySizeEditBookingId, setPartySizeEditBookingId] = useState<string | null>(null)
   const [changeTimeOpen, setChangeTimeOpen] = useState(false)
@@ -564,6 +565,8 @@ export function FohScheduleClient({
       />
 
       <FohPartySizeModal
+        bookingId={partySizeEditBookingId}
+        onCoursesChange={setChristmasCourseCounts}
         open={partySizeEditOpen}
         bookingActionInFlight={bookingActionInFlight}
         partySizeEditValue={partySizeEditValue}
@@ -576,7 +579,7 @@ export function FohScheduleClient({
           if (!bid) return
           setPartySizeEditOpen(false)
           void (async () => {
-            const ok = await runAction(() => postBookingAction(`/api/foh/bookings/${bid}/party-size`, { party_size: nextSize, send_sms: true }), 'Party size updated', 'party_size')
+            const ok = await runAction(() => postBookingAction(`/api/foh/bookings/${bid}/party-size`, { party_size: nextSize, send_sms: true, christmas_course_counts: christmasCourseCounts }), 'Party size updated', 'party_size')
             if (ok) closeBookingDetails()
           })()
         }}

--- a/src/app/(authenticated)/table-bookings/foh/components/FohMiniModals.tsx
+++ b/src/app/(authenticated)/table-bookings/foh/components/FohMiniModals.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import React from 'react'
+import { ChristmasCourseFields } from '@/components/features/table-bookings/ChristmasCourseFields'
 import { Modal, ModalActions } from '@/ds'
 
 type FohPartySizeModalProps = {
+  bookingId?: string | null
+  onCoursesChange?: (counts: number[] | undefined) => void
   open: boolean
   bookingActionInFlight: string | null
   partySizeEditValue: string
@@ -62,6 +65,7 @@ export const FohPartySizeModal = React.memo(function FohPartySizeModal(props: Fo
           autoFocus
         />
       </label>
+      {open && props.bookingId && props.onCoursesChange ? <ChristmasCourseFields bookingId={props.bookingId} partySize={Number(partySizeEditValue)} onChange={props.onCoursesChange} /> : null}
     </Modal>
   )
 })

--- a/src/app/api/boh/table-bookings/[id]/party-size/route.ts
+++ b/src/app/api/boh/table-bookings/[id]/party-size/route.ts
@@ -5,6 +5,7 @@ import { requireBohTableBookingPermission } from '@/lib/foh/api-auth'
 import { logger } from '@/lib/logger'
 import {
   PartySizeUpdateFailedAfterMoveError,
+  ChristmasCourseValidationError,
   mapSeatUpdateBlockedReason,
   updateTableBookingPartySizeWithLinkedEventSeats
 } from '@/lib/events/staff-seat-updates'
@@ -20,6 +21,7 @@ import {
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 const UpdatePartySizeSchema = z.object({
+  christmas_course_counts: z.array(z.number().int().min(1).max(3)).min(6).max(20).optional(),
   party_size: z.preprocess(
     (value) => (typeof value === 'string' ? Number.parseInt(value, 10) : value),
     z.number().int().min(1).max(20)
@@ -82,6 +84,7 @@ export async function POST(
     const result = await updateTableBookingPartySizeWithLinkedEventSeats(auth.supabase, {
       tableBookingId: id,
       partySize: newPartySize,
+      christmasCourseCounts: parsed.data.christmas_course_counts,
       actor: 'boh',
       sendSms: parsed.data.send_sms,
       appBaseUrl,
@@ -199,6 +202,7 @@ export async function POST(
       smsSent: depositTransition?.state === 'deposit_required' ? depositTransition.smsSent : false,
     })
   } catch (error) {
+    if (error instanceof ChristmasCourseValidationError) return NextResponse.json({ error: error.message }, { status: 409 })
     logger.error('BOH table-booking party-size update failed', {
       error: error instanceof Error ? error : new Error(String(error)),
       metadata: { tableBookingId: id },

--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -59,6 +59,8 @@ const CreateEventBookingSchema = z.object({
   event_price: z.number().min(0).optional(),
   event_value: z.number().min(0).optional(),
   food_intent: z.string().trim().min(1).max(80).optional(),
+  dining_request: z.enum(['before_event', 'during_event', 'not_sure']).optional(),
+  early_arrival_request: z.boolean().optional(),
   communication_consent: OptionalCommunicationConsentSchema,
   // Per-ticket attendee names (ordered; index 0 = lead booker). Basic shape
   // guard only — the count-vs-seats rule is enforced by normalizeAttendeeNames.
@@ -187,6 +189,8 @@ export async function POST(request: NextRequest) {
       seating_preference: parsed.data.seating_preference || 'seated',
       expected_event_date: parsed.data.expected_event_date || null,
       ...(attendeeNames.length > 0 ? { attendee_names: attendeeNames } : {}),
+      ...(parsed.data.dining_request ? { dining_request: parsed.data.dining_request } : {}),
+      ...(parsed.data.early_arrival_request === true ? { early_arrival_request: true } : {}),
       communication_consent: consentHashPayload(parsed.data.communication_consent),
     })
     const attribution = buildBookingAttribution(parsed.data)
@@ -374,7 +378,9 @@ export async function POST(request: NextRequest) {
         firstName: parsed.data.first_name || customerResolution.resolvedFirstName,
         attendeeNames: attendeeNames.length > 0 ? attendeeNames : undefined,
         attribution,
-        ticketSelections
+        ticketSelections,
+        diningRequest: parsed.data.dining_request,
+        earlyArrivalRequest: parsed.data.early_arrival_request
       })
 
       if (result.rpcFailed) {
@@ -444,7 +450,8 @@ export async function POST(request: NextRequest) {
           total_remaining: rpcResult.total_remaining ?? null,
           event_seating_type: eventSeatingType,
           next_step_url: nextStepUrl,
-          manage_booking_url: manageUrl
+          manage_booking_url: manageUrl,
+          requests_recorded: (resolvedState === 'confirmed' || resolvedState === 'pending_payment') && rpcResult.requests_recorded === true
         },
         meta: {
           status_code: responseStatus,

--- a/src/app/api/foh/bookings/[id]/christmas-courses/route.ts
+++ b/src/app/api/foh/bookings/[id]/christmas-courses/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireFohPermission } from '@/lib/foh/api-auth'
+
+export async function GET(_request: NextRequest, context: { params: Promise<{ id: string }> }): Promise<NextResponse> {
+  const auth = await requireFohPermission('view')
+  if (!auth.ok) return auth.response
+  const { id } = await context.params
+  if (!/^[0-9a-f-]{36}$/i.test(id)) return NextResponse.json({ error: 'Invalid booking' }, { status: 400 })
+  const { data, error } = await auth.supabase.from('table_bookings').select('*').eq('id', id).maybeSingle()
+  if (error || !data) return NextResponse.json({ error: 'Could not load course choices' }, { status: 404 })
+  return NextResponse.json({ course_counts: data.christmas_course_counts ?? null })
+}

--- a/src/app/api/foh/bookings/[id]/party-size/route.ts
+++ b/src/app/api/foh/bookings/[id]/party-size/route.ts
@@ -5,6 +5,7 @@ import { requireFohPermission } from '@/lib/foh/api-auth'
 import { logger } from '@/lib/logger'
 import {
   PartySizeUpdateFailedAfterMoveError,
+  ChristmasCourseValidationError,
   mapSeatUpdateBlockedReason,
   updateTableBookingPartySizeWithLinkedEventSeats
 } from '@/lib/events/staff-seat-updates'
@@ -18,6 +19,7 @@ import {
 } from '@/lib/table-bookings/preorder'
 
 const UpdatePartySizeSchema = z.object({
+  christmas_course_counts: z.array(z.number().int().min(1).max(3)).min(6).max(20).optional(),
   party_size: z.preprocess(
     (value) => (typeof value === 'string' ? Number.parseInt(value, 10) : value),
     z.number().int().min(1).max(20)
@@ -75,6 +77,7 @@ export async function POST(
     const result = await updateTableBookingPartySizeWithLinkedEventSeats(auth.supabase, {
       tableBookingId: id,
       partySize: newPartySize,
+      christmasCourseCounts: parsed.data.christmas_course_counts,
       actor: 'foh',
       sendSms: parsed.data.send_sms,
       appBaseUrl: process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin,
@@ -190,6 +193,7 @@ export async function POST(
       preorderRemoved,
     })
   } catch (error) {
+    if (error instanceof ChristmasCourseValidationError) return NextResponse.json({ error: error.message }, { status: 409 })
     logger.error('FOH table-booking party-size update failed', {
       error: error instanceof Error ? error : new Error(String(error)),
       metadata: { tableBookingId: id },

--- a/src/app/api/table-bookings/periods/route.test.ts
+++ b/src/app/api/table-bookings/periods/route.test.ts
@@ -25,6 +25,7 @@ const state = {
   /** The system_settings row as stored: the jsonb column wraps the value, {"value": true}. */
   settingsRow: { value: { value: true } } as Record<string, unknown> | null,
   settingsError: null as unknown,
+  coursePolicy: null as unknown,
 }
 
 /** Every filter the route applies, so the test can prove the live-only query was really built. */
@@ -54,6 +55,7 @@ function chainFor(table: string, resolve: () => QueryResult) {
 
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminClient: vi.fn(() => ({
+    rpc: vi.fn(async () => ({ data: state.coursePolicy, error: state.coursePolicy ? null : { code: "PGRST202" } })),
     from: vi.fn((table: string) => {
       calls.tables.push(table)
       return {
@@ -345,5 +347,19 @@ describe('GET /api/table-bookings/periods', () => {
     expect(json.data.period.period_kind).toBe('christmas')
     expect(json.data.period.code).toBe('christmas-2026')
     expect(json.data.deposit.if_accepted.amount).toBe(160)
+  })
+})
+
+
+describe('Christmas course capability', () => {
+  it('only advertises course selection when the database supports it', async () => {
+    state.period = CHRISTMAS_ROW
+    state.menu = [{ id: 'menu-main', course: 'main', name: 'Main', is_active: true }]
+    state.coursePolicy = { version: 1, preorder_closes_at: '2026-11-28T12:00:00Z', multiple_courses_available: true }
+    const response = await GET(makeRequest('?date=2026-12-05&party_size=6'))
+    expect((await response.json()).data.period.course_policy).toEqual(state.coursePolicy)
+    state.coursePolicy = null
+    const oldResponse = await GET(makeRequest('?date=2026-12-05&party_size=6'))
+    expect((await oldResponse.json()).data.period.course_policy).toBeNull()
   })
 })

--- a/src/app/api/table-bookings/periods/route.ts
+++ b/src/app/api/table-bookings/periods/route.ts
@@ -227,6 +227,13 @@ export async function GET(request: NextRequest) {
         const offerability = getPeriodOfferability(period, date)
         const bookable = offerability.offerable
         const collect = await isDepositCollectionEnabled(supabase)
+        // Optional capability: an older database keeps the existing seasonal journey.
+        // A missing RPC never advertises unsupported one-course booking.
+        let coursePolicy: unknown = null
+        if (period.periodKind === 'christmas') {
+          const { data, error } = await supabase.rpc('christmas_course_policy_v01', { p_booking_date: date })
+          if (!error) coursePolicy = data
+        }
 
         return createApiResponse(
           {
@@ -241,6 +248,7 @@ export async function GET(request: NextRequest) {
               starts_on: period.startsOn,
               ends_on: period.endsOn,
               requires_preorder: period.requiresPreorder,
+              course_policy: coursePolicy,
               preorder_cutoff_days: period.preorderCutoffDays,
               deposit_basis: period.depositBasis,
               deposit_amount: period.depositAmount,

--- a/src/app/api/table-bookings/route.ts
+++ b/src/app/api/table-bookings/route.ts
@@ -89,6 +89,7 @@ const CreateTableBookingSchema = z.object({
   // normal terms. See GET /api/table-bookings/periods for what to show the guest.
   booking_period_id: z.string().uuid().optional(),
   booking_period_answer: z.boolean().optional(),
+  christmas_course_counts: z.array(z.number().int().min(1).max(3)).min(6).max(20).optional(),
   notes: z.string().trim().max(500).optional(),
   // Deprecated. Older public clients may still post this while their bundle
   // rolls forward, but Sunday bookings no longer have a pre-order flow.
@@ -414,7 +415,8 @@ export async function POST(request: NextRequest) {
       // byte-for-byte the hash this route produced before the fields existed.
       booking_period_id: payload.booking_period_id,
       booking_period_answer: payload.booking_period_answer,
-      preorder: payload.preorder
+      preorder: payload.preorder,
+      christmas_course_counts: payload.christmas_course_counts
     })
 
     const supabase = createAdminClient()
@@ -473,7 +475,12 @@ export async function POST(request: NextRequest) {
       //
       // v06 falls back to v05 internally while table_allocation_v06_enabled is false, so
       // this switch is inert until the flag is turned on.
-      const { data: rpcResultRaw, error: rpcError } = await supabase.rpc('create_table_booking_public_v06', {
+      const { data: rpcResultRaw, error: rpcError } = await (payload.christmas_course_counts
+        ? supabase.rpc('create_table_booking_christmas_v01', {
+            p_request: { ...payload, customer_id: customerResolution.customerId, time: bookingTime, source: 'brand_site' },
+            p_course_counts: payload.christmas_course_counts
+          })
+        : supabase.rpc('create_table_booking_public_v06', {
         p_customer_id: customerResolution.customerId,
         p_booking_date: payload.date,
         p_booking_time: bookingTime,
@@ -496,7 +503,7 @@ export async function POST(request: NextRequest) {
         // period for the date is refused rather than priced.
         p_booking_period_id: payload.booking_period_id ?? null,
         p_booking_period_answer: payload.booking_period_answer ?? null
-      })
+      }))
 
       let bookingResult: TableBookingRpcResult
       if (rpcError) {
@@ -582,7 +589,8 @@ export async function POST(request: NextRequest) {
       // there is no menu to choose from, and every dish id is validated against
       // that period before anything is written.
       let preorderResult: PreorderPersistResult | null = null
-      if (bookingResult.table_booking_id && (payload.preorder?.length ?? 0) > 0) {
+      if (bookingResult.table_booking_id && (payload.preorder?.length ?? 0) > 0
+          && !(payload.christmas_course_counts && bookingResult.booking_period_requires_preorder === false)) {
         const entries = payload.preorder ?? []
 
         if (entries.length > payload.party_size) {

--- a/src/app/g/[token]/table-manage/PreorderSection.tsx
+++ b/src/app/g/[token]/table-manage/PreorderSection.tsx
@@ -147,8 +147,9 @@ export function PreorderSection({
           Your food choices
         </h2>
         <p className="font-anchor-body text-[14px] leading-[1.6] text-guest-text-muted">
-          Everyone eating from the {menuName} menu chooses their main course in advance so the kitchen can
-          prepare it. A starter and a pudding are optional.
+          {order.covers.some(cover => cover.courseCount != null)
+            ? `Guests having two or three courses from the ${menuName} menu choose their dishes in advance. One course needs no pre-order.`
+            : `Everyone eating from the ${menuName} menu chooses their main course in advance so the kitchen can prepare it. A starter and a pudding are optional.`}
         </p>
       </div>
 
@@ -182,6 +183,7 @@ export function PreorderSection({
 
             {seats.map((ordinal) => {
               const cover = coversByOrdinal.get(ordinal)
+              if (cover?.courseCount === 1) return <p key={ordinal}>Guest {ordinal}: 1 course, no pre-order required.</p>
               const withdrawn = withdrawnChoices(cover)
               const hasError = errorSeat === ordinal
               const noteIds = [
@@ -383,6 +385,7 @@ export function PreorderSection({
           <ul className="flex flex-col gap-[14px]">
             {seats.map((ordinal) => {
               const cover = coversByOrdinal.get(ordinal)
+              if (cover?.courseCount === 1) return <p key={ordinal}>Guest {ordinal}: 1 course, no pre-order required.</p>
               const chosen = PREORDER_COURSES.map((course) => {
                 const selection = cover ? getCoverCourse(cover, course) : null
                 return selection ? `${PREORDER_COURSE_LABELS[course]}: ${selection.itemName}` : null

--- a/src/app/g/[token]/table-manage/__tests__/preorder-cutoff.test.ts
+++ b/src/app/g/[token]/table-manage/__tests__/preorder-cutoff.test.ts
@@ -25,6 +25,7 @@ describe('resolvePreorderCutoff', () => {
 
   it('closes the form the moment the cutoff passes', () => {
     expect(resolvePreorderCutoff('2026-12-24', 7, new Date('2026-12-17T11:59:00Z')).editable).toBe(true)
+    expect(resolvePreorderCutoff('2026-12-24', 7, new Date('2026-12-17T12:00:00Z')).editable).toBe(false)
     expect(resolvePreorderCutoff('2026-12-24', 7, new Date('2026-12-17T12:00:01Z')).editable).toBe(false)
   })
 

--- a/src/components/features/table-bookings/ChristmasCourseFields.tsx
+++ b/src/components/features/table-bookings/ChristmasCourseFields.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface ChristmasCourseFieldsProps {
+  bookingId: string
+  partySize: number
+  onChange: (counts: number[] | undefined) => void
+}
+
+/** Existing bookings without a snapshot retain their original policy and show no controls. */
+export function ChristmasCourseFields({ bookingId, partySize, onChange }: ChristmasCourseFieldsProps) {
+  const [counts, setCounts] = useState<number[] | null>(null)
+  const [failed, setFailed] = useState(false)
+  useEffect(() => {
+    const controller = new AbortController()
+    setCounts(null)
+    setFailed(false)
+    onChange(undefined)
+    void fetch(`/api/foh/bookings/${bookingId}/christmas-courses`, { signal: controller.signal })
+      .then(async response => {
+        if (!response.ok) throw new Error('Could not load courses')
+        const data = await response.json()
+        if (!controller.signal.aborted) setCounts(data.course_counts)
+      }).catch(() => { if (!controller.signal.aborted) setFailed(true) })
+    return () => controller.abort()
+  }, [bookingId, onChange])
+  useEffect(() => {
+    if (!counts) return
+    const next = Array.from({ length: Math.min(20, Math.max(0, partySize || 0)) }, (_, index) => counts[index] ?? 0)
+    onChange(next)
+  }, [counts, partySize, onChange])
+  if (failed) return <p role="alert">Course choices could not be loaded. Refresh before changing a Christmas booking.</p>
+  if (!counts) return null
+  const next = Array.from({ length: Math.min(20, Math.max(0, partySize || 0)) }, (_, index) => counts[index] ?? 0)
+  return <fieldset className="space-y-2"><legend className="text-sm font-medium">Christmas courses for each guest</legend>
+    <p className="text-sm">One course needs no pre-order. Two or three courses need food choices by the pre-order deadline.</p>
+    {next.map((count, index) => <label key={index} className="flex items-center gap-3 text-sm">
+      Guest {index + 1}
+      <select value={count} className="rounded-md border border-gray-300 p-2"
+        onChange={event => setCounts(next.map((value, seat) => seat === index ? Number(event.target.value) : value))}>
+        <option value={0}>Choose courses</option><option value={1}>1 course</option><option value={2}>2 courses</option><option value={3}>3 courses</option>
+      </select>
+    </label>)}
+  </fieldset>
+}

--- a/src/components/features/table-bookings/preorder/SeasonalPreorderSection.tsx
+++ b/src/components/features/table-bookings/preorder/SeasonalPreorderSection.tsx
@@ -473,6 +473,7 @@ export default function SeasonalPreorderSection({
         ) : (
           <div className="space-y-3">
             {order.covers.map((cover) => {
+              if (cover.courseCount === 1) return <p key={cover.id} className="text-sm">Seat {cover.ordinal}: 1 course, no pre-order required.</p>
               const coverDraft = draft[cover.id]
               if (!coverDraft) return null
               const missingMain = !coverDraft.choices.main
@@ -595,6 +596,7 @@ export default function SeasonalPreorderSection({
             {bookingAddons.count > 0 && (
               <ul className="mt-1 space-y-0.5 text-xs text-gray-700">
                 {order.covers.map((cover) => {
+              if (cover.courseCount === 1) return <p key={cover.id} className="text-sm">Seat {cover.ordinal}: 1 course, no pre-order required.</p>
                   const summary = addonsByCover.get(cover.id)?.summary
                   if (!summary || summary.count === 0) return null
                   return (

--- a/src/lib/event-booking-sheet-template.test.ts
+++ b/src/lib/event-booking-sheet-template.test.ts
@@ -30,6 +30,13 @@ const options = {
 }
 
 describe('booking sheet template', () => {
+  it('prints unconfirmed food and arrival requests from durable booking notes', () => {
+    const bookingNotes = 'UNCONFIRMED REQUEST: Guest asks about food before the event. Guest would like to discuss arriving early. Food availability and arrival arrangements must be agreed with the team.'
+    const html = generateEventBookingSheetsHTML([{ ...baseSheet, bookingNotes }], options)
+    expect(html).toContain(bookingNotes)
+    expect(html).toContain('Booking notes')
+  })
+
   it('renders Sunday roast items from provided menu data', () => {
     const html = generateEventBookingSheetsHTML([baseSheet], options)
 

--- a/src/lib/events/staff-seat-updates.test.ts
+++ b/src/lib/events/staff-seat-updates.test.ts
@@ -41,7 +41,8 @@ const bookingRow = {
   booking_time: '18:00:00',
   start_datetime: '2026-07-10T17:00:00.000Z',
   end_datetime: '2026-07-10T19:00:00.000Z',
-  duration_minutes: 120
+  duration_minutes: 120,
+  christmas_course_counts: undefined as number[] | undefined
 }
 
 type UpdateResult = { data: Record<string, unknown> | null; error: { message: string } | null }
@@ -94,6 +95,7 @@ const availability = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  bookingRow.christmas_course_counts = undefined
   mockedGetAvailability.mockResolvedValue(availability)
   mockedMoveToTables.mockResolvedValue({ ok: true })
 })
@@ -201,6 +203,26 @@ describe('updateTableBookingPartySizeWithLinkedEventSeats (auto-move grow)', () 
       })
     ).rejects.toMatchObject({ message: 'update failed' })
 
+    expect(mockedMoveToTables).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('Christmas amendment preflight', () => {
+  it('rejects missing course choices before any table move or update', async () => {
+    bookingRow.christmas_course_counts = [1, 1, 1, 1, 1, 1]
+    const { client } = createSupabaseStub({ data: null, error: null })
+    await expect(updateTableBookingPartySizeWithLinkedEventSeats(client, { tableBookingId: 'tb-1', partySize: 7, autoMoveTable: true }))
+      .rejects.toThrow('Choose one, two or three courses')
+    expect(mockedGetAvailability).not.toHaveBeenCalled()
+    expect(mockedMoveToTables).not.toHaveBeenCalled()
+  })
+  it('rejects a course change after the deadline before moving tables', async () => {
+    bookingRow.christmas_course_counts = [1, 1, 1, 1, 1, 1]
+    const { client } = createSupabaseStub({ data: null, error: null })
+    Object.assign(client, { rpc: vi.fn(async () => ({ data: { multiple_courses_available: false }, error: null })) })
+    await expect(updateTableBookingPartySizeWithLinkedEventSeats(client, { tableBookingId: 'tb-1', partySize: 7, autoMoveTable: true, christmasCourseCounts: [1, 1, 1, 1, 1, 1, 2] }))
+      .rejects.toThrow('deadline has passed')
     expect(mockedMoveToTables).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/events/staff-seat-updates.ts
+++ b/src/lib/events/staff-seat-updates.ts
@@ -15,6 +15,8 @@ type SeatUpdateSmsMeta = {
   logFailure: boolean
 }
 
+export class ChristmasCourseValidationError extends Error {}
+
 export type UpdatedTableBookingRow = {
   id: string
   party_size: number | null
@@ -141,6 +143,7 @@ export async function updateTableBookingPartySizeWithLinkedEventSeats(
   input: {
     tableBookingId: string
     partySize: number
+    christmasCourseCounts?: number[]
     actor?: string
     sendSms?: boolean
     appBaseUrl?: string
@@ -154,7 +157,7 @@ export async function updateTableBookingPartySizeWithLinkedEventSeats(
   }
 ): Promise<TableBookingSeatUpdateResult> {
   const { data: tableBooking, error: tableBookingError } = await supabase.from('table_bookings')
-    .select('id, status, party_size, event_booking_id, event_id, booking_date, booking_time, start_datetime, end_datetime, duration_minutes')
+    .select('*')
     .eq('id', input.tableBookingId)
     .maybeSingle()
 
@@ -190,13 +193,31 @@ export async function updateTableBookingPartySizeWithLinkedEventSeats(
 
   const oldPartySize = Math.max(1, Number(tableBooking.party_size || 1))
   const newPartySize = Math.max(1, Number(input.partySize || 1))
+  const recordedCourses: number[] | null = tableBooking.christmas_course_counts ?? null
+  const nextCourses = recordedCourses ? (input.christmasCourseCounts ?? recordedCourses) : null
+  const coursesChanged = JSON.stringify(recordedCourses) !== JSON.stringify(nextCourses)
+  if (recordedCourses) {
+    // Before looking for or moving tables. The database repeats these checks on the final update.
+    if (newPartySize < 6 || newPartySize > 20 || nextCourses?.length !== newPartySize
+        || nextCourses.some(course => !Number.isInteger(course) || course < 1 || course > 3)) {
+      throw new ChristmasCourseValidationError('Choose one, two or three courses for every Christmas guest before changing the party size.')
+    }
+    if (coursesChanged && nextCourses.some(course => course > 1)) {
+      const { data: policy, error } = await supabase.rpc('christmas_course_policy_v01', { p_booking_date: tableBooking.booking_date })
+      if (error || policy?.multiple_courses_available !== true) {
+        throw new ChristmasCourseValidationError('The Christmas pre-order deadline has passed. New course choices cannot be accepted for this date.')
+      }
+    }
+  } else if (input.christmasCourseCounts) {
+    throw new ChristmasCourseValidationError('This booking retains its original course policy. Refresh before making changes.')
+  }
   let autoMovedTableIds: string[] | null = null
   let autoMovedTableName: string | null = null
   let autoMovedFromTableIds: string[] | null = null
   let autoMoveWindow: { startIso: string; endIso: string } | null = null
 
   if (!tableBooking.event_booking_id) {
-    if (oldPartySize === newPartySize) {
+    if (oldPartySize === newPartySize && !coursesChanged) {
       return {
         state: 'unchanged',
         table_booking_id: tableBooking.id,
@@ -295,6 +316,7 @@ export async function updateTableBookingPartySizeWithLinkedEventSeats(
     const { data: updatedTableBooking, error: tableUpdateError } = await supabase.from('table_bookings')
       .update({
         party_size: newPartySize,
+        ...(nextCourses ? { christmas_course_counts: nextCourses } : {}),
         committed_party_size: newPartySize,
         updated_at: nowIso
       })

--- a/src/lib/table-bookings/booking-idempotency.test.ts
+++ b/src/lib/table-bookings/booking-idempotency.test.ts
@@ -182,3 +182,15 @@ describe('fixture booking intent', () => {
     expect(computeTableBookingRequestHash(makeFields({ notes }))).not.toBe(computeTableBookingRequestHash(makeFields({ notes: notes.replace('Italy', 'France') })))
   })
 })
+
+
+describe('Christmas course snapshot retries', () => {
+  it('keeps old requests stable and conflicts when a seat changes tier', () => {
+    const old = makeFields()
+    expect(computeTableBookingRequestHash({ ...old, christmas_course_counts: undefined })).toBe(computeTableBookingRequestHash(old))
+    const counts = [1, 1, 1, 1, 1, 1]
+    const first = computeTableBookingRequestHash({ ...old, christmas_course_counts: counts })
+    expect(first).toBe(computeTableBookingRequestHash({ ...old, christmas_course_counts: [...counts] }))
+    expect(first).not.toBe(computeTableBookingRequestHash({ ...old, christmas_course_counts: [1, 1, 1, 1, 1, 2] }))
+  })
+})

--- a/src/lib/table-bookings/booking-idempotency.ts
+++ b/src/lib/table-bookings/booking-idempotency.ts
@@ -9,6 +9,7 @@ import type { CommunicationConsentPayload } from '@/lib/consent/types'
  * intent posted twice hashes identically regardless of input formatting.
  */
 export type TableBookingIdempotencyFields = {
+  christmas_course_counts?: number[]
   phone: string
   first_name?: string | null
   last_name?: string | null
@@ -119,6 +120,7 @@ export function computeTableBookingRequestHash(fields: TableBookingIdempotencyFi
     // the old choice. Same undefined-when-absent trick as the fields above, so a
     // client that sends no pre-order hashes exactly as it did before this field.
     preorder: preorderHashPayload(fields.preorder),
+    christmas_course_counts: fields.christmas_course_counts ?? undefined,
     communication_consent: consentHashPayload(fields.communication_consent)
   })
 }

--- a/src/lib/table-bookings/bookings.ts
+++ b/src/lib/table-bookings/bookings.ts
@@ -74,6 +74,7 @@ export type TableBookingRpcResult = {
   booking_period_name?: string | null
   booking_period_answer?: boolean | null
   booking_period_requires_preorder?: boolean | null
+  christmas_course_counts?: number[] | null
 }
 
 /**
@@ -331,6 +332,15 @@ function formatBookingTimeLabel(booking: TableBookingNotificationRow): string {
   return 'Unknown time'
 }
 
+export function describeChristmasCourseCounts(counts?: number[] | null): string {
+  if (!counts?.length) return ''
+  const summary = [1, 2, 3].map(course => {
+    const guests = counts.filter(count => count === course).length
+    return guests ? `${guests} x ${course} course${course === 1 ? '' : 's'}` : null
+  }).filter(Boolean).join(', ')
+  return `Christmas courses: ${summary}. One course needs no pre-order.`
+}
+
 function buildTableBookingCustomerEmail(input: {
   firstName: string
   bookingMoment: string
@@ -341,6 +351,7 @@ function buildTableBookingCustomerEmail(input: {
   manageLink?: string | null
   paymentLink?: string | null
   depositLabel?: string | null
+  christmasCourseSummary?: string
   highChairCount?: number | null
   isOutsideSeating?: boolean | null
 }): { subject: string; html: string; text: string } {
@@ -386,6 +397,7 @@ function buildTableBookingCustomerEmail(input: {
       : '',
     isOutside ? '<li><strong>Outside seating</strong> (weather permitting)</li>' : '',
     '</ul>',
+    input.christmasCourseSummary ? `<p>${escapeHtml(input.christmasCourseSummary)}</p>` : '',
     cta,
     '<p>If you need to change anything, reply to this email or call the pub.</p>',
     '<p>The Anchor</p>',
@@ -399,6 +411,7 @@ function buildTableBookingCustomerEmail(input: {
     input.bookingReference ? `Reference: ${input.bookingReference}` : null,
     `When: ${input.bookingMoment}`,
     `Party size: ${input.partySize} ${input.seatWord}`,
+    input.christmasCourseSummary || null,
     grantedHighChairs > 0 ? `High chair reserved x${grantedHighChairs}` : null,
     isOutside ? 'Outside seating (weather permitting)' : null,
     isPendingPayment
@@ -1032,6 +1045,9 @@ export async function sendTableBookingCreatedSmsIfAllowed(
     smsBody = `The Anchor: Hi ${firstName}, your ${bookingNoun} for ${partySize} ${seatWord} on ${bookingMoment} is confirmed.${highChairSuffix}${outsideSuffix}${linkSuffix}`
   }
 
+  const christmasCourseSummary = describeChristmasCourseCounts(input.bookingResult.christmas_course_counts)
+  if (christmasCourseSummary) smsBody += ` ${christmasCourseSummary}`
+
   const templateKey = input.bookingResult.state === 'pending_payment'
     ? 'table_booking_pending_payment'
     : 'table_booking_confirmed'
@@ -1045,6 +1061,7 @@ export async function sendTableBookingCreatedSmsIfAllowed(
     manageLink,
     paymentLink: input.nextStepUrl || null,
     depositLabel,
+    christmasCourseSummary,
     highChairCount: grantedHighChairs,
     isOutsideSeating: isOutside,
   })
@@ -1187,7 +1204,7 @@ export async function sendTableBookingConfirmedAfterDepositSmsIfAllowed(
 ): Promise<SmsSafetyMeta> {
   const { data: booking, error: bookingError } = await supabase
     .from('table_bookings')
-    .select('id, customer_id, party_size, booking_date, booking_time, start_datetime, status, booking_type, high_chair_count, is_outside_seating')
+    .select('*')
     .eq('id', tableBookingId)
     .maybeSingle()
 
@@ -1238,7 +1255,8 @@ export async function sendTableBookingConfirmedAfterDepositSmsIfAllowed(
   const highChairSuffix = grantedHighChairs > 0 ? ` High chair reserved x${grantedHighChairs}.` : ''
   const outsideSuffix = isOutside ? ' Outside seating (weather permitting).' : ''
   const bookingNoun = isOutside ? 'outside booking' : 'table'
-  const composedMessage = `The Anchor: ${firstName}! Deposit sorted — your ${bookingNoun} for ${partySize} ${seatWord} on ${bookingMoment} is locked in. See you then!${highChairSuffix}${outsideSuffix}${manageLink ? ` ${manageLink}` : ''}`
+  const christmasCourseSummary = describeChristmasCourseCounts(booking.christmas_course_counts)
+  const composedMessage = `The Anchor: ${firstName}! Deposit sorted, your ${bookingNoun} for ${partySize} ${seatWord} on ${bookingMoment} is locked in. See you then!${highChairSuffix}${outsideSuffix}${manageLink ? ` ${manageLink}` : ''}${christmasCourseSummary ? ` ${christmasCourseSummary}` : ''}`
   const templateKey = 'table_booking_deposit_confirmed'
 
   const body = ensureReplyInstruction(composedMessage, supportPhone)

--- a/src/lib/table-bookings/highchair-outside.test.ts
+++ b/src/lib/table-bookings/highchair-outside.test.ts
@@ -317,6 +317,19 @@ describe('sendTableBookingCreatedSmsIfAllowed — wording', () => {
     }
   }
 
+  it('renders the recorded Christmas tiers consistently in SMS and both email formats', async () => {
+    await sendTableBookingCreatedSmsIfAllowed(customerClient(), {
+      customerId: 'cust-1', normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult({ christmas_course_counts: [1, 1, 1, 1, 2, 3] }),
+    })
+    const rendered = await capture()
+    for (const content of [rendered.sms, rendered.html, rendered.text]) {
+      expect(content).toContain('Christmas courses: 4 x 1 course, 1 x 2 courses, 1 x 3 courses.')
+      expect(content).toContain('One course needs no pre-order.')
+      expect(content).not.toMatch(/undefined|Invalid Date|NaN/)
+    }
+  })
+
   it('should use outside/booking wording (not "your table") for an outside booking', async () => {
     await sendTableBookingCreatedSmsIfAllowed(customerClient(), {
       customerId: 'cust-1',

--- a/src/lib/table-bookings/preorder.test.ts
+++ b/src/lib/table-bookings/preorder.test.ts
@@ -85,6 +85,23 @@ describe('isCoverComplete', () => {
   })
 })
 
+describe('snapshotted Christmas course completeness', () => {
+  it('exempts one course but preserves old missing-tier records', () => {
+    expect(isCoverComplete({ ...cover(1, []), courseCount: 1 })).toBe(true)
+    expect(isCoverComplete({ ...cover(1, []), courseCount: null })).toBe(false)
+  })
+  it('requires the exact chosen number of courses, including a main', () => {
+    const main = selection('main', 'Fixture main')
+    const starter = selection('starter', 'Fixture starter')
+    const dessert = selection('dessert', 'Fixture dessert')
+    expect(isCoverComplete({ ...cover(1, [main]), courseCount: 2 })).toBe(false)
+    expect(isCoverComplete({ ...cover(1, [main, starter]), courseCount: 2 })).toBe(true)
+    expect(isCoverComplete({ ...cover(1, [starter, dessert]), courseCount: 2 })).toBe(false)
+    expect(isCoverComplete({ ...cover(1, [main, starter]), courseCount: 3 })).toBe(false)
+    expect(isCoverComplete({ ...cover(1, [main, starter, dessert]), courseCount: 3 })).toBe(true)
+  })
+})
+
 describe('getPreorderCompleteness', () => {
   it('treats a party with mixed course counts as complete when every seat has a main', () => {
     const order = {
@@ -121,7 +138,7 @@ describe('getPreorderCompleteness', () => {
 
     expect(completeness.complete).toBe(false)
     expect(completeness.ordinalsMissingMain).toEqual([2, 3])
-    expect(describePreorderGaps(completeness)).toBe('no main chosen for seat 2, 3.')
+    expect(describePreorderGaps(completeness)).toBe('course choices incomplete for seat 2, 3.')
   })
 
   it('is incomplete when there are fewer seats than the party size, even if every seat has a main', () => {

--- a/src/lib/table-bookings/preorder.ts
+++ b/src/lib/table-bookings/preorder.ts
@@ -135,8 +135,11 @@ export function mapPreorderCoverRow(
  * and chosen no main is NOT complete, and a seat with a main and no add-ons IS. Anything else would
  * mean the chase cron nagged a guest for not buying an extra.
  */
-export function isCoverComplete(cover: Pick<PreorderCover, 'selections'>): boolean {
-  return cover.selections.some((selection) => selection.course === 'main')
+export function isCoverComplete(cover: Pick<PreorderCover, 'selections' | 'courseCount'>): boolean {
+  if (cover.courseCount === 1) return true
+  const hasMain = cover.selections.some((selection) => selection.course === 'main')
+  if (!cover.courseCount) return hasMain // Existing records retain their recorded policy.
+  return hasMain && cover.selections.filter((selection) => isPreorderCourse(selection.course)).length === cover.courseCount
 }
 
 /**
@@ -206,7 +209,7 @@ export function describePreorderGaps(completeness: PreorderCompleteness): string
     )
   }
   if (completeness.ordinalsMissingMain.length > 0) {
-    parts.push(`no main chosen for seat ${completeness.ordinalsMissingMain.join(', ')}`)
+    parts.push(`course choices incomplete for seat ${completeness.ordinalsMissingMain.join(', ')}`)
   }
   return parts.length > 0 ? `${parts.join(', and ')}.` : 'Something is missing from this pre-order.'
 }
@@ -501,10 +504,8 @@ export async function loadPreorderOrder(
 ): Promise<PreorderOrder | null> {
   const { data: bookingRow, error: bookingError } = await supabase
     .from('table_bookings')
-    .select(
-      'id, booking_reference, booking_date, booking_time, party_size, allergies, ' +
-        'booking_period_id, booking_period_name, booking_period_answer, booking_period_requires_preorder',
-    )
+    // Select the row so the optional snapshot remains compatible before its migration.
+    .select('*')
     .eq('id', tableBookingId)
     .maybeSingle()
 
@@ -522,6 +523,7 @@ export async function loadPreorderOrder(
     booking_period_name: string | null
     booking_period_answer: boolean | null
     booking_period_requires_preorder: boolean | null
+    christmas_course_counts?: Array<1 | 2 | 3> | null
   }
 
   const [covers, preorderCutoffDays] = await Promise.all([
@@ -543,7 +545,7 @@ export async function loadPreorderOrder(
     periodId: booking.booking_period_id ?? null,
     periodName: booking.booking_period_name ?? null,
     preorderCutoffDays,
-    covers,
+    covers: covers.map(cover => ({ ...cover, courseCount: booking.christmas_course_counts?.[cover.ordinal - 1] ?? null })),
   }
 }
 

--- a/src/services/__tests__/event-bookings-dining-requests.test.ts
+++ b/src/services/__tests__/event-bookings-dining-requests.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Module mocks (must be declared before imports) ───────────────────────────
+
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
+vi.mock('@/lib/twilio', () => ({ sendSMS: vi.fn() }))
+vi.mock('@/lib/sms/support', () => ({ ensureReplyInstruction: vi.fn((m: string) => m) }))
+vi.mock('@/lib/sms/bulk', () => ({ getSmartFirstName: vi.fn((n: string | null | undefined) => n || 'there') }))
+vi.mock('@/lib/events/event-payments', () => ({ createEventPaymentToken: vi.fn() }))
+vi.mock('@/lib/events/manage-booking', () => ({ createEventManageToken: vi.fn() }))
+vi.mock('@/lib/analytics/events', () => ({ recordAnalyticsEvent: vi.fn() }))
+vi.mock('@/lib/google-calendar-events', () => ({ syncPubOpsEventCalendarByEventId: vi.fn() }))
+vi.mock('@/lib/email/event-ticket-emails', () => ({ sendEventPaymentLinkEmail: vi.fn() }))
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { recordAnalyticsEvent } from '@/lib/analytics/events'
+import { syncPubOpsEventCalendarByEventId } from '@/lib/google-calendar-events'
+import { createEventManageToken } from '@/lib/events/manage-booking'
+import { EventBookingService, type CreateBookingParams } from '../event-bookings'
+
+const CONFIRMED_RPC_RESULT = {
+  state: 'confirmed' as const,
+  booking_id: 'booking-uuid-001',
+  payment_mode: 'prepaid' as const,
+  event_id: 'event-uuid-001',
+  event_name: 'Quiz Night',
+  event_start_datetime: '2026-06-15T19:00:00Z',
+  seats_remaining: 8,
+}
+
+const BASE_PARAMS: CreateBookingParams = {
+  eventId: 'event-uuid-001',
+  customerId: 'customer-uuid-001',
+  normalizedPhone: '+447700900001',
+  seats: 3,
+  source: 'brand_site',
+  bookingMode: 'general',
+  appBaseUrl: 'https://example.com',
+  shouldSendSms: false,
+}
+
+function makeSupabaseMock(rpcResults: Record<string, { data: unknown; error: unknown }>) {
+  return {
+    rpc: vi.fn((name: string) => Promise.resolve(rpcResults[name] ?? { data: null, error: null })),
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  }
+}
+
+
+describe('atomic event dining requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(createEventManageToken).mockResolvedValue({ url: 'https://example.com/manage/abc' } as Awaited<ReturnType<typeof createEventManageToken>>)
+    vi.mocked(recordAnalyticsEvent).mockResolvedValue(undefined)
+    vi.mocked(syncPubOpsEventCalendarByEventId).mockResolvedValue({ state: 'updated' })
+  })
+
+  it.each([undefined, [{ ticket_type_id: 'type-adult', quantity: 3 }]])('uses the atomic wrapper for requests with basket %j', async (ticketSelections) => {
+    const supabase = makeSupabaseMock({ create_event_booking_with_requests_v01: { data: { ...CONFIRMED_RPC_RESULT, requests_recorded: true }, error: null } })
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const result = await EventBookingService.createBooking({ ...BASE_PARAMS, diningRequest: 'before_event', earlyArrivalRequest: true, ticketSelections })
+    expect(supabase.rpc).toHaveBeenCalledWith('create_event_booking_with_requests_v01', expect.objectContaining({ p_dining_request: 'before_event', p_early_arrival_request: true, p_ticket_selections: ticketSelections ?? null }))
+    expect(result.rpcResult.requests_recorded).toBe(true)
+    expect(supabase.rpc.mock.calls.map(([name]) => name)).not.toContain('create_event_booking_v06')
+  })
+
+  it('surfaces failed persistence without tokens, messages or a success result', async () => {
+    const supabase = makeSupabaseMock({ create_event_booking_with_requests_v01: { data: null, error: { message: 'event_booking_request_persistence_failed' } } })
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const result = await EventBookingService.createBooking({ ...BASE_PARAMS, diningRequest: 'before_event' })
+    expect(result.rpcFailed).toBe(true)
+    expect(result.bookingId).toBeNull()
+    expect(createEventManageToken).not.toHaveBeenCalled()
+    expect(recordAnalyticsEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not update or acknowledge requests for a conflict carrying an existing ID', async () => {
+    const supabase = makeSupabaseMock({ create_event_booking_with_requests_v01: { data: { state: 'blocked', reason: 'customer_conflict', booking_id: 'existing-id' }, error: null } })
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const result = await EventBookingService.createBooking({ ...BASE_PARAMS, diningRequest: 'not_sure', earlyArrivalRequest: true })
+    expect(result.resolvedState).toBe('blocked')
+    expect(result.rpcResult.requests_recorded).toBeUndefined()
+    expect(supabase.from).not.toHaveBeenCalled()
+    expect(createEventManageToken).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/event-bookings.ts
+++ b/src/services/event-bookings.ts
@@ -53,6 +53,7 @@ type EventBookingRpcResult = {
   table_name?: string | null
   table_names?: string[]
   table_ids?: string[]
+  requests_recorded?: boolean
 }
 
 type EventTableReservationRpcResult = {
@@ -137,6 +138,8 @@ export type CreateBookingParams = {
    * gate — when the flag is off it must not pass multi/non-default selections here.
    */
   ticketSelections?: TicketSelectionInput[]
+  diningRequest?: 'before_event' | 'during_event' | 'not_sure'
+  earlyArrivalRequest?: boolean
 }
 
 export type CreateBookingResult = {
@@ -520,7 +523,9 @@ export class EventBookingService {
       attendeeNames,
       attribution = null,
       paymentHoldMinutes,
-      ticketSelections
+      ticketSelections,
+      diningRequest,
+      earlyArrivalRequest
     } = params
 
     // A multi-type basket (more than one line, or any line whose ticket_type_id is
@@ -536,7 +541,20 @@ export class EventBookingService {
 
     // ── 1. Call the create RPC (v06 legacy single-type, or v07 multi-type) ─────
     const holdMinutes = paymentHoldMinutes ?? (source === 'brand_site' ? 15 : 24 * 60)
-    const { data: rpcResultRaw, error: rpcError } = useTicketSelections
+    const hasRequests = Boolean(diningRequest || earlyArrivalRequest)
+    const { data: rpcResultRaw, error: rpcError } = hasRequests
+      ? await supabase.rpc('create_event_booking_with_requests_v01', {
+          p_event_id: eventId,
+          p_customer_id: customerId,
+          p_seats: seats,
+          p_source: source,
+          p_seating_preference: normalizeSeatingPreference(seatingPreference),
+          p_payment_hold_minutes: holdMinutes,
+          p_ticket_selections: useTicketSelections ? ticketSelections as unknown as object : null,
+          p_dining_request: diningRequest ?? null,
+          p_early_arrival_request: earlyArrivalRequest ?? false
+        })
+      : useTicketSelections
       ? await supabase.rpc('create_event_booking_v07', {
           p_event_id: eventId,
           p_customer_id: customerId,
@@ -556,7 +574,7 @@ export class EventBookingService {
 
     if (rpcError) {
       const rpcErrorCode = classifyBookingRpcError(rpcError.message)
-      logger.error(`${useTicketSelections ? 'create_event_booking_v07' : 'create_event_booking_v06'} RPC failed`, {
+      logger.error(`${hasRequests ? 'create_event_booking_with_requests_v01' : useTicketSelections ? 'create_event_booking_v07' : 'create_event_booking_v06'} RPC failed`, {
         error: new Error(rpcError.message),
         metadata: { eventId, customerId, source, rpcErrorCode }
       })

--- a/src/types/preorders.ts
+++ b/src/types/preorders.ts
@@ -132,6 +132,7 @@ export type PreorderSelection = {
 }
 
 export type PreorderCover = {
+  courseCount?: 1 | 2 | 3 | null
   id: string
   tableBookingId: string
   /** Seat number, 1-based. Stable, and the number staff and the kitchen see. */

--- a/supabase/migrations/20260905100155_christmas_course_snapshot.sql
+++ b/supabase/migrations/20260905100155_christmas_course_snapshot.sql
@@ -1,0 +1,167 @@
+-- Draft only. New callers opt into a course snapshot; existing callers and bookings are unchanged.
+-- Capability defaults off until the staff amendment journey has shipped. No setting is enabled here.
+-- The wrapper shares the existing allocation/deposit transaction. No customer communication runs here.
+ALTER TABLE public.table_bookings ADD COLUMN christmas_course_counts integer[];
+COMMENT ON COLUMN public.table_bookings.christmas_course_counts IS
+  'Per-seat Christmas courses in ordinal order. NULL preserves the legacy recorded policy.';
+
+CREATE FUNCTION public.christmas_course_policy_v01(p_booking_date date)
+RETURNS jsonb LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public, pg_catalog AS $$
+  SELECT jsonb_build_object(
+    'version', 1,
+    'preorder_closes_at', ((p_booking_date - p.preorder_cutoff_days) + time '12:00') AT TIME ZONE 'Europe/London',
+    'multiple_courses_available', now() < (((p_booking_date - p.preorder_cutoff_days) + time '12:00') AT TIME ZONE 'Europe/London')
+  ) FROM public.booking_periods p
+  WHERE public.get_setting_bool('christmas_course_policy_enabled', false)
+    AND p.period_kind = 'christmas' AND p.is_active AND p.archived_at IS NULL
+    AND p_booking_date BETWEEN p.starts_on AND p.ends_on;
+$$;
+REVOKE ALL ON FUNCTION public.christmas_course_policy_v01(date) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.christmas_course_policy_v01(date) TO service_role;
+
+CREATE FUNCTION public.create_table_booking_christmas_v01(p_request jsonb, p_course_counts integer[])
+RETURNS jsonb LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_catalog AS $$
+DECLARE
+  v_party integer := (p_request->>'party_size')::integer;
+  v_date date := (p_request->>'date')::date;
+  v_policy jsonb;
+  v_result jsonb;
+  v_requires boolean;
+  v_index integer;
+  v_entry jsonb;
+  v_dish_count integer;
+  v_choice record;
+BEGIN
+  IF p_course_counts IS NULL OR cardinality(p_course_counts) <> v_party
+     OR array_ndims(p_course_counts) <> 1 OR array_lower(p_course_counts, 1) <> 1
+     OR EXISTS (SELECT 1 FROM unnest(p_course_counts) c WHERE c IS NULL OR c NOT BETWEEN 1 AND 3) THEN
+    RAISE EXCEPTION 'Christmas bookings need a course choice for every guest.' USING ERRCODE = '22023';
+  END IF;
+  IF v_party NOT BETWEEN 6 AND 20 THEN
+    RAISE EXCEPTION 'Christmas bookings are for 6 to 20 guests.' USING ERRCODE = '22023';
+  END IF;
+  IF (p_request->>'booking_period_answer')::boolean IS DISTINCT FROM true
+     OR p_request->>'booking_period_id' IS NULL THEN
+    RAISE EXCEPTION 'Christmas bookings need an accepted seasonal offer.' USING ERRCODE = '22023';
+  END IF;
+  FOR v_index IN 1..v_party LOOP
+    v_entry := p_request->'preorder'->(v_index - 1);
+    IF p_course_counts[v_index] > 1 THEN
+      v_dish_count := (CASE WHEN nullif(v_entry->>'starter_menu_item_id', '') IS NULL THEN 0 ELSE 1 END)
+        + (CASE WHEN nullif(v_entry->>'main_menu_item_id', '') IS NULL THEN 0 ELSE 1 END)
+        + (CASE WHEN nullif(v_entry->>'dessert_menu_item_id', '') IS NULL THEN 0 ELSE 1 END);
+      IF nullif(v_entry->>'main_menu_item_id', '') IS NULL OR v_dish_count <> p_course_counts[v_index] THEN
+        RAISE EXCEPTION 'Christmas bookings need the selected courses for every guest having two or three courses.' USING ERRCODE = '22023';
+      END IF;
+    END IF;
+    FOR v_choice IN SELECT * FROM (VALUES
+      ('starter', v_entry->>'starter_menu_item_id'),
+      ('main', v_entry->>'main_menu_item_id'),
+      ('dessert', v_entry->>'dessert_menu_item_id')
+    ) AS choices(course, id) WHERE id IS NOT NULL LOOP
+      IF p_course_counts[v_index] = 1 THEN
+        RAISE EXCEPTION 'Christmas one-course guests do not need a pre-order.' USING ERRCODE = '22023';
+      END IF;
+      IF NOT EXISTS (SELECT 1 FROM public.booking_period_menu_items m
+        WHERE m.id = v_choice.id::uuid AND m.period_id = (p_request->>'booking_period_id')::uuid
+          AND m.course = v_choice.course AND m.is_active) THEN
+        RAISE EXCEPTION 'Christmas menu choice is unavailable. Please refresh the menu.' USING ERRCODE = '22023';
+      END IF;
+    END LOOP;
+  END LOOP;
+  v_policy := public.christmas_course_policy_v01(v_date);
+  IF v_policy IS NULL THEN
+    RAISE EXCEPTION 'Christmas bookings are not open for that date.' USING ERRCODE = '22023';
+  END IF;
+  v_requires := EXISTS (SELECT 1 FROM unnest(p_course_counts) c WHERE c > 1);
+  IF v_requires AND NOT (v_policy->>'multiple_courses_available')::boolean THEN
+    RAISE EXCEPTION 'Christmas bookings for two or three courses need a pre-order by noon seven days before the booking. Please choose one course or contact the team.' USING ERRCODE = '22023';
+  END IF;
+  v_result := public.create_table_booking_public_v06(
+    p_customer_id := (p_request->>'customer_id')::uuid,
+    p_booking_date := v_date, p_booking_time := (p_request->>'time')::time,
+    p_party_size := v_party, p_booking_purpose := 'christmas',
+    p_notes := p_request->>'notes', p_sunday_lunch := false,
+    p_source := coalesce(p_request->>'source', 'brand_site'),
+    p_high_chair_count := coalesce((p_request->>'high_chair_count')::integer, 0),
+    p_outside_seating := coalesce((p_request->>'outside_seating')::boolean, false),
+    p_requires_accessible_table := coalesce((p_request->>'requires_accessible_table')::boolean, false),
+    p_booking_period_id := (p_request->>'booking_period_id')::uuid,
+    p_booking_period_answer := true
+  );
+  IF v_result->>'state' IN ('confirmed', 'pending_payment') THEN
+    UPDATE public.table_bookings SET christmas_course_counts = p_course_counts,
+      booking_period_requires_preorder = v_requires
+      WHERE id = (v_result->>'table_booking_id')::uuid;
+    IF NOT FOUND THEN RAISE EXCEPTION 'Christmas booking snapshot was not saved.'; END IF;
+    v_result := v_result || jsonb_build_object('christmas_course_counts', p_course_counts,
+      'booking_period_requires_preorder', v_requires);
+  END IF;
+  RETURN v_result;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.create_table_booking_christmas_v01(jsonb, integer[]) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_table_booking_christmas_v01(jsonb, integer[]) TO service_role;
+
+-- Keep amendments explicit. Changing a date cannot silently switch off the pre-order policy;
+-- increasing a party needs a corresponding course choice for each added seat.
+CREATE FUNCTION public.assert_christmas_course_snapshot_v01()
+RETURNS trigger LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_catalog AS $$
+DECLARE v_requires boolean;
+BEGIN
+  IF NEW.christmas_course_counts IS NULL THEN
+    IF TG_OP = 'UPDATE' AND OLD.christmas_course_counts IS NOT NULL THEN
+      RAISE EXCEPTION 'Christmas course choices cannot be cleared.' USING ERRCODE = '22023';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF cardinality(NEW.christmas_course_counts) <> NEW.party_size
+     OR array_ndims(NEW.christmas_course_counts) <> 1
+     OR array_lower(NEW.christmas_course_counts, 1) <> 1
+     OR EXISTS (SELECT 1 FROM unnest(NEW.christmas_course_counts) c WHERE c IS NULL OR c NOT BETWEEN 1 AND 3) THEN
+    RAISE EXCEPTION 'Christmas bookings need a course choice for every guest when changing the party size.' USING ERRCODE = '22023';
+  END IF;
+  IF NEW.booking_type::text <> 'christmas' OR NEW.booking_period_answer IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Christmas course choices must remain attached to a Christmas booking.' USING ERRCODE = '22023';
+  END IF;
+  v_requires := EXISTS (SELECT 1 FROM unnest(NEW.christmas_course_counts) c WHERE c > 1);
+  NEW.booking_period_requires_preorder := v_requires;
+  IF TG_OP = 'UPDATE' AND (
+      NEW.booking_date IS DISTINCT FROM OLD.booking_date
+      OR NEW.christmas_course_counts IS DISTINCT FROM OLD.christmas_course_counts
+    ) AND v_requires AND (public.christmas_course_policy_v01(NEW.booking_date)->>'multiple_courses_available')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Christmas pre-order deadline has passed for that date.' USING ERRCODE = '22023';
+  END IF;
+  IF TG_OP = 'UPDATE' AND OLD.christmas_course_counts IS NOT NULL
+     AND NEW.christmas_course_counts IS DISTINCT FROM OLD.christmas_course_counts THEN
+    -- A changed tier invalidates that seat's old dishes. This runs in the same transaction
+    -- as the explicit staff amendment, so a later failure restores both snapshot and dishes.
+    DELETE FROM public.booking_preorder_selections s USING public.booking_preorder_covers c
+      WHERE s.cover_id = c.id AND c.table_booking_id = NEW.id
+        AND NEW.christmas_course_counts[c.ordinal] IS DISTINCT FROM OLD.christmas_course_counts[c.ordinal];
+  END IF;
+  RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.assert_christmas_course_snapshot_v01() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assert_christmas_course_snapshot_v01() TO service_role;
+CREATE TRIGGER table_bookings_christmas_course_snapshot
+BEFORE INSERT OR UPDATE ON public.table_bookings
+FOR EACH ROW EXECUTE FUNCTION public.assert_christmas_course_snapshot_v01();
+
+CREATE FUNCTION public.assert_christmas_preorder_selection_v01()
+RETURNS trigger LANGUAGE plpgsql SECURITY INVOKER SET search_path = public, pg_catalog AS $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.booking_preorder_covers c
+      JOIN public.table_bookings b ON b.id=c.table_booking_id
+      WHERE c.id=NEW.cover_id AND b.christmas_course_counts[c.ordinal]=1) THEN
+    RAISE EXCEPTION 'One-course Christmas guests do not need a pre-order.' USING ERRCODE = '22023';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.assert_christmas_preorder_selection_v01() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assert_christmas_preorder_selection_v01() TO service_role;
+CREATE TRIGGER booking_preorder_selections_christmas_course
+BEFORE INSERT OR UPDATE ON public.booking_preorder_selections
+FOR EACH ROW EXECUTE FUNCTION public.assert_christmas_preorder_selection_v01();

--- a/supabase/migrations/20260905100521_event_booking_dining_requests.sql
+++ b/supabase/migrations/20260905100521_event_booking_dining_requests.sql
@@ -1,0 +1,77 @@
+-- DRAFT: apply before deploying the optional event dining/arrival request UI.
+-- Existing booking creation stays unchanged for callers without requests.
+-- Requests and the new booking commit together, or both roll back.
+CREATE OR REPLACE FUNCTION public.create_event_booking_with_requests_v01(
+  p_event_id uuid,
+  p_customer_id uuid,
+  p_seats integer,
+  p_source text DEFAULT 'brand_site',
+  p_seating_preference text DEFAULT 'seated',
+  p_payment_hold_minutes integer DEFAULT NULL,
+  p_ticket_selections jsonb DEFAULT NULL,
+  p_dining_request text DEFAULT NULL,
+  p_early_arrival_request boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_booking_id uuid;
+  v_notes text;
+BEGIN
+  IF p_dining_request IS NOT NULL AND p_dining_request NOT IN ('before_event', 'during_event', 'not_sure') THEN
+    RAISE EXCEPTION 'invalid_dining_request' USING ERRCODE = '22023';
+  END IF;
+
+  v_notes := CASE p_dining_request
+    WHEN 'before_event' THEN 'Guest asks about food before the event.'
+    WHEN 'during_event' THEN 'Guest asks about food during the event.'
+    WHEN 'not_sure' THEN 'Guest would like to discuss food options.'
+    ELSE NULL
+  END;
+  IF COALESCE(p_early_arrival_request, false) THEN
+    v_notes := concat_ws(' ', v_notes, 'Guest would like to discuss arriving early.');
+  END IF;
+  IF v_notes IS NOT NULL THEN
+    v_notes := 'UNCONFIRMED REQUEST: ' || v_notes || ' Food availability and arrival arrangements must be agreed with the team. No separate dining booking has been made.';
+  END IF;
+
+  IF p_ticket_selections IS NOT NULL THEN
+    v_result := public.create_event_booking_v07(
+      p_event_id, p_customer_id, p_source, p_seating_preference,
+      p_payment_hold_minutes, p_ticket_selections
+    );
+  ELSE
+    v_result := public.create_event_booking_v06(
+      p_event_id, p_customer_id, p_seats, p_source,
+      p_seating_preference, p_payment_hold_minutes
+    );
+  END IF;
+
+  -- Conflicts can contain the ID of an EXISTING booking. Never change it.
+  -- Only these explicit states are new successful creates in v06 and v07.
+  IF COALESCE(v_result->>'state', '') NOT IN ('confirmed', 'pending_payment') THEN
+    RETURN v_result;
+  END IF;
+  IF v_notes IS NULL THEN
+    RETURN v_result;
+  END IF;
+
+  v_booking_id := NULLIF(v_result->>'booking_id', '')::uuid;
+  UPDATE public.bookings
+  SET notes = concat_ws(E'\n', NULLIF(btrim(notes), ''), v_notes), updated_at = now()
+  WHERE id = v_booking_id AND event_id = p_event_id AND customer_id = p_customer_id
+    AND status IN ('confirmed', 'pending_payment');
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_booking_request_persistence_failed';
+  END IF;
+
+  RETURN v_result || jsonb_build_object('requests_recorded', true);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) TO service_role;
+COMMENT ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) IS 'Service-only atomic event creation with unconfirmed dining and early-arrival requests in staff-visible booking notes.';

--- a/tasks/anchor-booking-growth/baseline.sql
+++ b/tasks/anchor-booking-growth/baseline.sql
@@ -1,0 +1,83 @@
+-- Read-only baseline. Change only these two London boundaries for later cohorts.
+-- Cohort: records created in this window, not bookings occurring in this window.
+with bounds as (
+  select timestamptz '2026-08-08 00:00 Europe/London' as starts,
+         timestamptz '2026-09-05 00:00 Europe/London' as ends
+), dining as (
+  select source, status, count(*) as bookings, sum(party_size) as booked_covers,
+    count(*) filter (where status::text not in ('cancelled','no_show')
+      and (seated_at is not null or completed_at is not null)) as attendance_marked,
+    count(*) filter (where status::text in ('cancelled','no_show')
+      and (seated_at is not null or completed_at is not null)) as conflicting_attendance
+  from table_bookings, bounds
+  where created_at >= starts and created_at < ends
+    and booking_purpose='food' and event_booking_id is null
+  group by source,status
+), hire as (
+  select status,count(*) as enquiries,
+    count(*) filter(where deposit_paid_date is not null) as deposit_recorded,
+    count(*) filter(where total_amount > 0) as nonzero_header_values
+  from private_bookings,bounds where created_at >= starts and created_at < ends
+  group by status
+), events as (
+  select status,count(*) as reservations,sum(seats) as reserved_seats
+  from bookings,bounds where created_at >= starts and created_at < ends
+    and not coalesce(is_reminder_only,false) group by status
+), analytics as (
+  select event_type,count(*) as raw_events,
+    count(distinct table_booking_id) as distinct_table_bookings,
+    count(distinct event_booking_id) as distinct_event_bookings,
+    count(distinct private_booking_id) as distinct_private_bookings
+  from analytics_events,bounds where created_at >= starts and created_at < ends
+    and event_type in ('table_booking_created','event_booking_created','private_booking_confirmed')
+  group by event_type
+)
+select jsonb_build_object(
+  'dining',(select jsonb_agg(dining) from dining),
+  'private_hire',(select jsonb_agg(hire) from hire),
+  'events',(select jsonb_agg(events) from events),
+  'analytics',(select jsonb_agg(analytics) from analytics)
+);
+
+-- Supplement: effective private-hire charges, aggregated before the cohort join.
+with cohort as (
+ select id,status from private_bookings
+ where created_at >= timestamptz '2026-08-08 00:00 Europe/London'
+   and created_at < timestamptz '2026-09-05 00:00 Europe/London'
+), values_by_booking as (
+ select c.id,c.status,count(i.id) as items,coalesce(sum(i.line_total),0) as line_total
+ from cohort c left join private_booking_items i on i.booking_id=c.id group by c.id,c.status
+)
+select status,count(*) as bookings,count(*) filter(where items>0) as with_items,
+ count(*) filter(where line_total>0) as nonzero_item_totals,sum(line_total) as item_totals
+from values_by_booking group by status;
+
+-- Supplement: event analytics reconciliation at reservation-ID grain.
+with c as (
+ select id from bookings
+ where created_at >= timestamptz '2026-08-08 00:00 Europe/London'
+ and created_at < timestamptz '2026-09-05 00:00 Europe/London'
+ and not coalesce(is_reminder_only,false)
+), a as (
+ select distinct event_booking_id as id from analytics_events
+ where event_type='event_booking_created'
+ and created_at >= timestamptz '2026-08-08 00:00 Europe/London'
+ and created_at < timestamptz '2026-09-05 00:00 Europe/London'
+)
+select (select count(*) from c) as booking_records,(select count(*) from a) as distinct_analytics,
+ (select count(*) from c join a using(id)) as matched,
+ (select count(*) from c left join a using(id) where a.id is null) as without_analytics,
+ (select count(*) from a left join c using(id) where c.id is null) as outside_cohort;
+
+-- Supplement: repeat events are not automatically duplicate customer bookings.
+select count(*) as event_rows,count(distinct metadata->>'source') as sources,
+ count(distinct metadata->>'seats') as seat_values
+from analytics_events where event_type='event_booking_created'
+ and created_at >= timestamptz '2026-08-08 00:00 Europe/London'
+ and created_at < timestamptz '2026-09-05 00:00 Europe/London'
+group by event_booking_id having count(*)>1;
+
+-- Supplement: check-in event-time count, deliberately separate from creation cohort.
+select count(*) as checkin_rows from event_check_ins
+where check_in_time >= timestamptz '2026-08-08 00:00 Europe/London'
+ and check_in_time < timestamptz '2026-09-05 00:00 Europe/London';

--- a/tasks/anchor-booking-growth/capacity-review.md
+++ b/tasks/anchor-booking-growth/capacity-review.md
@@ -1,0 +1,47 @@
+# Dated event capacity review
+
+Read-only snapshot: production events, 5 September 2026. No values changed.
+
+| Date | Event | Booking mode | Capacity |
+|---|---|---|---|
+| 11 September | Detention Disco: Back to School Music Bingo | communal | unset |
+| 16 September | Autumn Kick-Off Quiz Night | communal | unset |
+| 18 September | Big Sing Friday: Karaoke Night | communal | unset |
+| 25 September | Lovely Jubbly: Only Fools and Horses Charity Quiz Night | table | unset |
+| 30 September | Autumn Jackpot Cash Bingo | communal | unset |
+| 7 October | A Hint of Halloween Quiz Night | communal | unset |
+| 16 October | Screams & Soundtracks: Classic Horror Music Bingo | communal | unset |
+| 31 October | Enter If You Dare: The House of Horrors Halloween Party | general | 100 |
+| 4 November | Sparks & Sparklers Quiz Night | communal | unset |
+| 13 November | Sequins & Showstoppers: Strictly-Season Music Bingo | table | unset |
+| 18 November | Snowball Showdown Cash Bingo | communal | unset |
+| 20 November | Tasting Night | table | unset |
+| 2 December | Tinsel & Trivia Quiz Night | communal | unset |
+| 11 December | Sleigh My Name: Festive Music Bingo | table | unset |
+| 16 December | Christmas Jackpot Cash Bingo | communal | unset |
+
+Seated and standing capacities are also unset on these records. The one existing capacity is recorded configuration, not an independent physical safety assessment. Table and communal allocation rules must be checked separately; a generic capacity number does not prove a room layout can accommodate it.
+
+The report's quiz 80, cash bingo 60 and music bingo 90 figures are operating guidance, not approval to set each dated event. Exact sellable values require venue confirmation after layout, holds and staff constraints. Keep truthful availability based on the existing allocator; do not add scarcity to unset records.
+
+The live September karaoke record predates the report's proposed 2027 programme. Preserve it and flag the discrepancy for the owner; do not cancel or promote it automatically.
+
+## Exact record mapping
+
+The table above is in the same order as these verified event IDs. No after-values are proposed until the venue confirms each layout.
+
+1. `5cdadf74-97c1-4ec0-b495-d369a7304494`
+2. `9b78f364-7712-4c92-9b09-ffa9132e37e5`
+3. `9d03a427-d331-45bd-91af-142b396b82ae`
+4. `e9e84ee8-c59b-4f93-80f6-7e7961a03240`
+5. `d81512e7-5e99-48fd-a153-3400c2f6f009`
+6. `76ec328b-48f8-47c0-b041-cc405e085deb`
+7. `c3ac7e18-e562-4ef8-bea7-cae29f6e96ac`
+8. `d52cbd18-d293-4516-beca-e151eaa90180`
+9. `8acfe965-ade6-4a9f-a666-e90ecdea2b7b`
+10. `c3e9fbbd-df4a-41f2-a1c6-8194a5979735`
+11. `6e761f65-8b17-4bc9-8a01-d032b77f6a66`
+12. `5bd854ce-48e7-4ca8-8e7c-c52cc7ec1e65`
+13. `ccbe8b82-15b0-4261-b58e-2ac4d7210e25`
+14. `9b8f85f8-c5cc-4956-ad1f-72f569e7fc4a`
+15. `b9334958-76b4-4504-a64a-0d47145bd75e`

--- a/tasks/anchor-booking-growth/changed-files.md
+++ b/tasks/anchor-booking-growth/changed-files.md
@@ -1,0 +1,210 @@
+# Changed files and retained counterparts
+
+Application edits are in isolated codex/anchor-booking-growth worktrees. Original working copies and unrelated edits remain untouched.
+
+## Management
+
+- `src/app/(authenticated)/table-bookings/[id]/BookingDetailClient.tsx`
+
+- `src/app/(authenticated)/table-bookings/foh/FohScheduleClient.tsx`
+
+- `src/app/(authenticated)/table-bookings/foh/components/FohMiniModals.tsx`
+
+- `src/app/api/boh/table-bookings/[id]/party-size/route.ts`
+
+- `src/app/api/event-bookings/route.ts`
+
+- `src/app/api/foh/bookings/[id]/christmas-courses/route.ts`
+
+- `src/app/api/foh/bookings/[id]/party-size/route.ts`
+
+- `src/app/api/table-bookings/periods/route.test.ts`
+
+- `src/app/api/table-bookings/periods/route.ts`
+
+- `src/app/api/table-bookings/route.ts`
+
+- `src/app/g/[token]/table-manage/PreorderSection.tsx`
+
+- `src/app/g/[token]/table-manage/__tests__/preorder-cutoff.test.ts`
+
+- `src/components/features/table-bookings/ChristmasCourseFields.tsx`
+
+- `src/components/features/table-bookings/preorder/SeasonalPreorderSection.tsx`
+
+- `src/lib/event-booking-sheet-template.test.ts`
+
+- `src/lib/events/staff-seat-updates.test.ts`
+
+- `src/lib/events/staff-seat-updates.ts`
+
+- `src/lib/table-bookings/booking-idempotency.test.ts`
+
+- `src/lib/table-bookings/booking-idempotency.ts`
+
+- `src/lib/table-bookings/bookings.ts`
+
+- `src/lib/table-bookings/highchair-outside.test.ts`
+
+- `src/lib/table-bookings/preorder.test.ts`
+
+- `src/lib/table-bookings/preorder.ts`
+
+- `src/services/__tests__/event-bookings-dining-requests.test.ts`
+
+- `src/services/event-bookings.ts`
+
+- `src/types/preorders.ts`
+
+- `supabase/migrations/20260905100155_christmas_course_snapshot.sql`
+
+- `supabase/migrations/20260905100521_event_booking_dining_requests.sql`
+
+- `tasks/anchor-booking-growth/baseline.sql`
+
+- `tasks/anchor-booking-growth/capacity-review.md`
+
+- `tasks/anchor-booking-growth/changed-files.md`
+
+- `tasks/anchor-booking-growth/christmas-course-activate.sql`
+
+- `tasks/anchor-booking-growth/christmas-course-disable.sql`
+
+- `tasks/anchor-booking-growth/christmas-policy-verification.md`
+
+- `tasks/anchor-booking-growth/measurement.md`
+
+- `tasks/anchor-booking-growth/menu-corrections.json`
+
+- `tasks/anchor-booking-growth/promotion-brief.md`
+
+- `tasks/anchor-booking-growth/release-approval.md`
+
+- `tasks/anchor-booking-growth/verification.md`
+
+- `tasks/event-dining-request-migration-2026-09-05.md`
+
+- `tasks/plan-2026-09-05-anchor-booking-growth.md`
+
+- `tasks/todo.md`
+
+- `tests/api/event-bookings-dining-requests.test.ts`
+
+- `tests/api/tableBookingRouteErrorPayloads.test.ts`
+
+- `tests/api/tableBookingStructuredPersistence.test.ts`
+
+- `tests/database/event-booking-dining-requests.sql`
+
+- `tests/db/christmas-course-activation.sql`
+
+- `tests/db/christmas-course-snapshot.sql`
+
+## Website
+
+- `app/api/analytics/route.test.ts`
+
+- `app/api/analytics/route.ts`
+
+- `app/api/enquiry/christmas/route.ts`
+
+- `app/api/event-bookings/route.ts`
+
+- `app/api/public/private-booking/route.ts`
+
+- `app/api/table-bookings/route.ts`
+
+- `app/book-table/page.tsx`
+
+- `app/christmas-parties/client-components.tsx`
+
+- `app/christmas-parties/page.tsx`
+
+- `app/events/[id]/page.tsx`
+
+- `app/sunday-roast/page.tsx`
+
+- `components/CommunicationConsentFields.tsx`
+
+- `components/PrivateBookingSection.tsx`
+
+- `components/PrivateHireQuickEnquiry.tsx`
+
+- `components/features/EventBooking/ManagementEventBookingForm.tsx`
+
+- `components/features/TableBooking/ManagementTableBookingForm.tsx`
+
+- `components/features/TableBooking/SeasonalPreorderPicker.tsx`
+
+- `components/features/christmas/ChristmasLightbox.tsx`
+
+- `components/features/christmas/__tests__/lightbox-suppression.test.ts`
+
+- `components/layout/StickyCtas.tsx`
+
+- `docs/SSOT.md`
+
+- `lib/api/bookings.ts`
+
+- `lib/api/events.ts`
+
+- `lib/booking-cta.ts`
+
+- `lib/table-booking-idempotency.ts`
+
+- `lib/table-booking/__tests__/quick-book.test.ts`
+
+- `lib/table-booking/quick-book.ts`
+
+- `lib/table-booking/submission.ts`
+
+- `lib/tracking/dispatcher.ts`
+
+- `lib/tracking/url-context.ts`
+
+- `scripts/booking-growth-smoke-server.cjs`
+
+- `scripts/christmas-course-growth-smoke.cjs`
+
+- `scripts/cta-growth-smoke.cjs`
+
+- `scripts/event-request-growth-smoke.cjs`
+
+- `scripts/full-table-growth-smoke.cjs`
+
+- `scripts/private-hire-smoke.cjs`
+
+- `scripts/table-growth-smoke.cjs`
+
+- `tasks/todo.md`
+
+- `tests/api/christmas-enquiry.test.ts`
+
+- `tests/api/event-bookings-idempotency.test.ts`
+
+- `tests/api/private-booking-idempotency.test.ts`
+
+- `tests/lib/tracking-url-context.test.ts`
+
+- `tests/ssot-drift-guard.test.ts`
+
+- `tests/unit/ManagementEventBookingForm.test.tsx`
+
+- `tests/unit/ManagementTableBookingForm.test.tsx`
+
+- `tests/unit/booking-cta.test.ts`
+
+- `tests/unit/christmas-course-policy.test.tsx`
+
+- `tests/unit/christmas-parties-booking-journeys.test.ts`
+
+- `tests/unit/christmas-parties-responsive.test.ts`
+
+- `tests/unit/private-hire-quick-enquiry.test.tsx`
+
+- `tests/unit/sticky-ctas-journeys.test.tsx`
+
+
+## Deliberately unchanged
+
+Existing allocation RPCs v06/v07, ordinary table availability API purpose rules, waitlist machinery, payment capture/refund arithmetic, event booking-sheet renderer and published operating hours remain unchanged. The new wrappers call the existing allocators. The sheet already reads notes. Existing private-hire queues are reused. Latest unrelated main-branch API fixes were incorporated without conflict.

--- a/tasks/anchor-booking-growth/christmas-course-activate.sql
+++ b/tasks/anchor-booking-growth/christmas-course-activate.sql
@@ -1,0 +1,12 @@
+-- Proposed only. Apply after the paired deployments and approved migration pass verification.
+-- Verified starting state: this key did not exist in tfcasgxopxegwrabvwat on 5 September 2026.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.system_settings WHERE key='christmas_course_policy_enabled') THEN
+    RAISE EXCEPTION 'Christmas course setting changed since review. Re-read and approve its current state.';
+  END IF;
+  INSERT INTO public.system_settings(key, value, description)
+  VALUES ('christmas_course_policy_enabled', '{"value": true}'::jsonb,
+    'Enable per-guest Christmas course selection after the compatible booking and staff amendment deployments.');
+END;
+$$;

--- a/tasks/anchor-booking-growth/christmas-course-disable.sql
+++ b/tasks/anchor-booking-growth/christmas-course-disable.sql
@@ -1,0 +1,11 @@
+-- Proposed non-destructive rollback. Retains snapshots and restores the original disabled behaviour.
+DO $$
+BEGIN
+  UPDATE public.system_settings
+  SET value='{"value": false}'::jsonb, updated_at=now()
+  WHERE key='christmas_course_policy_enabled' AND value='{"value": true}'::jsonb;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Christmas course setting is not in the reviewed enabled state. Re-read before changing it.';
+  END IF;
+END;
+$$;

--- a/tasks/anchor-booking-growth/christmas-policy-verification.md
+++ b/tasks/anchor-booking-growth/christmas-policy-verification.md
@@ -1,0 +1,72 @@
+# Christmas course policy implementation and migration review
+
+Status: local only, not applied, feature disabled by default. No customer records, payments, communications or production settings were changed.
+
+## Verified current contract
+
+The repository's `.env.local` resolves to `tfcasgxopxegwrabvwat.supabase.co`. Read-only catalogue queries on 5 September 2026 matched that project.
+
+The live `christmas-2026` period is active from 10 November to 20 December 2026. Its configuration is 6 to 20 guests, 24 hours' booking notice, a 10-pound deposit per guest, required pre-orders, seven-day pre-order cutoff and seven-day refund cutoff. The existing code closes pre-orders at noon London seven calendar days before the booking, not 168 hours before the sitting. This boundary is preserved.
+
+The live booking table has no course-tier column, and the public v06 create RPC accepts no tier argument. Existing per-seat food selections permit mixed course counts at one table. New course state therefore records an integer array in seat order; a booking-wide scalar would discard that supported behaviour.
+
+Existing refund code includes the whole London calendar day exactly seven days before the booking. The SQL refund snapshot says "Full refund up to 7 days". The Christmas page now states this inclusive boundary. Existing financial logic and recorded promises are unchanged.
+
+Live metadata at review: 793 booking rows, approximately 880 kB including indexes; latest applied migration `20260905052727`. Dependent views are `customer_communications` and `table_bookings_awaiting_confirmation`. Their existing columns and behaviour remain unchanged; this additive field is not exposed through them.
+
+## Exact migration draft
+
+File: `supabase/migrations/20260905100155_christmas_course_snapshot.sql`
+
+Migration name: `christmas_course_snapshot`
+
+SHA-256 at this review: `92af6c81488e03aafd15286d82aa570a91273c55c1f21b4aa4f357d813079b21`
+
+The SQL file is the complete application payload. Recalculate the checksum after any review edit before approval.
+
+The draft adds nullable `table_bookings.christmas_course_counts`, four service-only functions and two triggers. The new create wrapper validates every seat's tier and dishes, delegates to unchanged public v06 allocation and deposit logic, then stores the snapshot and resolved pre-order requirement in that same transaction. Blocked results never update an existing booking. The old public RPC remains unchanged.
+
+The capability RPC returns no supported policy until `christmas_course_policy_enabled` is explicitly enabled. Its default is false. This migration does not enable it. Deploy the compatible management and website consumers, verify them with fixtures, then separately enable the setting.
+
+The snapshot guard preserves null legacy records. New records cannot lose their snapshot or change party size without matching course choices. Date and tier changes preserve the cutoff. Explicit tier amendments clear only that changed seat's old dishes, in the same transaction, and selections cannot subsequently be inserted for a one-course seat. Other seats and all deposits remain untouched.
+
+## Risk and rollout
+
+`ALTER TABLE ADD COLUMN` needs a brief exclusive metadata lock, with no default, rewrite or backfill. Trigger creation also takes a short table lock. Functions use SECURITY INVOKER and fixed search paths. All new executable functions revoke PUBLIC, anon and authenticated access and grant only service_role. No existing grant, RLS policy, refund promise or historical booking is changed.
+
+The conditional DELETE in the amendment trigger is a high-risk statement requiring review: it runs only after an explicit course-count change on a booking carrying the new snapshot and clears dishes for the changed seats. A failed update rolls it back. It prevents the kitchen receiving dishes the amended tier no longer includes. The isolated SQL fixture covers this behaviour.
+
+Management and website code must be deployed before activation. Missing schema or a disabled setting never advertises course support. Existing clients continue the legacy path; supplied new course fields cannot silently fall back if the wrapper is unavailable.
+
+## Validation completed
+
+- Isolated PostgreSQL 17 executes the complete migration inside a fixture transaction and rolls it back, using `tests/db/christmas-course-snapshot.sql`.
+- SQL fixtures prove the default-off capability returns no policy before the test setting is enabled, using the same wrapped-value lookup as the live get_setting_bool helper. They cover six and twenty one-course guests and 60/200-pound deposits; five and twenty-one rejected; missing tiers and missing dishes rejected; mixed one/two/three-course snapshots; dates after the pre-order cutoff rejected; date and headcount amendments; blocked conflict with an existing ID; allocator failure; legacy null snapshots; changed-tier dish clearing; one-course dish rejection; service-only grants.
+- The allocator in this isolated SQL harness is a fixture. It proves wrapper and trigger behaviour, not the full live allocation system. The production v06 allocator is unchanged and was inspected read-only.
+- Management targeted tests: 75 baseline/course/party-edit tests, 84 deposit/Christmas/cutoff/fixture-rendered confirmation tests, and 19 create/error route tests passed in their recorded runs. These groups overlap.
+- Website targeted tests: 51 course-picker and Christmas-page tests passed before final inclusive-refund copy adjustment. Parent integration checks must rerun after the final copy adjustment.
+- Idempotency tests confirm omitted fields retain old hashes, identical arrays replay and changed tiers conflict.
+- Existing GMT, BST and clock-change cutoff tests pass. No real SMS or email was sent: confirmation templates were rendered with mocked transports and checked for missing or invalid values.
+- Parent owns final full-suite, lint, typecheck, production build and browser verification across both repositories. Do not interpret this file as proof of live deployment.
+
+## Safe rollback and post-apply checks
+
+Default rollback is to disable `christmas_course_policy_enabled`, leaving the additive schema, stored snapshots and historical choices intact. Do not drop the column after bookings use it. Existing snapshots remain readable and enforced. A forward fix is required if snapshot-aware amendments are affected.
+
+Before application, re-read the exact file and recheck its checksum and project identity. After approved application, confirm migration history, column and trigger definitions, function grants and the anonymous-surface report. Keep the feature disabled until the paired deployments pass fixture booking, retry, amendment and payment-review checks. Activation is a separate production setting change and is not performed by this draft.
+
+## Exact activation and rollback setting payloads
+
+A read-only live query confirmed `christmas_course_policy_enabled` is absent on project `tfcasgxopxegwrabvwat`. Its original behaviour is disabled through the default false. No setting value has been changed.
+
+The separate activation payload is `tasks/anchor-booking-growth/christmas-course-activate.sql`, SHA-256 `b3bacf187e3b25ce1ab474b8f78a4fa2791b24f9f53ec1dc223a7c65396e2085`. It refuses to run if the key already exists, so changed starting state requires fresh review. Apply only after the migration and paired deployments pass verification.
+
+The exact disable rollback is `tasks/anchor-booking-growth/christmas-course-disable.sql`, SHA-256 `5dc3e2c507c09edb7ae2ed9a0e81af4a39ce75d9a014ad0aab06dc73d947a9fc`. It changes only the reviewed true value to false and refuses any unexpected state. It restores the original disabled behaviour while retaining the setting row and all booking snapshots.
+
+Both complete SQL payloads executed in an isolated PostgreSQL transaction using `tests/db/christmas-course-activation.sql`: activation returned the true setting, rollback returned false, and the harness rolled all objects back. No production setting changed.
+
+This rollback retains the new schema and recorded snapshots. It stops new course-aware bookings and also refuses multi-course/date amendments that need the disabled capability. Read-only staff views and existing financial records remain intact; repair and re-enable rather than dropping snapshots.
+
+Final targeted follow-up: 19 create/error-route tests passed after their mocks were aligned; 116 website enquiry, page, course-picker and SSOT checks passed under UTC. Management gained explicit one/two/three-course completeness and exactly-noon cutoff assertions. Those Vitest runs used the repository configuration, which pins London; setting TZ=UTC in the shell alone was not an independent UTC verification. Parent owns the UTC override-configuration run. Parent integration logs remain the final authority for full-suite/build checks.
+
+Public browser fixture verification completed: six one-course selectors without menu fields; incomplete mixed selections blocked progression; complete mixed choices enabled it; after-cutoff two/three-course choices disabled. Fixture matched the enabled two-screen live flag. No booking was submitted from this check; blocked telemetry produced expected fetch errors. Sanitised evidence and screenshots are under /tmp/anchor-growth/christmas/.

--- a/tasks/anchor-booking-growth/measurement.md
+++ b/tasks/anchor-booking-growth/measurement.md
@@ -1,0 +1,48 @@
+# Booking growth measurement baseline
+
+Read-only snapshot: 5 September 2026. Source: production Supabase project `tfcasgxopxegwrabvwat`, verified against the repository's configured project. Reproducible query: `baseline.sql` beside this file.
+
+## What this baseline can support
+
+Use unique booking IDs to compare booking acquisition. Do not use raw analytics rows as conversions, and do not use these counts to estimate incremental profit or attendance.
+
+The cohort contains records created from 8 August 2026 00:00 London, inclusive, to 5 September 2026 00:00 London, exclusive. It includes bookings for later service dates. It is not the June to August service-date cohort in the original report. No guest names, contact details or free-text booking notes were exported.
+
+| Measure | Observed result | Meaning |
+|---|---:|---|
+| Event reservation records, excluding reminder-only rows | 23 | 20 confirmed, 1 completed, 2 cancelled at snapshot |
+| Event booking-created analytics rows | 25 | Raw event count overstates unique reservations |
+| Distinct event IDs in those analytics | 23 | All 23 matched the actual reservation cohort; none unmatched |
+| Private-hire records created | 6 | 2 confirmed with deposit dates, 3 draft, 1 cancelled |
+| Nonzero private-hire header totals | 0 of 6 | Header totals are not the effective charge source |
+| Private-hire item totals | 2 confirmed bookings: £1,249; 1 draft: £900 | Actual item-level values exist despite zero headers; these are quoted line totals, not verified completed revenue |
+| Private-hire confirmation analytics | 5 rows, 3 IDs | Confirmation events are not enquiry-cohort conversion counts |
+| Brand-site food booking records | 71 | 34 completed, 10 visited-waiting-for-review, 9 confirmed, 14 cancelled, 4 no-show |
+| Table booking-created analytics | 83 unique IDs | Different source/purpose coverage from the food-only website cohort; do not equate totals |
+| Event check-in rows occurring in the window | 0 | This check-in table alone cannot establish event attendance |
+
+Two repeated event-creation IDs each have two different recorded sources and identical seat counts. They are not proven duplicate customer bookings. Count distinct booking IDs and keep source conflicts visible. Do not delete analytics records to force a match.
+
+The table query found three records with cancellation/no-show status and an attendance timestamp. It excludes those from the conservative attendance-marked measure and reports them separately. A timestamp alone is not proof of a completed visit. Some visited statuses lack timestamps. Staff interpretation is needed before historical attendance is treated as a reliable denominator.
+
+## Repeatable definitions
+
+- Dining acquisition: unique non-event food booking ID created in the cohort, segmented by source and current state. Show cancellations and no-shows separately.
+- Dining attendance: service-date cohort with a trustworthy attended status/timestamp, excluding contradictory terminal states. Report missing and conflicting data rather than impute it.
+- Event acquisition: unique non-reminder reservation ID. Sum seats once per reservation and retain cancellations separately.
+- Event attendance/fill: attended seats divided by approved sellable seats for the same dated event. A completed reservation, check-in row and individual attended seat are different grains. Do not multiply a lead-booker check-in into full-party attendance without operational confirmation.
+- Private hire: enquiry-created cohort followed through quote, deposit and completion. Use actual deposited status rather than a button or repeated confirmation analytics event. Use item-level charge totals (as the current queries service does), reconcile invoices/payment state and discounts/VAT before reporting completed value.
+- Web conversion: unique business confirmations divided by eligible consent-aware sessions in the same definition/window. GA4 sessions/device detail are not present in these database aggregates; no conversion rate is published here.
+- Contribution: verified sales less relevant variable costs, with deposit receipts excluded from double counting and attendance/substitution limitations stated.
+
+## Weekly operating check
+
+Run the read-only query with a new completed cohort window. Reconcile IDs before interpreting changes. Track late status updates separately; an enquiry cohort must mature before judging close rate. Keep baseline snapshots for comparison and annotate releases, service changes and promotions.
+
+The initial promotion gate remains closed until service capacity and staff coverage are confirmed, a source-tagged campaign can be tied to its booking IDs, and attendance/sales can be established. No dashboard, automation, campaign or live record was changed for this baseline.
+
+## Private-hire follow-up coverage
+
+Independent read-only review of the same six-record cohort found one contract-sent timestamp, two deposit dates, no completed bookings and one cancellation with a populated reason. Existing staff queues cover expiring holds, stale drafts, missing details, unpaid balances and pending SMS. Use these existing queues.
+
+There is no assigned lead owner or first-human-response timestamp in the inspected schema. Created-by, updated-at and automated message timestamps do not establish these measures. Response-time and ownership reporting therefore remain unavailable. Cancellation reasons sometimes use generic defaults, so a populated value is not automatically an actionable commercial loss reason. No fields or retrospective values were invented.

--- a/tasks/anchor-booking-growth/menu-corrections.json
+++ b/tasks/anchor-booking-growth/menu-corrections.json
@@ -1,0 +1,16 @@
+{
+  "status": "prepared, not applied",
+  "reason": "Replace generated editorial instructions with the verified existing dish name. No ingredients, names, prices or dietary flags change.",
+  "changes": [
+    {"id":"3953fc58-b528-45af-adc0-56dc5a345160","name":"Mayonnaise","description":"Mayonnaise."},
+    {"id":"862e843a-7600-46fc-b3f0-c2f4a4d0e320","name":"Bisto Gravy","description":"Bisto gravy."},
+    {"id":"71086b08-9c25-4ecb-9b4b-d8375dfaff9b","name":"Burger Sauce","description":"Burger sauce."},
+    {"id":"8302b994-3ce5-48bb-b43c-b75a852edbe8","name":"Mint Sauce","description":"Mint sauce."},
+    {"id":"512e9811-cd69-40f3-92a3-ebe3e8ef0c5c","name":"Strawberry Sauce","description":"Strawberry sauce."},
+    {"id":"b3f74a39-ced7-4731-a699-665ab87aeeb8","name":"Broccoli Cheese","description":"Broccoli cheese."},
+    {"id":"d9772619-85eb-481c-8e7c-9795f177e6b9","name":"Add crispy bacon","description":"Add crispy bacon."},
+    {"id":"a0f4aed4-2b4f-4b82-8f12-e12fd6ad1114","name":"Add hash brown","description":"Add hash brown."}
+  ],
+  "expected_description_template": "{name} keeps the existing menu flavour clear and concise, using the current dish wording without adding new ingredients. It is written for guests choosing food from The Anchor menu.",
+  "application_guard": "Re-read each current description and only replace it if it still equals the captured template. Use the authorised menu edit path and preserve prior values for rollback. No record should be changed by ID alone."
+}

--- a/tasks/anchor-booking-growth/promotion-brief.md
+++ b/tasks/anchor-booking-growth/promotion-brief.md
@@ -1,0 +1,17 @@
+# First booking-growth test, prepared brief
+
+Status: proposal only, no campaign created and no spend authorised by this brief.
+
+## Proposed first test
+
+Use the reservation-led Sunday page before adding paid acquisition. Compare several comparable Sunday services against the saved baseline. Primary acquisition measure: unique website food bookings. Business guardrails: attended covers, cancellations/no-shows and service capacity. Separate existing walk-ins moving online from additional diners.
+
+The landing page is `https://www.the-anchor.pub/sunday-roast`; its booking action remains the current table-booking journey. Campaign links, when approved, use `utm_source=google`, `utm_medium=cpc`, `utm_campaign=anchor_sunday_booking_test`. Do not put customer identifiers in URLs.
+
+## Paid pilot after the gates pass
+
+Proposed first-stage ceiling: £100 total within the owner's £500 monthly ceiling, with no automatic replenishment. This is a proposed test cap, not an assumed market advertising rate or an instruction to spend. Configure exact live dates and targeting only after the team identifies Sunday services with sellable space and staffing. Retain those settings in the final campaign approval package.
+
+Use only verified current food photographs and the website's approved offer. Send diners directly to the Sunday page, not a generic homepage. Do not publish scarcity or unsupported prices. Pause the pilot if attribution breaks, the booking path fails or service capacity is exhausted. Do not interpret clicks or enquiry starts as sales.
+
+Before launch, include the final ad copy/assets, exact run dates, geographical settings, channel account, budget cap and break-even assumptions in one owner approval packet. Review completed attended bookings before spending more. Private-hire advertising follows once completed booking values and follow-up data can support a cost limit; hosted events follow verified date capacities. No promotional messages or partner outreach are sent by this implementation.

--- a/tasks/anchor-booking-growth/release-approval.md
+++ b/tasks/anchor-booking-growth/release-approval.md
@@ -1,0 +1,33 @@
+# Production release approval package
+
+Prepared only. Production project: the-anchor-management-tools, tfcasgxopxegwrabvwat, tfcasgxopxegwrabvwat.supabase.co. No production changes have been applied.
+
+## Changes requiring exact approval
+
+1. Christmas migration: `20260905100155_christmas_course_snapshot.sql`, SHA-256 `92af6c81488e03aafd15286d82aa570a91273c55c1f21b4aa4f357d813079b21`. Full SQL: [Christmas migration](../../supabase/migrations/20260905100155_christmas_course_snapshot.sql). Risk, validation, preserved booking behaviour and rollback: [Christmas review](christmas-policy-verification.md).
+2. Event-request migration: `20260905100521_event_booking_dining_requests.sql`, SHA-256 `7a2fb0cf3d419601d978cdac8d10c3ac3f754c4d1e9223a318ad92bbf0c3ab8f`. Full SQL and exact function-drop rollback: [event-request review](../event-dining-request-migration-2026-09-05.md).
+3. After both compatible applications are deployed and checked, activate Christmas course support using the separately checksummed guarded setting SQL in christmas-policy-verification.md. Disable using its guarded rollback if necessary; retain customer snapshots.
+4. Replace the eight generated menu descriptions below only while each still matches the captured old text. Names, prices, ingredients and dietary flags are not changed. Exact IDs, before-text template and guard are in menu-corrections.json.
+
+| Dish | Replacement description |
+|---|---|
+| Mayonnaise | Mayonnaise. |
+| Bisto Gravy | Bisto gravy. |
+| Burger Sauce | Burger sauce. |
+| Mint Sauce | Mint sauce. |
+| Strawberry Sauce | Strawberry sauce. |
+| Broccoli Cheese | Broccoli cheese. |
+| Add crispy bacon | Add crispy bacon. |
+| Add hash brown | Add hash brown. |
+
+## Ordered release
+
+Recheck project identity, migration history and checksums. Apply the exact approved migrations through the connected migration API. Re-read definitions, permissions, history and anonymous access. Release management before the website, then activate course support only after compatible consumers are verified. Apply guarded menu edits through the existing authorised menu path. Check production aliases, deployment IDs and read-only booking pages.
+
+No real booking, message, payment or refund is part of this approval package. Mutating tests remain isolated. No campaign or spend is included.
+
+## Outstanding operational data
+
+Dated sellable event capacities remain unchanged until the venue provides exact numbers for capacity-review.md. The existing Halloween capacity remains 100 as recorded. Guidance capacities are not substituted for actual layouts. The live September karaoke record is retained despite the report's 2027 statement.
+
+The promotion brief is prepared, but final service dates, capacity, assets, attribution and cost checks must be settled before a separate campaign approval. GA4 session/device reporting and measured first-human-response time remain unavailable in this review.

--- a/tasks/anchor-booking-growth/verification.md
+++ b/tasks/anchor-booking-growth/verification.md
@@ -1,6 +1,6 @@
 # Booking growth implementation evidence
 
-Status: local implementation, awaiting completed release checks and exact production migration approval. No production data, customer communication or campaign changed.
+Status: implementation pushed to the paired codex/anchor-booking-growth branches, awaiting exact production approval. Release checks completed; production application remains blocked on approval. No production data, customer communication or campaign changed.
 
 ## Implemented scope
 
@@ -63,3 +63,7 @@ Page-specific persistent actions: 18 checks passed in Chromium and WebKit across
 Sanitised evidence is in /tmp/anchor-growth/private-hire and /tmp/anchor-growth/tables. Browser scripts are saved in the website scripts directory. The temporary fixture has a copied app root and separate cache, guards upstream sockets/fetch, and never targets production for writes.
 
 Christmas browser check passed with the two-screen feature enabled, matching the read-only live flag. Six one-course guests were not asked for dishes. Mixed one/two/three-course choices blocked progression until the required dishes were selected, then allowed progression. After the cutoff, two/three-course options were disabled. External requests and all POST requests were blocked; expected blocked telemetry errors were recorded. Screenshots and sanitised evidence: /tmp/anchor-growth/christmas/.
+
+The enabled two-screen full table form also completed synthetic bookings in Chromium and WebKit. The actual website proxy forwarded purpose=drinks, four guests and the retained date/time. Both enabled and fallback full-form variants therefore have browser confirmation evidence.
+
+Draft pull requests: management #122 and the paired website booking-growth pull request. No production merge, migration, activation, menu edit or campaign has occurred.

--- a/tasks/anchor-booking-growth/verification.md
+++ b/tasks/anchor-booking-growth/verification.md
@@ -1,0 +1,65 @@
+# Booking growth implementation evidence
+
+Status: local implementation, awaiting completed release checks and exact production migration approval. No production data, customer communication or campaign changed.
+
+## Implemented scope
+
+- Reservation-led Sunday copy, with walk-ins still welcome.
+- A reproduced quick-book outage no longer remains on Checking times after the request ends. The sheet shows a failed-check state and retry action. The drinks-purpose handoff to the full form preserves the explicit choice.
+- Page-specific persistent actions for private hire, regular events and dated events. Existing Christmas and Nations actions retained. Closed, cancelled, expired and sold-out event states do not advertise a reservable form.
+- Short private-hire enquiry alongside the estimator, including undecided dates, retained error inputs, consent, spam protection, duplicate protection and truthful emailed-versus-saved confirmation.
+- Promotion suppression persists while the short enquiry is active, including after focus leaves a field.
+- Optional event dining and early-arrival discussion requests, stored transactionally in staff-visible notes with the event booking. These do not reserve a second table or guarantee food.
+- Christmas per-guest course snapshots, mixed-course party support, one-course pre-order exemption, selected-course validation, staff amendment controls and matching confirmation wording. Existing booking snapshots and payment rules remain intact. Capability defaults off pending the approved rollout.
+- Aggregate baseline, guarded menu corrections, dated-capacity review and a prepared promotion brief.
+- Analytics page/referrer URLs have query strings, fragments and credentials removed in the browser dispatcher and server endpoint. Existing campaign attribution remains separate. Controlled tests cover an email in the URL and rejected analytics consent.
+
+## Read-only production evidence
+
+The public availability API returned complete answers for 6 and 7 September. On Sunday, early slots were labelled drinks-only; on Monday all returned slots were drinks-only. The live quick sheet was opened without submitting and returned HTTP 200 availability. Wider live browser testing was not completed; isolated browser scenarios are recorded separately.
+
+Production baseline and capacities were queried from the verified management project tfcasgxopxegwrabvwat. Measurement definitions and limitations are in measurement.md. Eight exact editorial descriptions are captured in menu-corrections.json. They have not been replaced. Capacity-review.md lists the dated records needing venue input.
+
+## Review and test limits
+
+Independent review inspected the live inner SQL creator interfaces and reviewed both new wrappers. Event request hashing was corrected after review so changed requests under one explicit key receive a conflict. Christmas review found no remaining issue after an accidental email property reference was corrected.
+
+SQL validation ran only on an isolated PostgreSQL 17 fixture, while production uses PostgreSQL 15. Existing booking creators were substituted locally. This validates the new transaction, state gates, permissions and rollback, but does not replay the entire live allocator dependency tree. No real customer booking, deposit, refund or message was used as a smoke test.
+
+Both final production builds passed after the quick-book corrections and integration with the latest main branches (management 418ce1ac, website 565cf3ef). Final management build used Node 20 and an 8 GB heap after the earlier build process exhausted its default heap. The website browser fixture now uses its own temporary app root/cache, after the first concurrent dev/build attempt conflicted. Neither failure was treated as a deployed application defect.
+
+Full management London run: 722 suites passed, 6,198 tests passed and two existing skips. Full management UTC override run: 6,197 passed, one timezone-configuration assertion failed because its expected-zone flag was omitted. That unchanged suite was rerun with SCREENING_TEST_TZ=UTC and all 12 tests passed. The override is necessary because the repository's usual Vitest configuration pins London.
+
+Website full London run: 184 suites passed, 1,987 tests passed and one existing skip. Final UTC run including added tracking coverage: 185 suites passed, 1,990 tests passed and one existing skip. The three tracking suites separately passed in both timezones. Both repositories passed lint and typecheck; website content/layout audits passed.
+
+A passing build is not proof of a live booking or payment.
+
+## Release gates
+
+Apply the two exact reviewed migrations only after approval of the project, SQL checksums and rollback plans. Deploy the compatible management API before the dependent website. Enable Christmas capability only according to its packet after all consumers are present. Verify deployment aliases and read-only production responses before a live completion claim.
+
+The event request UI must not reach production before its wrapper exists. Menu replacement requires approval of the eight guarded changes. Event capacities require venue-confirmed dated values. Promotion remains a brief until service capacity, attribution, exact assets and spend are approved.
+
+## Deliberately retained
+
+Existing table availability purpose handling, waitlist allocation, deposit/refund arithmetic, PayPal capture, staff notes print template, currency presentation, published food hours and unrelated Nations changes remain in place. No new dashboard, queue, marketing automation or waitlist was introduced.
+
+Management coverage run under Node 20 passed all 722 suites and 6,198 tests, with two existing skips. Coverage: 52.89% lines, 42.50% branches and 60.79% functions, above the configured floors.
+
+## Final integrated gate
+
+Management: lint, typecheck, 722 suites with 6,208 passing tests (two existing skips), and production build passed on the integrated branch. Typecheck/build used Node 20 with an 8 GB heap. Website: all layout/content lint audits, typecheck, 188 suites with 2,013 passing tests (one existing skip) in both London and UTC, and production build passed. No application sources changed after these gates.
+
+## Browser evidence
+
+Private hire: short undecided-date enquiry and existing estimator, error retention, retry key, duplicate prevention, consent, no overflow at 320/375/768/1440, and active-form promotion suppression passed with isolated requests.
+
+Quick table booking: all 28 checks passed across Chromium and WebKit with accepted and rejected cookie choices. Covered Sunday 13:00 food start, no noon food, closed Monday food versus drinks, failure exiting loading, sold-out slots, retry recovery and full-form date/time/party/drinks handoff. WebKit logged blocked web-vitals transport errors during navigation; functional assertions passed.
+
+Full legacy table form: synthetic confirmations passed in Chromium and WebKit, with the actual website proxy forwarding the selected date, time, party size and drinks purpose. No real management booking was created.
+
+Page-specific persistent actions: 18 checks passed in Chromium and WebKit across private hire, quiz, cash bingo, music bingo, open/past/cancelled/sold-out dated events, and Nations. Event food/early-arrival request submissions passed in both browsers through the actual website proxy to the isolated upstream, with unconfirmed-request acknowledgement.
+
+Sanitised evidence is in /tmp/anchor-growth/private-hire and /tmp/anchor-growth/tables. Browser scripts are saved in the website scripts directory. The temporary fixture has a copied app root and separate cache, guards upstream sockets/fetch, and never targets production for writes.
+
+Christmas browser check passed with the two-screen feature enabled, matching the read-only live flag. Six one-course guests were not asked for dishes. Mixed one/two/three-course choices blocked progression until the required dishes were selected, then allowed progression. After the cutoff, two/three-course options were disabled. External requests and all POST requests were blocked; expected blocked telemetry errors were recorded. Screenshots and sanitised evidence: /tmp/anchor-growth/christmas/.

--- a/tasks/event-dining-request-migration-2026-09-05.md
+++ b/tasks/event-dining-request-migration-2026-09-05.md
@@ -1,0 +1,127 @@
+# Event dining request migration, not applied
+
+Production target: `the-anchor-management-tools` (connected project name verified), project `tfcasgxopxegwrabvwat`, host `tfcasgxopxegwrabvwat.supabase.co`. Identity verified from this repository's `supabase/.temp/project-ref` and `.env.local` host, then the connected SQL catalogue.
+
+Migration: `20260905100521_event_booking_dining_requests.sql`.
+Name: `event_booking_dining_requests`.
+SHA-256: `7a2fb0cf3d419601d978cdac8d10c3ac3f754c4d1e9223a318ad92bbf0c3ab8f`.
+
+## Effect and dependencies
+
+Adds one service-role-only, SECURITY INVOKER function. It calls existing v06 or v07 creation and writes unconfirmed food/early-arrival requests to `bookings.notes` within the same transaction. It only updates explicit confirmed/pending-payment creates, never a blocked response containing an existing booking ID. An update failure rolls back creation.
+
+No columns, tables, views or existing functions change. No backfill. Existing requests without these optional fields retain their current RPC. `bookings.notes` already feeds the booking-sheet route and escaped HTML template; both remain unchanged.
+
+Live preflight: bookings has 1,529 rows and uses 2,523,136 bytes including indexes. Notes is text. Dependent views `customer_communications` and `reminder_timing_debug` were inspected; no view shape changes. Booking constraints, triggers, RLS, RPC definitions and grants were inspected. The new function does not yet exist. The latest observed applied migration was `20260905052727`.
+
+## Risk and locks
+
+The grant/revoke statements are explicit access-control changes on the new function only. PUBLIC, anon and authenticated cannot execute it; service_role can. SECURITY INVOKER retains caller privileges and a fixed empty search path. No privilege changes affect v06/v07 or existing tables. Migration installation takes catalogue locks only; it does not rewrite or lock booking rows. Calls retain the existing creation transaction locks and add an update to the newly created row.
+
+There is no separate table reservation or food promise. The UI offers a request to discuss food or early arrival, with no unverified time picker. Arrangements remain unconfirmed until agreed with staff.
+
+## Validation
+
+Executed the exact migration on an isolated PostgreSQL 17 cluster at 127.0.0.1:55439. Production reports PostgreSQL 15; the local test uses PostgreSQL 17 and no version-specific syntax. Local fixture creators substitute for v06/v07; their real production definitions were inspected but the entire production dependency tree was not replayed locally.
+
+Passed: confirmed creation with preserved existing note; pending-payment multi-ticket routing; blocked/customer-conflict retry without overwriting notes; waitlist without notes; invalid request before creation; injected notes-update failure rolling back the booking; anon and authenticated calls rejected; service-role call accepted; rollback function removal. Local server stopped after tests.
+
+Management: 44 targeted tests passed, including API acknowledgement, API validation, retry replay, atomic-service routing, failed persistence and booking-sheet note rendering. Website: 18 tests passed in London and UTC, including typed proxy validation, changed retry keys, submitted form request fields and server-acknowledged confirmation. Both repositories passed typecheck and focused lint.
+
+## Deployment and rollback
+
+Apply only after approval of this exact project, SQL checksum and rollback. Required order: migration, management API deployment, website request-field deployment. The ordinary no-request path remains backward compatible.
+
+Rollback the website fields and management wrapper caller first, then execute:
+
+```sql
+DROP FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean);
+```
+
+This preserves all recorded booking notes and existing v06/v07 functions. No historical request data is removed.
+
+## Post-apply verification
+
+Re-read function body, SECURITY INVOKER/search_path, ACLs and migration history. Run the read-only anon-surface assertion. Verify the function accepts service_role and rejects anon/authenticated without creating a booking (invalid request fixture before creation), then use isolated fixture data for any mutating smoke test. Verify website request acknowledgement and printed staff notes with controlled responses before release. Do not create a real guest booking or send communications as a smoke test.
+
+## Exact SQL
+
+```sql
+-- DRAFT: apply before deploying the optional event dining/arrival request UI.
+-- Existing booking creation stays unchanged for callers without requests.
+-- Requests and the new booking commit together, or both roll back.
+CREATE OR REPLACE FUNCTION public.create_event_booking_with_requests_v01(
+  p_event_id uuid,
+  p_customer_id uuid,
+  p_seats integer,
+  p_source text DEFAULT 'brand_site',
+  p_seating_preference text DEFAULT 'seated',
+  p_payment_hold_minutes integer DEFAULT NULL,
+  p_ticket_selections jsonb DEFAULT NULL,
+  p_dining_request text DEFAULT NULL,
+  p_early_arrival_request boolean DEFAULT false
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_booking_id uuid;
+  v_notes text;
+BEGIN
+  IF p_dining_request IS NOT NULL AND p_dining_request NOT IN ('before_event', 'during_event', 'not_sure') THEN
+    RAISE EXCEPTION 'invalid_dining_request' USING ERRCODE = '22023';
+  END IF;
+
+  v_notes := CASE p_dining_request
+    WHEN 'before_event' THEN 'Guest asks about food before the event.'
+    WHEN 'during_event' THEN 'Guest asks about food during the event.'
+    WHEN 'not_sure' THEN 'Guest would like to discuss food options.'
+    ELSE NULL
+  END;
+  IF COALESCE(p_early_arrival_request, false) THEN
+    v_notes := concat_ws(' ', v_notes, 'Guest would like to discuss arriving early.');
+  END IF;
+  IF v_notes IS NOT NULL THEN
+    v_notes := 'UNCONFIRMED REQUEST: ' || v_notes || ' Food availability and arrival arrangements must be agreed with the team. No separate dining booking has been made.';
+  END IF;
+
+  IF p_ticket_selections IS NOT NULL THEN
+    v_result := public.create_event_booking_v07(
+      p_event_id, p_customer_id, p_source, p_seating_preference,
+      p_payment_hold_minutes, p_ticket_selections
+    );
+  ELSE
+    v_result := public.create_event_booking_v06(
+      p_event_id, p_customer_id, p_seats, p_source,
+      p_seating_preference, p_payment_hold_minutes
+    );
+  END IF;
+
+  -- Conflicts can contain the ID of an EXISTING booking. Never change it.
+  -- Only these explicit states are new successful creates in v06 and v07.
+  IF COALESCE(v_result->>'state', '') NOT IN ('confirmed', 'pending_payment') THEN
+    RETURN v_result;
+  END IF;
+  IF v_notes IS NULL THEN
+    RETURN v_result;
+  END IF;
+
+  v_booking_id := NULLIF(v_result->>'booking_id', '')::uuid;
+  UPDATE public.bookings
+  SET notes = concat_ws(E'\n', NULLIF(btrim(notes), ''), v_notes), updated_at = now()
+  WHERE id = v_booking_id AND event_id = p_event_id AND customer_id = p_customer_id
+    AND status IN ('confirmed', 'pending_payment');
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'event_booking_request_persistence_failed';
+  END IF;
+
+  RETURN v_result || jsonb_build_object('requests_recorded', true);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) TO service_role;
+COMMENT ON FUNCTION public.create_event_booking_with_requests_v01(uuid, uuid, integer, text, text, integer, jsonb, text, boolean) IS 'Service-only atomic event creation with unconfirmed dining and early-arrival requests in staff-visible booking notes.';
+```

--- a/tasks/plan-2026-09-05-anchor-booking-growth.md
+++ b/tasks/plan-2026-09-05-anchor-booking-growth.md
@@ -1,0 +1,256 @@
+# Anchor Booking Growth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use the implement-plan skill to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it easier to complete a valid dining booking, send a useful private-hire enquiry and reserve event seats, then measure attended business rather than clicks.
+
+**Architecture:** Keep the management app as the authority for hours, availability, booking rules and records. The website consumes its existing APIs. Deliver small, independently deployable releases, reusing booking, enquiry, waitlist and analytics infrastructure.
+
+**Tech Stack:** Website: Next.js 14, React 18, TypeScript, Jest. Management: Next.js 15, React 19, TypeScript, Vitest. Existing management API, Supabase and PayPal integrations.
+
+**Spec:** User-supplied booking-growth report at `/Users/peterpitcher/.codex/attachments/606facf1-6f86-4173-b74e-e604cc59c300/pasted-text.txt`, narrowed by the decisions below. This plan supersedes that report where it conflicts with confirmed operational rules.
+
+## Global constraints
+
+- Planning only is authorised. No application edits, production writes, sends, migrations, campaign launch or deployment are authorised by this document.
+- Read both project CLAUDE.md files, the workspace rules and relevant skills before execution. Apply systematic-debugging to unproven booking failures, e2e-test to browser testing, Supabase guidance to database work, prod-migrate to any production migration and deploy-verify to deployment verification.
+- Management root: `/Users/peterpitcher/Cursor/OJ-AnchorManagementTools`. Website root: `/Users/peterpitcher/Cursor/OJ-The-Anchor.pub`. All file lists below are relative to the labelled root.
+- This is a cross-repository programme, complexity 5 overall. Split into releases below, targeting 300 to 500 meaningful changed lines per PR. Separate backend and frontend PRs when needed.
+- Preserve unrelated work. At planning time both repositories contain another task's local changes; management main is also behind its tracked remote. Refresh remote history and use isolated implementation branches before execution.
+- No opening-hours change, deposit-rate change, site redesign, new booking engine or new analytics platform.
+- Keep menu item prices without currency symbols. Prices and hours remain live-source values. Never invent dishes, ingredients, capacities, response promises or package inclusions.
+- Ordinary group deposit: £10 per person for 15 or more. Christmas: £10 per person at every permitted party size, minimum 6, maximum 20, minimum 24 hours' notice. Reuse existing rule sources.
+- Christmas one course does not require pre-order; two and three courses do, with the approved seven-day deadline. Do not silently discard that deadline to accommodate short notice.
+- Availability fails closed. No locally invented slots during an API failure. Normal dining cannot gain early-arrival meal slots without an explicitly supported operational rule.
+- All dates use Europe/London. Check both London and UTC test runs.
+- Live tests must not create bookings, trigger holds, payments, sends or jobs without explicit approval. Use intercepted requests and isolated test data for write-path verification; interception must occur before a real write can leave the browser.
+- New database structure is not assumed. Inspect the live schema and existing persistence first. Any required schema extension gets its own reviewed migration and explicit application approval.
+- No em dashes. No personal details or free-text notes in analytics. The confirmed Greene King tenancy takes precedence over stale independent-pub wording in source documents.
+
+## Recommendations and scope
+
+1. Clear the booking-reliability questions first, while preparing the small copy corrections.
+2. Fix Christmas rules end to end before promoting the seasonal offer more widely.
+3. Give private hire a short enquiry alongside the estimator. Retain phone as required initially, allow optional email and record a requested reply method without inventing an automated guarantee.
+4. Make event actions reserve event seats. Add dining interest using the existing contract only after proving it reaches staff. Treat arrival as a request requiring validation, never a second dining reservation.
+5. Establish comparable baseline measures before conversion changes launch. Measure attended covers, deposit-secured hires and attended event seats separately.
+6. Defer paid promotion until the operational and measurement gates pass. Retain the report's £500 ceiling as a maximum, not a spending instruction.
+
+Exclude from initial delivery: homepage rebuild, speculative new SEO pages, new private-hire packages, a new waitlist, bulk promotional messages and email-only enquiries. Review existing proof placement and promotion assets after the core releases demonstrate reliable outcomes.
+
+## Evidence and existing work
+
+Confirmed during this task's read-only checks:
+
+- Website commits `55e781c6`, `47134c8f`, `4d2795ea` and `9ff59f24` address Christmas refund copy, duplicate event/table instructions, popup suppression and enquiry-button wording. Do not rebuild these fixes. Verify their deployed behaviour in Task 1.
+- A direct live page fetch still showed editorial prose in Broccoli Cheese and a walk-in-led Sunday introduction. It showed the new enquiry navigation wording too. These were page-content checks, not successful booking tests.
+- `components/PrivateBookingSection.tsx` still presents the estimator as the entry route. The canonical management enquiry endpoint accepts an omitted date and requires a phone number. Do not extend the deprecated management `/api/public/private-booking` endpoint.
+- `components/layout/StickyCtas.tsx` special-cases Christmas and otherwise opens table quick booking. Event pages already expose `#event-booking`.
+- The management event-booking schema accepts `food_intent`; its persistence and staff visibility have not been established. The customer event form does not currently expose the proposed choice.
+- Website `ManagementTableBookingForm.tsx` derives pre-order requirement from the seasonal period flag. Course-specific enforcement needs investigation across API, stored records and UI.
+- Waitlist infrastructure exists in management `src/lib/events/waitlist-offers.ts`. Website analytics already has table, event and private-hire events.
+- Event capacities, live seasonal configuration, full conversion reconciliation and physical mobile browser results have not been rechecked. These are verification tasks, not established defects.
+
+## Release order
+
+| Release | Tasks | Dependency | Deliverable |
+|---|---|---|---|
+| Baseline | 1 and 7 baseline | None | Current evidence, agreed denominators and exact remaining gaps |
+| Dining | 2, plus reproduced fixes from 1 | Baseline | Valid slots and clearer Sunday/menu content |
+| Christmas | 3 | Baseline and rule tracing | Course-aware requirements across booking and communications |
+| Private hire | 4 | Baseline | Short enquiry with context preserved |
+| Events | 5 and 6 | Baseline; verified capacity before scarcity | Relevant booking actions and staff-visible dining requests |
+| Measurement | 7 reconciliation | Each released journey | Comparable outcome reporting |
+| Promotion | 8 | Prior gates and separate approval | One measured campaign or conversion test at a time |
+
+These are sequencing recommendations, not promised delivery dates. Estimate effort after Task 1 establishes which fixes and schema changes are actually required.
+
+## Task 1: Verify booking reliability and the existing fixes
+
+**Files to inspect, change only for a reproduced defect:**
+- Website: `components/features/TableBooking/QuickBookSheet.tsx`, `ManagementTableBookingForm.tsx`, `useAvailabilityRequests.ts` in the same directory; `app/api/table-bookings/availability/route.ts`; `lib/table-booking-service-windows.ts`; `lib/hours-utils.ts`; `components/features/christmas/ChristmasLightbox.tsx`.
+- Management: `src/app/api/table-bookings/route.ts` and the live RPC/service it actually calls for availability. Trace the current route before identifying a database function to change.
+- Existing tests: website `tests/api/table-availability-contract.test.ts`, `tests/api/table-bookings-availability-combined.test.ts`; management `src/app/api/table-bookings/__tests__/table-availability-contract.test.ts`.
+- Create evidence: management `tasks/anchor-booking-growth/verification.md` containing sanitised steps, observations, commit and deployment IDs.
+
+**Interfaces:** Consume the existing availability query/response contract. Preserve it unless a demonstrated gap requires an additive, backward-compatible extension. Produce a reproduced-failure list or explicit cleared observations.
+
+- [ ] Refresh repository and deployment evidence; trace actual route imports. Check the four already-merged changes against the currently served build.
+- [ ] Run quick booking and the full form on iPhone Safari and Android Chrome if accessible. Otherwise run WebKit and Chromium emulation and record the physical-device gap explicitly. Repeat with cookie acceptance and rejection.
+- [ ] Exercise ordinary food, Sunday lunch, drinks, closed kitchen, split sittings, sold out, API error and a deliberately delayed response using controlled responses. Check both date and refinement changes during an in-flight request.
+- [ ] Check selected date, party size and purpose survive quick-book to full-form and alternative selection. Old responses must not repopulate a new search; loading must end in valid slots, closed, sold out or a recoverable error.
+- [ ] Reproduce any mismatch using the same date, purpose and party size against the live read-only API. Read relevant deployment logs and browser errors before changing logic.
+- [ ] For each reproduced fault, add a regression at the owning layer, prove it fails, make the smallest fix and rerun it. Keep existing fail-closed and effective-date behaviour.
+- [ ] Verify Christmas overlays do not take focus over table or enquiry forms, and closing the active form restores focus and scroll. No duplicate table request appears on event instructions.
+
+**Acceptance:** One evidence row per scenario, with actual result and environment. A cleared historical finding results in no implementation change. Failed or unrun scenarios stay explicitly open.
+
+## Task 2: Correct food content and make Sunday booking easier to choose
+
+**Files:** Website `app/sunday-roast/page.tsx`, `docs/SSOT.md`, `SSOT.json` only for genuine mirrored-rule updates; inspect the menu feed and its management editor to find the existing stable dish ID. Do not rename dishes or change pricing.
+
+**Interfaces:** Existing menu description field and live menu API. No API change. Sunday booking continues to use the current table journey.
+
+- [ ] Read the current menu record and its revision/source history. Prepare the exact before/after description using verified dish facts; do not infer ingredients or replace it with more editorial filler.
+- [ ] Review reported truncation in both the stored description and rendered page. Fix whichever layer actually truncates it; leave intentional display-only shortening alone if the full description remains accessible.
+- [ ] Lead the Sunday page with choosing a time and keep walk-ins/no-pre-order reassurance immediately beside it. Use the current service-hours source and existing booking action. Preserve menu prices and diet statements.
+- [ ] Check deposit wording on the touched page against the existing 15-person rule. Do not repeat stale 10-person text from a cached web result.
+- [ ] Present the exact menu record correction as part of the complete production change list. Apply only after explicit live-write approval, preserving the stable ID and recording the previous value for reversal.
+- [ ] Visually check mobile and desktop page rendering, menu API output and booking-link destination. Run the SSOT drift guard only if SSOT or its mirror changes.
+
+**Acceptance:** No editorial instructions or accidental clipped prose in the affected menu entries; reservation is prominent; walk-ins remain welcome; no price, ingredient or operational policy is invented. No bespoke tests for a simple description edit.
+
+## Task 3: Align Christmas courses, deadlines and deposits
+
+**Files:**
+- Website: `components/features/TableBooking/ManagementTableBookingForm.tsx`, `SeasonalPreorderPicker.tsx`, `useBookingPeriod.ts` in the same directory; `lib/api/bookings.ts`; `app/christmas-parties/page.tsx`, `client-components.tsx`; `components/features/christmas/ChristmasLightbox.tsx` only if package wording conflicts.
+- Management: `src/app/api/table-bookings/periods/route.ts`, `src/app/api/table-bookings/route.ts`, `src/lib/table-bookings/periods.ts`, `src/lib/table-bookings/preorder.ts`, `src/lib/table-bookings/period-deposit.ts`. Trace current confirmation/reminder consumers before listing changes to them.
+- Existing tests: management `src/app/api/table-bookings/periods/route.test.ts`, `src/lib/table-bookings/christmas-guard.test.ts`, `src/lib/table-bookings/period-deposit.test.ts`. Add website `tests/unit/christmas-course-policy.test.ts` for the final resolved contract.
+
+**Interfaces:** The management period response must expose the selected tier's actual pre-order requirement and deadline. Reuse an existing tier identifier if present. Persist the chosen tier so staff, confirmation and amendment paths use the same rule; an unpersisted browser-only flag is insufficient.
+
+- [ ] Inspect live period configuration and schema, existing tier identifiers, menu associations, booking storage and amendment behaviour. Record the actual contract in the verification document before changing code.
+- [ ] Trace the exact seven-day boundary and the 24-hour minimum in current code and live read-only settings. Do not substitute calendar-day arithmetic for elapsed-time arithmetic without matching the approved rule.
+- [ ] Use one-course/no-pre-order as the supported short-notice online path. Where two/three-course notice is already insufficient, explain the deadline and offer one course or a staff enquiry; do not promise an exception or alter hours.
+- [ ] Prepare the smallest backward-compatible contract extension only if existing fields cannot express the tier. Add a shared management rule resolver and expose its result to the website. Define and test its exact types before the consumer PR begins.
+- [ ] Add regression fixtures covering one, two and three courses; 6 and 20 guests; 5 and 21 rejected; 24-hour and seven-day boundaries; party/date/tier changes; retries; amendments; missing tier; and an old client. Required pre-orders cannot disappear after a date or course change.
+- [ ] Keep existing bookings and deposits intact. Handle records without a tier explicitly using their existing recorded policy; never silently reinterpret them as one course.
+- [ ] Align page, form, payment review, staff display and fixture-rendered confirmations/reminders with the same resolved rule. Test the refund boundary, including exactly seven days, without moving money.
+- [ ] If a migration is necessary, use prod-migrate for a separate reviewed draft, validation and explicit application approval. Deploy backward-compatible server support before the website consumer; verify each independently.
+
+**Acceptance:** An isolated six-person one-course booking requires the existing £60 deposit but no menu pre-order. Two/three-course bookings require the correct choices/deadline. Stored tier and communications agree. No real booking or payment is created during routine verification.
+
+## Task 4: Add the short private-hire enquiry
+
+**Files:**
+- Website: create `components/PrivateHireQuickEnquiry.tsx`; modify `components/PrivateBookingSection.tsx`; inspect `components/PrivateBookingInquiryForm.tsx`, `PrivateBookingCalculator.tsx`, `app/api/private-booking-enquiry/route.ts`, `app/api/public/private-booking/route.ts`, `lib/api/private-bookings.ts` and `lib/gtm-events.ts`.
+- Management: reuse canonical `src/app/api/private-booking-enquiry/route.ts` and `src/services/private-bookings/mutations.ts`; modify only where a verified contract gap prevents context preservation.
+- Tests: create website `tests/unit/private-hire-quick-enquiry.test.tsx`; extend `tests/api/private-booking-idempotency.test.ts`, `tests/api/private-booking-resilience.test.ts`; management `tests/api/privateBookingEnquiryAdminClient.test.ts` if the canonical route changes.
+
+**Interfaces:** Reuse canonical enquiry fields `phone`, `name`, optional `email`, `event_type`, `date`, `time`, `group_size`, `notes` and `communication_consent`. Omit an undecided date rather than sending a dummy date. Never post a new integration directly to the deprecated management public-booking endpoint.
+
+- [ ] Present two visible actions: short date enquiry and existing cost estimator. The short route asks occasion, preferred/undecided date, approximate guests, name and phone; email and notes are optional. Do not force room, catering or entertainment selection.
+- [ ] Keep phone required for the first release. An optional requested reply method may be recorded in existing staff-visible enquiry notes; do not claim automatic email-only routing or promise a reply time.
+- [ ] Preserve the originating occasion and estimator choices through the current proxy mapping. Verify notes and selected items reach the staff record; do not silently truncate an enquiry context beyond documented limits.
+- [ ] Reuse current Turnstile, consent, rate limit and idempotency handling. A rejected or unavailable backend must show a recoverable error and retain inputs, never display a false success.
+- [ ] State that the enquiry does not hold the date. Confirm the requested details after successful acceptance and explain that the team will reply, without a new time guarantee.
+- [ ] Test dated and undecided enquiries, invalid phone, optional email, large parties within the canonical endpoint limit, double submit, timeout/retry, blocked bot validation, preserved context and no accidental hold/deposit creation using isolated data.
+- [ ] Verify that the enquiry appears in the existing staff workflow and that its notification is rendered correctly with a stubbed transport. Reuse current follow-up queues; review ownership and due-date gaps before adding new staff fields.
+
+**Acceptance:** A guest can send an enquiry without completing the estimator or choosing a firm date. A retry produces one enquiry. Staff receive the submitted context and a visible next action. Email-only customer creation is outside this release.
+
+## Task 5: Make persistent actions match the page
+
+**Files:** Website `components/layout/StickyCtas.tsx`; create `lib/booking-cta.ts`, `tests/unit/booking-cta.test.ts`; modify `app/events/[id]/page.tsx`, `app/quiz-night/page.tsx`, `app/cash-bingo/page.tsx`, `app/music-bingo/page.tsx` only where required anchors are absent. Preserve the Christmas-specific action.
+
+**Interfaces:** Add a pure resolver with this complete contract. It selects navigation only; it never infers availability or creates a booking.
+
+```ts
+export type BookingCta =
+  | { kind: 'table'; label: 'Book a table' }
+  | { kind: 'link'; label: 'Reserve seats' | 'View upcoming dates' | 'Enquire about your date'; href: string }
+  | { kind: 'christmas'; label: 'Christmas enquiry' }
+
+export function resolveBookingCta(pathname: string): BookingCta {
+  if (pathname === '/christmas-parties') return { kind: 'christmas', label: 'Christmas enquiry' }
+  if (/^\/events\/[^/]+\/?$/.test(pathname)) return { kind: 'link', label: 'Reserve seats', href: '#event-booking' }
+  if (['/quiz-night', '/cash-bingo', '/music-bingo'].includes(pathname)) return { kind: 'link', label: 'View upcoming dates', href: '#upcoming-dates' }
+  if (pathname === '/private-hire' || pathname.startsWith('/private-hire/')) return { kind: 'link', label: 'Enquire about your date', href: '#enquiry' }
+  return { kind: 'table', label: 'Book a table' }
+}
+```
+
+Initial scope is these verified route families. Additional hire landing pages join the map only after checking their actual enquiry target. On past, cancelled or closed dated events the page must override/hide the reserve action and expose an honest upcoming-date or existing waitlist action. A route-only resolver cannot decide sales state.
+
+- [ ] Add this behavioural test before the resolver implementation:
+
+```ts
+import { resolveBookingCta } from '@/lib/booking-cta'
+
+test.each([
+  ['/sunday-roast', { kind: 'table', label: 'Book a table' }],
+  ['/private-hire', { kind: 'link', label: 'Enquire about your date', href: '#enquiry' }],
+  ['/events/example', { kind: 'link', label: 'Reserve seats', href: '#event-booking' }],
+  ['/cash-bingo', { kind: 'link', label: 'View upcoming dates', href: '#upcoming-dates' }],
+  ['/christmas-parties', { kind: 'christmas', label: 'Christmas enquiry' }],
+])('%s chooses its own booking journey', (path, expected) => {
+  expect(resolveBookingCta(path)).toEqual(expected)
+})
+```
+
+- [ ] Run `npx jest tests/unit/booking-cta.test.ts --runInBand`, observe failure, implement the resolver, then repeat and observe pass.
+- [ ] Connect the existing sticky control to the resolver, retaining current modal focus, keyboard and cookie-banner behaviour. Add anchors only where the destination section exists.
+- [ ] Use actual event sales state for overrides; retain existing waitlist policy. Test past, cancelled, sold-out and open events in the browser, plus navigation between route types.
+- [ ] Track the correct action using the current analytics helpers. A seat or enquiry click must not emit a table-booking start.
+
+**Acceptance:** Each action reaches the right form or date choice; no wrong table modal on the scoped event/hire pages; no obscured fields, broken anchor or inaccessible focus target at narrow widths.
+
+## Task 6: Finish event dining and capacity handling
+
+**Files:** Website `components/features/EventBooking/ManagementEventBookingForm.tsx`, `app/events/[id]/page.tsx`, `app/api/event-bookings/route.ts`, `lib/api/events.ts`; management `src/app/api/event-bookings/route.ts`, `src/services/event-bookings.ts`, `src/lib/event-booking-sheet-template.ts`, `src/lib/events/waitlist-offers.ts` for inspection, not replacement. Trace confirmation/reminder templates from the service before making edits.
+
+**Interfaces:** Reuse `food_intent` only after confirming where it is persisted. An analytics-only field is not a staff instruction. An optional arrival request must have a validated, durable staff-visible home before exposing it to guests.
+
+- [ ] Read future event records and distinguish maximum venue capacity, configured sellable capacity, reserved seats, holds and remaining availability. Produce one proposed before/after list using actual event IDs. Never copy 80/60/90 into live events as assumed availability.
+- [ ] Obtain venue-approved capacities for the dated events before applying that list. Keep all changes within existing authorised event-management paths. Do not send marketing or trigger queue processing as a side effect.
+- [ ] Trace food intent from browser through API to staff view, booking sheet and fixture-rendered confirmation. Reuse an existing durable field or prepare a separate additive schema plan if none exists.
+- [ ] Offer optional dining interest. Add arrival selection only where existing kitchen/service rules can validate it for the actual date. If an early arrival needs manual agreement, display it as a request and leave the confirmed reservation time unchanged.
+- [ ] Keep one event reservation; do not create a second table booking. Do not claim a dining request guarantees kitchen capacity or a particular table unless the existing allocator verifies it.
+- [ ] Check cash-bingo per-book wording against the actual ticket/payment contract, and align only verified mismatches. Keep event-specific cash/payment facts in the existing facts strip.
+- [ ] Test no dining, dining requested, closed kitchen, changed date, different requested arrival, duplicate submit, missing capacity and sold out. Confirm the existing waitlist and cancellation/release paths still work with isolated data.
+
+**Acceptance:** Staff see the same dining/arrival request the guest submitted. No duplicate table reservation, invalid food promise or invented scarcity. Live capacity changes remain blocked until their exact values are approved.
+
+## Task 7: Reconcile measurement and private-hire follow-up
+
+**Files:** Website `lib/gtm-events.ts`; management `src/lib/analytics/events.ts`, `src/lib/private-bookings/weekly-digest-classifier.ts`, existing private-booking queries and communications. Create management `tasks/anchor-booking-growth/measurement.md` for definitions and validation evidence, not a new dashboard by default.
+
+**Interfaces:** Reuse `trackTableBookingFunnel`, `trackEventBookingComplete`, `trackPrivateHireEnquiryStarted`, `trackPrivateHireEnquirySubmitted` and the existing business-record identifiers. Inspect payloads before adding anything.
+
+- [ ] Before launching UI changes, save an aggregate baseline by journey, device, source and service/event date. Fix the eligibility and date-window definitions; record unknown sources separately and exclude staff/test activity.
+- [ ] Reconcile completed table bookings, event reservations and private enquiries against unique business IDs. Check refresh, retry and payment-return behaviour for double counting and verify consent handling.
+- [ ] Trace booked to attended/cancelled/no-show using existing records. Keep event seats separate from booking counts, and private-hire enquiries grouped by enquiry date rather than mixing with event-date cohorts.
+- [ ] Measure private-hire contact time, quote/deposit status, completed value and recorded loss reasons where supported. Mark missing data as unknown. Reuse existing staff queues and propose only verified missing fields or ownership controls.
+- [ ] Add regression tests only for demonstrated duplicate, missing or personal-data analytics payloads. Validate the outbound payload in a controlled browser run, including rejected analytics consent.
+- [ ] Publish a small weekly aggregate readout: dining confirmations and attended covers; private enquiries and deposit-secured hires; event reserved/attended seats and verified capacity. Add contribution only where actual values and costs exist.
+
+**Acceptance:** Journey totals reconcile or have a quantified, explained difference. No invented source attribution or assumed attendance. No deposits counted again as sales. A click never represents a completed booking.
+
+## Task 8: Controlled promotion and conversion tests
+
+**Deliverable:** A separate campaign brief after Tasks 1 to 7, not a live campaign created by this plan.
+
+- [ ] Verify Google Business Profile booking/menu destinations and current source tags without duplicating existing citation work. Check event links reach the actual dated page and old dates lead honestly to upcoming dates.
+- [ ] Choose one dining service with verified room and staffing capacity, or private hire once its value and follow-up data are usable. Keep hosted-event order quiz, cash bingo, music bingo; karaoke stays a 2027 item.
+- [ ] Prepare the exact audience, landing page, assets, dates, spend ceiling, measurement window and stop criteria as one approval package. Base cost limits on verified incremental contribution; the original uplift cases remain sensitivities, not forecasts.
+- [ ] Test one material journey change at a time. Use several comparable services/event cycles and annotate seasonality or concurrent campaigns. Do not claim statistical certainty from one event.
+- [ ] Launch only after explicit campaign approval. Do not start an automation, send messages or spend the available £500 because this plan exists.
+
+**Acceptance:** One approved test with traceable booking outcomes and an actual cost ceiling. No budget is spent until it can be reconciled to the agreed outcome.
+
+## Verification and release checklist for every code release
+
+- [ ] Use Node 20 for management. Read `.nvmrc` and package scripts in both checkouts before running commands.
+- [ ] Run relevant regression tests, then lint, clean typecheck, full tests and an uncached production build in each changed repository. Run date-sensitive tests in both London and UTC. Website uses Jest; management uses Vitest.
+- [ ] Render changed message templates with fixtures; reject undefined values, invalid dates and missing amounts. Transports remain stubbed.
+- [ ] Exercise the exact affected browser path, including failure/retry, with production writes blocked. Record screenshots and sanitised network evidence. A build alone is not feature proof.
+- [ ] List every changed file and deliberately untouched counterpart in the PR. Record assumptions, test limits and any unapplied migration by its real filename.
+- [ ] Present all live data changes, migration applications, deployment actions and any real write-path smoke test together for owner approval. Approval of development is not approval to send messages or apply a production migration.
+- [ ] Deploy approved compatible backend changes before dependent website changes. Verify each production alias against commit and deployment ID. Website main does not automatically mean a production deployment.
+- [ ] Run post-deployment read-only smoke checks. Do not claim the full payment/confirmation journey verified unless the approved write-path test actually ran.
+- [ ] Roll back a faulty UI with the previous verified deployment. Restore any approved menu/capacity data from the recorded prior values. Never automatically drop migrated columns or undo customer bookings; use a reviewed forward repair when records depend on a schema extension.
+- [ ] Finish approved merge/push/deploy/verification and tidy only this work's branches. Update checkboxes and evidence with actual outcomes.
+
+## Approval and decision handling
+
+No further business answers are needed to approve development of the bounded releases. Previously approved Christmas course rules remain the default. Event capacity values, production data edits, migrations, deployments and campaign launch each require concrete reviewable evidence before their respective approvals. Do not put questions in this document or invent defaults when a live operational decision is missing; return those decisions together in chat after completing independent work.
+
+## Planning completion
+
+- [x] Compared the supplied report with current route/component code and prior implementation evidence.
+- [x] Split the programme into independently reviewable releases with dependencies and acceptance criteria.
+- [x] Preserved existing implementations and separated unverified findings from required changes.
+- [x] Recorded production safeguards, test coverage, rollout order and deferred scope.
+- [x] Development authorised and started in isolated codex/anchor-booking-growth worktrees.
+
+Status: implementation prepared locally in both repositories. See anchor-booking-growth/verification.md for current evidence and release gates. Two migration drafts are not applied. Menu and capacity data remain unchanged; no campaign has run.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -169,3 +169,13 @@ remain excluded.
 ## API connections, 5 September 2026
 
 See `tasks/fix-function/2026-09-05-api-connections/todo.md` for the isolated remediation run, verified fixes and production rollout.
+
+## 5 September 2026: Anchor booking growth
+
+- [x] Implement event dining requests and Christmas course snapshots in the isolated booking-growth branch.
+- [x] Complete independent SQL/code review and isolated migration/rollback tests.
+- [x] Save baseline, guarded menu corrections, dated-capacity review and release approval package in `tasks/anchor-booking-growth/`.
+- [x] Complete paired browser verification and refreshed integration gates.
+- [ ] Obtain approval of exact production migration, activation and menu payloads before application.
+- [ ] Deploy the paired approved release and verify production aliases.
+- [ ] Configure only venue-confirmed dated capacities; campaign remains a prepared brief.

--- a/tests/api/event-bookings-dining-requests.test.ts
+++ b/tests/api/event-bookings-dining-requests.test.ts
@@ -1,0 +1,240 @@
+vi.mock('@/services/event-bookings', () => ({ EventBookingService: { createBooking: vi.fn(), normalizeBookingMode: () => 'general' } }))
+import { EventBookingService } from '@/services/event-bookings'
+import { consentHashPayload } from '@/lib/consent/validation'
+import { claimIdempotencyKey } from '@/lib/api/idempotency'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Mirror the REAL createErrorResponse envelope: { success: false, error: { code, message } }.
+// The website contract asserts a 409 with error.code === 'SALES_CLOSED'.
+vi.mock('@/lib/api/auth', () => ({
+  withApiAuth: vi.fn(
+    async (
+      handler: (request: Request) => Promise<Response>,
+      _permissions: string[],
+      request: Request
+    ) => handler(request)
+  ),
+  createApiResponse: vi.fn((data: unknown, status = 200) => Response.json(data, { status })),
+  getApiKeyAuthState: vi.fn().mockResolvedValue('authenticated'),
+  createErrorResponse: vi.fn((message: string, code: string, status = 400) =>
+    Response.json(
+      {
+        success: false,
+        error: {
+          code,
+          message,
+        },
+      },
+      { status }
+    )
+  ),
+}))
+
+vi.mock('@/lib/api/idempotency', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api/idempotency')>()),
+  claimIdempotencyKey: vi.fn().mockResolvedValue({ state: 'claimed' }),
+  getIdempotencyKey: vi.fn().mockReturnValue('idem-1'),
+  persistIdempotencyResponse: vi.fn(),
+  releaseIdempotencyClaim: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  formatPhoneForStorage: vi.fn((value: string) => value),
+}))
+
+vi.mock('@/lib/sms/customers', () => ({
+  ensureCustomerForPhone: vi.fn(),
+}))
+
+vi.mock('@/lib/twilio', () => ({
+  sendSMS: vi.fn(),
+}))
+
+vi.mock('@/lib/sms/support', () => ({
+  ensureReplyInstruction: vi.fn((value: string) => value),
+}))
+
+vi.mock('@/lib/analytics/events', () => ({
+  recordAnalyticsEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/events/manage-booking', () => ({
+  createEventManageToken: vi.fn().mockResolvedValue({ url: 'https://example.com/manage' }),
+}))
+
+vi.mock('@/lib/events/event-payments', () => ({
+  createEventPaymentToken: vi.fn().mockResolvedValue({ url: 'https://example.com/pay' }),
+}))
+
+vi.mock('@/lib/events/sunday-lunch-only-policy', () => ({
+  isSundayLunchOnlyEvent: vi.fn().mockReturnValue(false),
+  SUNDAY_LUNCH_ONLY_EVENT_MESSAGE: 'Sunday lunch only',
+}))
+
+const { warn, error, info } = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    warn,
+    error,
+    info,
+  },
+}))
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { ensureCustomerForPhone } from '@/lib/sms/customers'
+import { POST } from '@/app/api/event-bookings/route'
+
+const EVENT_ID = '11111111-1111-4111-8111-111111111111'
+const CUSTOMER_ID = '22222222-2222-4222-8222-222222222222'
+
+function buildRequest(overrides: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/event-bookings', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'idempotency-key': 'idem-1' },
+    body: JSON.stringify({
+      event_id: EVENT_ID,
+      phone: '+447700900123',
+      first_name: 'Pat',
+      seats: 2,
+      ...overrides,
+    }),
+  })
+}
+
+/**
+ * Wires an admin-client mock whose events lookup returns the supplied row.
+ * A successful create_event_booking_v06 RPC lets the "not blocked" cases reach 201.
+ */
+function mockAdminClientWithEvent(eventRow: Record<string, unknown>) {
+  const eventMaybeSingle = vi.fn().mockResolvedValue({ data: eventRow, error: null })
+  const eventEq = vi.fn().mockReturnValue({ maybeSingle: eventMaybeSingle })
+  const eventSelect = vi.fn().mockReturnValue({ eq: eventEq })
+
+  const customerMaybeSingle = vi.fn().mockResolvedValue({
+    data: {
+      id: CUSTOMER_ID,
+      first_name: 'Pat',
+      mobile_number: '+447700900123',
+      sms_status: 'active',
+    },
+    error: null,
+  })
+  const customerEq = vi.fn().mockReturnValue({ maybeSingle: customerMaybeSingle })
+  const customerSelect = vi.fn().mockReturnValue({ eq: customerEq })
+
+  ;(createAdminClient as unknown as vi.Mock).mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === 'events') return { select: eventSelect }
+      if (table === 'customers') return { select: customerSelect }
+      throw new Error(`Unexpected table: ${table}`)
+    }),
+    rpc: vi.fn(async (name: string) => {
+      if (name === 'create_event_booking_v06') {
+        return {
+          data: {
+            state: 'confirmed',
+            booking_id: 'booking-1',
+            payment_mode: 'free',
+            event_id: EVENT_ID,
+            event_name: 'Test Event',
+            event_start_datetime: '2999-01-01T19:00:00Z',
+            seats_remaining: 10,
+          },
+          error: null,
+        }
+      }
+      throw new Error(`Unexpected RPC: ${name}`)
+    }),
+  })
+}
+
+const baseEventRow = {
+  id: EVENT_ID,
+  name: 'Test Event',
+  date: '2999-01-01',
+  start_datetime: '2999-01-01T19:00:00Z',
+  booking_mode: 'general',
+  bookings_enabled: true,
+  payment_mode: 'free',
+  is_free: true,
+  price: 0,
+  price_per_seat: 0,
+}
+
+
+describe('event dining requests at the authoritative API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(claimIdempotencyKey).mockResolvedValue({ state: 'claimed' } as Awaited<ReturnType<typeof claimIdempotencyKey>>)
+    vi.mocked(ensureCustomerForPhone).mockResolvedValue({ customerId: CUSTOMER_ID } as Awaited<ReturnType<typeof ensureCustomerForPhone>>)
+    mockAdminClientWithEvent(baseEventRow)
+    vi.mocked(EventBookingService.createBooking).mockResolvedValue({ resolvedState: 'confirmed', bookingId: 'booking-fixture', rpcResult: { state: 'confirmed', booking_id: 'booking-fixture', requests_recorded: true } } as Awaited<ReturnType<typeof EventBookingService.createBooking>>)
+  })
+  it.each([
+    [{ dining_request: 'before_event' }, { dining_request: 'during_event' }],
+    [{ early_arrival_request: true }, { early_arrival_request: false }],
+    [{ dining_request: 'before_event' }, {}],
+  ])('rejects a changed request with the same explicit key: %j to %j', async (first, changed) => {
+    let savedHash: string | null = null
+    vi.mocked(claimIdempotencyKey).mockImplementation(async (_db, _key, hash) => {
+      if (savedHash === null) {
+        savedHash = hash
+        return { state: 'claimed' }
+      }
+      return savedHash === hash
+        ? { state: 'replay', response: { success: true, data: { state: 'confirmed' }, meta: { status_code: 201 } } }
+        : { state: 'conflict' }
+    })
+    expect((await POST(buildRequest(first))).status).toBe(201)
+    const response = await POST(buildRequest(changed))
+    expect(response.status).toBe(409)
+    expect((await response.json()).error.code).toBe('IDEMPOTENCY_KEY_CONFLICT')
+    expect(EventBookingService.createBooking).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the legacy no-request hash and treats false as no early-arrival request', async () => {
+    await POST(buildRequest())
+    await POST(buildRequest({ early_arrival_request: false }))
+    const hashes = vi.mocked(claimIdempotencyKey).mock.calls.map((call) => call[2])
+    expect(hashes[0]).toBe(hashes[1])
+    const { computeIdempotencyRequestHash } = await import('@/lib/api/idempotency')
+    expect(hashes[0]).toBe(computeIdempotencyRequestHash({
+      event_id: EVENT_ID, phone: '+447700900123', first_name: 'Pat', last_name: null,
+      email: null, seats: 2, seating_preference: 'seated', expected_event_date: null,
+      communication_consent: consentHashPayload(undefined),
+    }))
+  })
+
+  it('passes validated requests to atomic creation and acknowledges persistence', async () => {
+    const response = await POST(buildRequest({ dining_request: 'before_event', early_arrival_request: true }))
+    expect(response.status).toBe(201)
+    expect((await response.json()).data.requests_recorded).toBe(true)
+    expect(EventBookingService.createBooking).toHaveBeenCalledWith(expect.objectContaining({ diningRequest: 'before_event', earlyArrivalRequest: true }))
+  })
+  it.each([{ dining_request: 'promised_meal' }, { early_arrival_request: '18:00' }])('rejects invalid operational request %j', async (extra) => {
+    expect((await POST(buildRequest(extra))).status).toBe(400)
+    expect(EventBookingService.createBooking).not.toHaveBeenCalled()
+  })
+  it('returns an error when atomic persistence fails', async () => {
+    vi.mocked(EventBookingService.createBooking).mockResolvedValue({ rpcFailed: true } as Awaited<ReturnType<typeof EventBookingService.createBooking>>)
+    const response = await POST(buildRequest({ dining_request: 'not_sure' }))
+    expect(response.status).toBe(500)
+    expect((await response.json()).success).toBe(false)
+  })
+  it('replays recorded acknowledgement without creating or appending again', async () => {
+    vi.mocked(claimIdempotencyKey).mockResolvedValue({ state: 'replay', response: { success: true, data: { state: 'confirmed', booking_id: 'booking-fixture', requests_recorded: true }, meta: { status_code: 201 } } } as Awaited<ReturnType<typeof claimIdempotencyKey>>)
+    const response = await POST(buildRequest({ dining_request: 'before_event' }))
+    expect((await response.json()).data.requests_recorded).toBe(true)
+    expect(EventBookingService.createBooking).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/tableBookingRouteErrorPayloads.test.ts
+++ b/tests/api/tableBookingRouteErrorPayloads.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/foh/bookings', () => ({
 vi.mock('@/lib/events/staff-seat-updates', () => ({
   mapSeatUpdateBlockedReason: vi.fn((reason?: string) => reason || 'blocked'),
   updateTableBookingPartySizeWithLinkedEventSeats: vi.fn(),
+  ChristmasCourseValidationError: class ChristmasCourseValidationError extends Error {},
   PartySizeUpdateFailedAfterMoveError: class PartySizeUpdateFailedAfterMoveError extends Error {},
 }))
 

--- a/tests/api/tableBookingStructuredPersistence.test.ts
+++ b/tests/api/tableBookingStructuredPersistence.test.ts
@@ -130,7 +130,7 @@ function buildSupabase() {
   const tableBookingsUpdateEq = vi.fn().mockResolvedValue({ error: null })
   const tableBookingsUpdate = vi.fn(() => ({ eq: tableBookingsUpdateEq }))
 
-  const rpc = vi.fn(async () => ({
+  const rpc = vi.fn(async (): Promise<{ data: Record<string, unknown> | null; error: { message: string } | null }> => ({
     data: {
       state: 'pending_payment',
       table_booking_id: BOOKING_ID,
@@ -172,6 +172,35 @@ describe('POST /api/table-bookings — structured persistence', () => {
     vi.clearAllMocks()
     ensureCustomerForPhone.mockResolvedValue({ customerId: 'cust-1' })
     saveSundayPreorderByBookingId.mockResolvedValue({ state: 'saved', item_count: 2, booking_id: BOOKING_ID })
+  })
+
+  it('routes explicit Christmas course choices through the atomic snapshot RPC', async () => {
+    const supabase = buildSupabase()
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const response = await POST(buildRequest({
+      phone: '+447000000000', first_name: 'Fixture', last_name: 'Guest', date: '2026-12-05', time: '18:00',
+      party_size: 6, purpose: 'food', booking_period_id: DISH_ID, booking_period_answer: true,
+      christmas_course_counts: [1, 1, 1, 1, 1, 1],
+    }) as Parameters<typeof POST>[0])
+    expect(response.status).toBeLessThan(400)
+    expect(supabase.rpc).toHaveBeenCalledWith('create_table_booking_christmas_v01', expect.objectContaining({
+      p_course_counts: [1, 1, 1, 1, 1, 1],
+      p_request: expect.objectContaining({ customer_id: 'cust-1', party_size: 6 }),
+    }))
+  })
+
+  it('fails visibly if the course RPC cannot run, without silently using the legacy create path', async () => {
+    const supabase = buildSupabase()
+    supabase.rpc.mockResolvedValueOnce({ data: null, error: { message: 'Course capability unavailable' } })
+    vi.mocked(createAdminClient).mockReturnValue(supabase as unknown as ReturnType<typeof createAdminClient>)
+    const response = await POST(buildRequest({
+      phone: '+447000000000', first_name: 'Fixture', date: '2026-12-05', time: '18:00',
+      party_size: 6, purpose: 'food', booking_period_id: DISH_ID, booking_period_answer: true,
+      christmas_course_counts: [1, 1, 1, 1, 1, 1],
+    }) as Parameters<typeof POST>[0])
+    expect(response.status).toBe(500)
+    expect((await response.json()).error).toBeTruthy()
+    expect(supabase.rpc).toHaveBeenCalledTimes(1)
   })
 
   it('persists dietary_requirements and allergies arrays on the booking row', async () => {

--- a/tests/database/event-booking-dining-requests.sql
+++ b/tests/database/event-booking-dining-requests.sql
@@ -1,0 +1,93 @@
+-- Run only in an empty isolated PostgreSQL database, never production.
+\set ON_ERROR_STOP on
+CREATE ROLE anon;
+CREATE ROLE authenticated;
+CREATE ROLE service_role;
+CREATE TABLE public.bookings (
+  id uuid PRIMARY KEY, event_id uuid, customer_id uuid, status text,
+  notes text CHECK (notes NOT LIKE '%reject-me%'), updated_at timestamptz
+);
+GRANT USAGE ON SCHEMA public TO service_role;
+GRANT ALL ON public.bookings TO service_role;
+CREATE FUNCTION public.create_event_booking_v06(uuid, uuid, integer, text, text, integer) RETURNS jsonb
+LANGUAGE plpgsql AS $$
+DECLARE v_id uuid := '33333333-3333-4333-8333-333333333333';
+BEGIN
+  IF $4 = 'conflict' THEN
+    RETURN jsonb_build_object('state','blocked','reason','customer_conflict','booking_id',v_id);
+  END IF;
+  IF $4 = 'waitlist' THEN
+    RETURN jsonb_build_object('state','full_with_waitlist_option');
+  END IF;
+  IF $4 = 'missing' THEN
+    RETURN jsonb_build_object('state','confirmed','booking_id',v_id);
+  END IF;
+  INSERT INTO public.bookings VALUES (v_id,$1,$2,CASE WHEN $4='pending' THEN 'pending_payment' ELSE 'confirmed' END,CASE WHEN $4='reject' THEN 'reject-me' ELSE 'Existing note' END, now());
+  RETURN jsonb_build_object('state',CASE WHEN $4='pending' THEN 'pending_payment' ELSE 'confirmed' END,'booking_id',v_id);
+END $$;
+CREATE FUNCTION public.create_event_booking_v07(uuid,uuid,text,text,integer,jsonb) RETURNS jsonb
+LANGUAGE sql AS $$ SELECT public.create_event_booking_v06($1,$2,2,$3,$4,$5) $$;
+\ir ../../supabase/migrations/20260905100521_event_booking_dining_requests.sql
+
+DO $$ BEGIN
+  IF has_function_privilege('anon','public.create_event_booking_with_requests_v01(uuid,uuid,integer,text,text,integer,jsonb,text,boolean)','EXECUTE') OR
+     has_function_privilege('authenticated','public.create_event_booking_with_requests_v01(uuid,uuid,integer,text,text,integer,jsonb,text,boolean)','EXECUTE') THEN
+    RAISE EXCEPTION 'Public role can execute';
+  END IF;
+END $$;
+SET ROLE anon;
+DO $$ BEGIN
+  BEGIN
+    PERFORM public.create_event_booking_with_requests_v01(NULL,NULL,2);
+    RAISE EXCEPTION 'Anon unexpectedly executed';
+  EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+END $$;
+RESET ROLE;
+SET ROLE authenticated;
+DO $$ BEGIN
+  BEGIN
+    PERFORM public.create_event_booking_with_requests_v01(NULL,NULL,2);
+    RAISE EXCEPTION 'Authenticated unexpectedly executed';
+  EXCEPTION WHEN insufficient_privilege THEN NULL; END;
+END $$;
+RESET ROLE;
+SET ROLE service_role;
+DO $$
+DECLARE v_result jsonb; v_before text;
+BEGIN
+  v_result := public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'brand_site','seated',15,NULL,'before_event',true);
+  IF v_result->>'requests_recorded' <> 'true' OR NOT EXISTS (SELECT 1 FROM public.bookings WHERE notes LIKE 'Existing note%' AND notes LIKE '%UNCONFIRMED REQUEST:%' AND notes LIKE '%before the event%' AND notes LIKE '%arriving early%') THEN RAISE EXCEPTION 'Request not stored'; END IF;
+  SELECT notes INTO v_before FROM public.bookings;
+  v_result := public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'conflict','seated',15,NULL,'during_event',true);
+  IF v_result->>'state' <> 'blocked' OR EXISTS (SELECT 1 FROM public.bookings WHERE notes <> v_before) THEN RAISE EXCEPTION 'Retry altered existing booking'; END IF;
+  DELETE FROM public.bookings;
+  v_result := public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'pending','seated',15,'[]','not_sure',false);
+  IF v_result->>'state' <> 'pending_payment' OR v_result->>'requests_recorded' <> 'true' THEN RAISE EXCEPTION 'Multi-ticket pending request lost'; END IF;
+  DELETE FROM public.bookings;
+  v_result := public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'waitlist','seated',15,NULL,'during_event',true);
+  IF v_result ? 'requests_recorded' OR EXISTS(SELECT 1 FROM public.bookings) THEN RAISE EXCEPTION 'Waitlist wrote notes'; END IF;
+  BEGIN
+    PERFORM public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'brand_site','seated',15,NULL,'invalid',false);
+    RAISE EXCEPTION 'Invalid request accepted';
+  EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  IF EXISTS(SELECT 1 FROM public.bookings) THEN RAISE EXCEPTION 'Invalid request created booking'; END IF;
+END $$;
+RESET ROLE;
+-- Fail the notes UPDATE, after the inner creator has inserted the booking.
+CREATE FUNCTION public.reject_booking_notes() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'injected notes failure'; END $$;
+CREATE TRIGGER reject_booking_notes BEFORE UPDATE ON public.bookings FOR EACH ROW EXECUTE FUNCTION public.reject_booking_notes();
+SET ROLE service_role;
+DO $$ BEGIN
+  BEGIN
+    PERFORM public.create_event_booking_with_requests_v01('11111111-1111-4111-8111-111111111111','22222222-2222-4222-8222-222222222222',2,'brand_site','seated',15,NULL,'before_event',false);
+    RAISE EXCEPTION 'Expected failure';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM <> 'injected notes failure' THEN RAISE; END IF;
+  END;
+  IF EXISTS(SELECT 1 FROM public.bookings) THEN RAISE EXCEPTION 'Booking survived failed request persistence'; END IF;
+END $$;
+RESET ROLE;
+DROP TRIGGER reject_booking_notes ON public.bookings;
+-- Reversible rollout: function removal does not remove booking notes or change legacy creators.
+DROP FUNCTION public.create_event_booking_with_requests_v01(uuid,uuid,integer,text,text,integer,jsonb,text,boolean);
+SELECT 'PASS: request persistence, conflict/retry, pending multi-type, waitlist, validation, atomic rollback, grants and rollback' AS result;

--- a/tests/db/christmas-course-activation.sql
+++ b/tests/db/christmas-course-activation.sql
@@ -1,0 +1,9 @@
+-- Isolated PostgreSQL only.
+\set ON_ERROR_STOP on
+BEGIN;
+CREATE TABLE public.system_settings(key text PRIMARY KEY, value jsonb NOT NULL, description text, updated_at timestamptz);
+\ir ../../tasks/anchor-booking-growth/christmas-course-activate.sql
+DO $$ BEGIN ASSERT (SELECT value='{"value":true}'::jsonb FROM system_settings WHERE key='christmas_course_policy_enabled'); END $$;
+\ir ../../tasks/anchor-booking-growth/christmas-course-disable.sql
+DO $$ BEGIN ASSERT (SELECT value='{"value":false}'::jsonb FROM system_settings WHERE key='christmas_course_policy_enabled'); END $$;
+ROLLBACK;

--- a/tests/db/christmas-course-snapshot.sql
+++ b/tests/db/christmas-course-snapshot.sql
@@ -1,0 +1,94 @@
+-- Isolated PostgreSQL harness only. The allocator is a fixture; never run on a linked database.
+\set ON_ERROR_STOP on
+BEGIN;
+CREATE ROLE anon;
+CREATE ROLE authenticated;
+CREATE ROLE service_role;
+CREATE FUNCTION public.get_setting_bool(text, boolean) RETURNS boolean LANGUAGE sql AS $$ SELECT true $$;
+CREATE TABLE public.booking_periods(period_kind text, is_active boolean, archived_at timestamptz,
+  starts_on date, ends_on date, preorder_cutoff_days integer);
+CREATE TABLE public.booking_period_menu_items(id uuid, period_id uuid, course text, is_active boolean);
+INSERT INTO public.booking_period_menu_items VALUES
+('00000000-0000-0000-0000-000000000011','00000000-0000-0000-0000-000000000002','main',true),
+('00000000-0000-0000-0000-000000000012','00000000-0000-0000-0000-000000000002','starter',true),
+('00000000-0000-0000-0000-000000000013','00000000-0000-0000-0000-000000000002','dessert',true);
+CREATE TABLE public.table_bookings(id uuid PRIMARY KEY, party_size integer, booking_date date,
+  booking_type text, booking_period_answer boolean, booking_period_requires_preorder boolean);
+CREATE TABLE public.booking_preorder_covers(id uuid, table_booking_id uuid, ordinal integer);
+CREATE TABLE public.booking_preorder_selections(cover_id uuid);
+INSERT INTO public.booking_periods VALUES ('christmas', true, NULL, current_date, current_date + 60, 7);
+CREATE FUNCTION public.create_table_booking_public_v06(p_customer_id uuid, p_booking_date date,
+  p_booking_time time, p_party_size integer, p_booking_purpose text DEFAULT 'food', p_notes text DEFAULT NULL,
+  p_sunday_lunch boolean DEFAULT false, p_source text DEFAULT 'brand_site', p_bypass_cutoff boolean DEFAULT false,
+  p_deposit_waived boolean DEFAULT false, p_bypass_pacing boolean DEFAULT false, p_high_chair_count integer DEFAULT 0,
+  p_outside_seating boolean DEFAULT false, p_requires_accessible_table boolean DEFAULT false,
+  p_booking_period_id uuid DEFAULT NULL, p_booking_period_answer boolean DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql AS $$
+DECLARE v_id uuid := gen_random_uuid();
+BEGIN
+  IF p_notes = 'conflict' THEN RETURN jsonb_build_object('state', 'blocked', 'reason', 'customer_conflict', 'table_booking_id', p_customer_id); END IF;
+  IF p_notes = 'failure' THEN RAISE EXCEPTION 'allocator unavailable'; END IF;
+  INSERT INTO table_bookings VALUES(v_id, p_party_size, p_booking_date, 'christmas', true, true);
+  RETURN jsonb_build_object('state', 'pending_payment', 'table_booking_id', v_id,
+    'deposit_amount', p_party_size * 10, 'booking_period_requires_preorder', true);
+END; $$;
+\ir ../../supabase/migrations/20260905100155_christmas_course_snapshot.sql
+DO $$
+DECLARE
+  r jsonb;
+  request jsonb := jsonb_build_object('party_size', 6, 'date', current_date + 30, 'time', '18:00',
+    'customer_id', '00000000-0000-0000-0000-000000000001',
+    'booking_period_id', '00000000-0000-0000-0000-000000000002', 'booking_period_answer', true);
+  before_count integer;
+  booking uuid;
+  mixed jsonb;
+BEGIN
+  r := create_table_booking_christmas_v01(request, ARRAY[1,1,1,1,1,1]);
+  booking := (r->>'table_booking_id')::uuid;
+  ASSERT r->>'state' = 'pending_payment';
+  ASSERT (r->>'deposit_amount')::numeric = 60;
+  ASSERT (r->>'booking_period_requires_preorder')::boolean = false;
+  ASSERT (SELECT christmas_course_counts = ARRAY[1,1,1,1,1,1] AND NOT booking_period_requires_preorder FROM table_bookings WHERE id=booking);
+  r := create_table_booking_christmas_v01(request || '{"party_size":20}', array_fill(1, ARRAY[20]));
+  ASSERT (r->>'deposit_amount')::numeric = 200;
+  BEGIN PERFORM create_table_booking_christmas_v01(request || '{"party_size":5}', array_fill(1, ARRAY[5])); RAISE EXCEPTION 'accepted five'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN PERFORM create_table_booking_christmas_v01(request || '{"party_size":21}', array_fill(1, ARRAY[21])); RAISE EXCEPTION 'accepted 21'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN PERFORM create_table_booking_christmas_v01(request, ARRAY[1,1,1,1,1,NULL]); RAISE EXCEPTION 'accepted missing tier'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN PERFORM create_table_booking_christmas_v01(request, ARRAY[1,1,1,1,1,2]); RAISE EXCEPTION 'accepted missing food'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN UPDATE table_bookings SET party_size=7 WHERE id=booking; RAISE EXCEPTION 'silently expanded'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN UPDATE table_bookings SET christmas_course_counts=NULL WHERE id=booking; RAISE EXCEPTION 'cleared snapshot'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  UPDATE table_bookings SET booking_period_requires_preorder=true WHERE id=booking;
+  ASSERT (SELECT NOT booking_period_requires_preorder FROM table_bookings WHERE id=booking);
+  SELECT count(*) INTO before_count FROM table_bookings;
+  r := create_table_booking_christmas_v01(request || jsonb_build_object('notes','conflict','customer_id',booking), ARRAY[1,1,1,1,1,1]);
+  ASSERT r->>'state' = 'blocked';
+  ASSERT (SELECT count(*) = before_count FROM table_bookings);
+  BEGIN PERFORM create_table_booking_christmas_v01(request || '{"notes":"failure"}', ARRAY[1,1,1,1,1,1]); EXCEPTION WHEN raise_exception THEN NULL; END;
+  ASSERT (SELECT count(*) = before_count FROM table_bookings);
+  r := create_table_booking_public_v06('00000000-0000-0000-0000-000000000001', current_date+30, '18:00', 6);
+  ASSERT (SELECT christmas_course_counts IS NULL AND booking_period_requires_preorder FROM table_bookings WHERE id=(r->>'table_booking_id')::uuid);
+  mixed := request || jsonb_build_object('preorder', jsonb_build_array(
+    '{}'::jsonb, '{}'::jsonb, '{}'::jsonb, '{}'::jsonb,
+    '{"main_menu_item_id":"00000000-0000-0000-0000-000000000011","starter_menu_item_id":"00000000-0000-0000-0000-000000000012"}'::jsonb,
+    '{"main_menu_item_id":"00000000-0000-0000-0000-000000000011","starter_menu_item_id":"00000000-0000-0000-0000-000000000012","dessert_menu_item_id":"00000000-0000-0000-0000-000000000013"}'::jsonb));
+  r := create_table_booking_christmas_v01(mixed, ARRAY[1,1,1,1,2,3]);
+  booking := (r->>'table_booking_id')::uuid;
+  ASSERT (r->>'booking_period_requires_preorder')::boolean;
+  ASSERT (SELECT christmas_course_counts = ARRAY[1,1,1,1,2,3] FROM table_bookings WHERE id=booking);
+  BEGIN PERFORM create_table_booking_christmas_v01(mixed || jsonb_build_object('date', current_date+6), ARRAY[1,1,1,1,2,3]); RAISE EXCEPTION 'accepted after cutoff'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  BEGIN UPDATE table_bookings SET booking_date=current_date+6 WHERE id=booking; RAISE EXCEPTION 'moved past cutoff'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  UPDATE table_bookings SET party_size=7, christmas_course_counts=ARRAY[1,1,1,1,2,3,1] WHERE id=booking;
+  ASSERT (SELECT booking_period_requires_preorder AND cardinality(christmas_course_counts)=7 FROM table_bookings WHERE id=booking);
+  UPDATE table_bookings SET booking_period_requires_preorder=false WHERE id=booking;
+  ASSERT (SELECT booking_period_requires_preorder FROM table_bookings WHERE id=booking);
+  INSERT INTO booking_preorder_covers VALUES('00000000-0000-0000-0000-000000000030', booking, 6);
+  INSERT INTO booking_preorder_selections VALUES('00000000-0000-0000-0000-000000000030');
+  UPDATE table_bookings SET christmas_course_counts=ARRAY[1,1,1,1,2,1,1] WHERE id=booking;
+  ASSERT NOT EXISTS (SELECT 1 FROM booking_preorder_selections);
+  BEGIN INSERT INTO booking_preorder_selections VALUES('00000000-0000-0000-0000-000000000030'); RAISE EXCEPTION 'added food for one course'; EXCEPTION WHEN invalid_parameter_value THEN NULL; END;
+  ASSERT (christmas_course_policy_v01(current_date+30)->>'preorder_closes_at')::timestamptz = ((current_date+23)+time '12:00') AT TIME ZONE 'Europe/London';
+  ASSERT NOT has_function_privilege('anon' ,'public.create_table_booking_christmas_v01(jsonb,integer[])','EXECUTE');
+  ASSERT NOT has_function_privilege('authenticated','public.christmas_course_policy_v01(date)','EXECUTE');
+  ASSERT has_function_privilege('service_role','public.create_table_booking_christmas_v01(jsonb,integer[])','EXECUTE');
+END; $$;
+ROLLBACK;

--- a/tests/db/christmas-course-snapshot.sql
+++ b/tests/db/christmas-course-snapshot.sql
@@ -4,7 +4,10 @@ BEGIN;
 CREATE ROLE anon;
 CREATE ROLE authenticated;
 CREATE ROLE service_role;
-CREATE FUNCTION public.get_setting_bool(text, boolean) RETURNS boolean LANGUAGE sql AS $$ SELECT true $$;
+CREATE TABLE public.system_settings(key text PRIMARY KEY, value jsonb);
+CREATE FUNCTION public.get_setting_bool(p_key text, p_default boolean) RETURNS boolean LANGUAGE sql AS $$
+  SELECT coalesce((SELECT (value->>'value')::boolean FROM public.system_settings WHERE key=p_key), p_default)
+$$;
 CREATE TABLE public.booking_periods(period_kind text, is_active boolean, archived_at timestamptz,
   starts_on date, ends_on date, preorder_cutoff_days integer);
 CREATE TABLE public.booking_period_menu_items(id uuid, period_id uuid, course text, is_active boolean);
@@ -33,6 +36,8 @@ BEGIN
     'deposit_amount', p_party_size * 10, 'booking_period_requires_preorder', true);
 END; $$;
 \ir ../../supabase/migrations/20260905100155_christmas_course_snapshot.sql
+DO $$ BEGIN ASSERT christmas_course_policy_v01(current_date+30) IS NULL; END $$;
+INSERT INTO public.system_settings VALUES ('christmas_course_policy_enabled', '{"value":true}');
 DO $$
 DECLARE
   r jsonb;


### PR DESCRIPTION
## What changed

Event food and early-arrival discussion requests now commit with the reservation and appear in existing staff notes. Christmas bookings can retain per-guest course choices through creation, pre-orders and staff amendments, including the one-course exemption and mixed-course parties.

## Why

Guests and staff need the same request and course information. Existing allocator, deposit and refund rules are retained. Changed selections under an existing booking key return a conflict instead of replaying old requests.

## Testing done

- [x] Lint, typecheck, 722 suites with 6,208 passing tests, and production build on Node 20.
- [x] Coverage before the latest main integration exceeded all floors: 52.89% lines, 42.50% branches, 60.79% functions.
- [x] Full UTC run plus corrected timezone-test configuration assertion; targeted confirmation templates with mocked transports.
- [x] Independent review and isolated SQL state/conflict/rollback/grant tests.
- [ ] Production application and smoke checks await exact SQL approval.

## Complexity score

L. Paired website release, two additive database changes and existing staff/guest consumers. Changed-file manifest, baseline and approval packets are in tasks/anchor-booking-growth/.

## Breaking changes

Apply both reviewed migrations before exposing the website event-request fields. Christmas capability stays disabled until compatible applications are deployed and the separately reviewed setting is enabled. Existing clients and legacy null course snapshots retain their path.

## Migration risk

High: new grants, triggers and explicit course-amendment dish clearing. No migration applied. Review 20260905100155_christmas_course_snapshot.sql and 20260905100521_event_booking_dining_requests.sql with the exact checksums and rollback plans in tasks/anchor-booking-growth/release-approval.md. Local PostgreSQL 17 fixtures substitute existing allocators; production uses PostgreSQL 15. No real booking, payment, refund or communication was used for testing.

Existing allocation RPCs, payment arithmetic, waitlist and booking-sheet renderer are deliberately retained. Event capacities and eight menu corrections remain prepared, not applied.

Paired pull request: https://github.com/peterjpitcher/the-anchor.pub/pull/135
