### PR TITLE
feat: consolidate manager emails into a Friday report

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Use this index to find the canonical documentation for The Anchor Management Too
 - [Testing](./TESTING.md) – current automated test status, manual smoke checks, and how to add new coverage.
 
 ## Operations & Support
+- [Friday manager report](./manager-weekly-report.md): notification policy, scheduling and delivery recovery.
 - [Deployment](./DEPLOYMENT.md) – environment configuration, release workflow, and monitoring checklist.
 - [Troubleshooting](./TROUBLESHOOTING.md) – quick diagnostics for auth, database, SMS, and build issues.
 - **Setup guides** (`/setup/`):

--- a/docs/manager-weekly-report.md
+++ b/docs/manager-weekly-report.md
@@ -1,0 +1,43 @@
+# Friday manager report
+
+The owner approved consolidating these manager notifications on 5 September 2026. Delivery is Friday at 09:00 Europe/London, including British Summer Time. The first report includes updates collected after this release, not a replay of previously delivered emails.
+
+## Email policy
+
+| Included in the Friday report | Remains immediate |
+| --- | --- |
+| New table booking alerts | New private booking enquiries |
+| Manager copies of staff shift acceptance reminders | Rejected shifts |
+| Holiday approval reminders | Completed employee onboarding |
+| Checklist alerts and weekly summary | Private-event outcome requests |
+| Recruitment manager alerts | Payroll earnings threshold alerts |
+| Private booking weekly summary | Open-shift requests |
+| Weekly rota alert | Guest feedback |
+
+Staff shift warnings, applicant messages and customer messages keep their existing timing. Other notification streams are unchanged, including urgent daily unfilled shifts, birthdays, parking, pre-orders, website enquiry failure fallback and Peter's technical alerts.
+
+## Scheduling and content
+
+`vercel.json` remains the schedule source of truth. Private booking, checklist and rota snapshots run at 08:00 London on Friday. Two UTC slots cover winter and summer, and each route checks the local hour. The delivery route runs hourly on Friday, permits delivery from 09:00 London, and retries the same report after a failure.
+
+The report groups updates into eight sections, gives their recorded dates and links to the relevant management pages. It includes a report even when no updates were collected. Missing snapshots are labelled unavailable. A shortened email includes an escaped HTML attachment containing the complete stored details. Recorded reminders can have been resolved since collection; the report directs the manager to the current app state.
+
+`MANAGER_EMAIL` supplies the default recipient. Existing per-feature recipient overrides are retained. Different configured recipients receive separate reports. The old `PRIVATE_BOOKINGS_WEEKLY_DIGEST_HOUR_LONDON` setting no longer controls scheduling.
+
+## Storage and delivery
+
+No database migration is required. Existing `email_messages` rows with `comm_type=manager_report_item` retain queued updates. A stable identifier based on section, source key and recipient prevents duplicate insertion or resetting an already sent item.
+
+Before delivery, the route persists an immutable `manager_weekly_report` row with its recipients, sender, content, attachments and source membership. An atomic lease in `cron_job_runs` serialises attempts. Delivery uses Resend with the same idempotency key and payload on every retry. Provider acceptance is recorded before source finalisation. Checklist, recruitment and holiday delivery records are finalised only after acceptance; queue acceptance alone is never recorded as a successful email send.
+
+Updates arriving after the report is frozen remain queued for the following Friday. Previously queued backlog is included with its original recorded date.
+
+Staff warning delivery runs independently of manager collection. Failed manager collection payloads use existing failed `rota_email_log` records for retry, retaining the original reminder even if its shift is later accepted or deleted. Recovery clears the retry marker without changing the historical failed log into a sent email. If both the queue and fallback storage fail, the route returns HTTP 500; the manager copy then needs reconstruction from shift and staff delivery records.
+
+## Recovery
+
+Inspect the protected route's 500 response and `cron_job_runs` failure message first. Failed sends retain their queued items and frozen payload. A recorded acceptance can be finalised again without resending the email.
+
+If provider acceptance is unknown for 23 hours, automatic delivery stops before Resend's idempotency protection expires. Subsequent reports remain blocked until the earlier attempt is reconciled with provider records. Confirm whether that exact report was accepted before changing its state. Do not delete the report, clear its first-attempt timestamp or create a new send key as a retry shortcut. Any corrective production write requires the owner's explicit approval.
+
+Verification must use mocked providers and database clients. Do not invoke the authenticated production route to send a test report. Read-only deployment checks can assert the route rejects an unauthenticated request and inspect the deployed schedule.

--- a/scripts/testing/manager-report-preview.ts
+++ b/scripts/testing/manager-report-preview.ts
@@ -1,0 +1,84 @@
+/** Local synthetic rendering only. No database queries, provider calls or sends. */
+import { mkdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { renderManagerReport } from '../../src/lib/manager-report/render'
+import type { ManagerReportEntry } from '../../src/lib/manager-report/types'
+
+const outputDirectory = process.argv[2]
+if (!outputDirectory) throw new Error('Pass an output directory for the synthetic preview')
+
+const base = {
+  to: 'manager@example.test',
+  createdAt: '2026-09-11T07:00:00Z',
+}
+const entries: ManagerReportEntry[] = [
+  {
+    ...base, id: 'booking-1', key: 'booking-1', section: 'table_bookings',
+    subject: 'New table booking: EXAMPLE-101',
+    createdAt: '2026-09-09T14:30:00Z',
+    html: '<p>A new table booking has been created.</p><ul><li><strong>Reference:</strong> EXAMPLE-101</li><li><strong>When:</strong> Saturday 12 September 2026 at 18:30</li><li><strong>Party size:</strong> 6</li><li><strong>Guest:</strong> Alex Example</li><li><strong>Status:</strong> Confirmed</li><li><strong>Notes:</strong> One high chair requested.</li></ul>',
+  },
+  {
+    ...base, id: 'booking-2', key: 'booking-2', section: 'table_bookings',
+    subject: 'New table booking: EXAMPLE-102',
+    createdAt: '2026-09-10T10:45:00Z',
+    html: '<ul><li><strong>When:</strong> Sunday 13 September 2026 at 13:00</li><li><strong>Party size:</strong> 4</li><li><strong>Guest:</strong> Sam Sample</li><li><strong>Status:</strong> Confirmed</li></ul>',
+  },
+  {
+    ...base, id: 'shift-1', key: 'shift-1', section: 'staff_shift_reminders',
+    subject: 'Shift acceptance reminder: Jamie Example',
+    text: 'Jamie Example received a reminder to accept the Saturday 12 September, 17:00 to 23:00 bar shift. Acceptance was outstanding when the reminder was recorded.',
+  },
+  {
+    ...base, id: 'holiday-1', key: 'holiday-1', section: 'holiday_reminders',
+    subject: 'Holiday request awaiting approval: Robin Sample',
+    text: 'Requested dates: 21 to 23 September 2026. This request was awaiting a manager decision when the reminder was recorded.',
+  },
+  {
+    ...base, id: 'checklist-alert-1', key: 'checklist-alert-1', section: 'checklist_alerts',
+    subject: 'Checklist: closing task missed',
+    text: 'The bar closing checklist recorded one missed task on 9 September. Review the task record and follow-up notes.',
+  },
+  {
+    ...base, id: 'checklist-summary-1', key: 'checklist-summary-1', section: 'checklist_summary',
+    subject: 'Checklist summary, week to 11 September 2026',
+    html: '<h2>Checklists, week to 11 September 2026</h2><p>Completion: 96% (48 done, 2 missed, 1 late).</p><p>Spot checks recorded: 10 of 10 expected.</p><h3>Readings out of range (0)</h3><p>None.</p>',
+  },
+  {
+    ...base, id: 'recruitment-1', key: 'recruitment-1', section: 'recruitment',
+    subject: 'Recruitment: new application to review',
+    text: 'Taylor Example applied for a bar team role. Review the application and recorded assessment in Recruitment.',
+  },
+  {
+    ...base, id: 'private-summary-1', key: 'private-summary-1', section: 'private_bookings',
+    subject: 'Private bookings: coming events and actions',
+    metadata: { event_count: 2, action_count: 1 },
+    text: 'Saturday 12 September: Example family celebration, 30 guests. Final catering numbers awaiting confirmation.\nSunday 20 September: Sample community lunch, 20 guests. No outstanding action recorded.',
+  },
+  {
+    ...base, id: 'rota-summary-1', key: 'rota-summary-1', section: 'rota',
+    subject: 'Rota: one week needs attention',
+    metadata: { weeks_needing_attention: 1, unfilled_shifts: 0, pending_leave: 1 },
+    text: 'Week beginning 14 September: the draft rota has not been published.\nNo unfilled shifts recorded at snapshot time.\nOne holiday request was awaiting approval.',
+  },
+]
+
+async function main(): Promise<void> {
+  const report = renderManagerReport({
+    entries,
+    periodStart: '2026-09-04T08:00:00Z',
+    periodEnd: '2026-09-11T08:00:00Z',
+    appUrl: 'https://management.example.test',
+  })
+  if (/undefined|Invalid Date|NaN/.test(report.html + report.text)) {
+    throw new Error('Synthetic preview contains an invalid rendered value')
+  }
+  await mkdir(outputDirectory, { recursive: true })
+  await writeFile(join(outputDirectory, 'friday-report-preview.html'), report.html, 'utf8')
+  await writeFile(join(outputDirectory, 'friday-report-preview.txt'), report.text, 'utf8')
+  if (report.attachment) {
+    await writeFile(join(outputDirectory, report.attachment.filename), report.attachment.content, 'utf8')
+  }
+}
+
+void main()

--- a/src/app/api/cron/checklists-weekly-summary/route.ts
+++ b/src/app/api/cron/checklists-weekly-summary/route.ts
@@ -3,12 +3,9 @@ import { toZonedTime, format, formatInTimeZone } from 'date-fns-tz'
 import { authorizeCronRequest } from '@/lib/cron-auth'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { getChecklistSettings } from '@/lib/checklists/settings'
-import { jobQueue } from '@/lib/unified-job-queue'
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 
-// Vercel Cron: 0 * * * 1 (hourly on Mondays, UTC). Gates on 09:00 Europe/London so it fires
-// once per Monday regardless of DST; the weekly idempotency key makes any double-fire or
-// retry harmless. Builds one weekly_summary outbox row for the previous 7 locked business
-// days and lets the outbox processor deliver it. No individual scores in the email (spec 7).
+// Prepare the checklist snapshot at 08:00 London on Friday for the combined 09:00 report.
 const TIMEZONE = 'Europe/London'
 
 function esc(s: string): string {
@@ -23,13 +20,13 @@ export async function GET(request: Request) {
 
   const nowUtc = new Date()
   const nowLocal = toZonedTime(nowUtc, TIMEZONE)
-  if (nowLocal.getDay() !== 1 || nowLocal.getHours() !== 9) {
-    return NextResponse.json({ skipped: true, reason: 'Not Monday 09:00 London' })
+  if (nowLocal.getDay() !== 5 || nowLocal.getHours() !== 8) {
+    return NextResponse.json({ skipped: true, reason: 'Not Friday 08:00 London' })
   }
 
   const settings = await getChecklistSettings()
-  if (!settings.moduleEnabled) {
-    return NextResponse.json({ skipped: true, reason: 'Module disabled' })
+  if (!settings.moduleEnabled || !settings.emailsEnabled) {
+    return NextResponse.json({ skipped: true, reason: 'Checklist module or emails disabled' })
   }
 
   const db = createAdminClient()
@@ -38,13 +35,14 @@ export async function GET(request: Request) {
   const isoWeek = formatInTimeZone(nowUtc, TIMEZONE, "RRRR-'W'II")
 
   // Locked instances over the previous week (locked = the business day has closed).
-  const { data: instances } = await db
+  const { data: instances, error: instancesError } = await db
     .from('checklist_task_instances')
     .select('state, was_late, value_breach, value_recorded, value_unit, title_snapshot, business_date')
     .gte('business_date', from)
     .lt('business_date', today)
     .not('locked_at', 'is', null)
 
+  if (instancesError) return NextResponse.json({ error: 'Could not read checklist completion' }, { status: 500 })
   const rows = instances ?? []
   const done = rows.filter((r) => r.state === 'done').length
   const missed = rows.filter((r) => r.state === 'missed').length
@@ -53,19 +51,22 @@ export async function GET(request: Request) {
   const completionPct = denom > 0 ? Math.round((done / denom) * 100) : null
   const breaches = rows.filter((r) => r.value_breach)
 
-  const { data: expectations } = await db
+  const { data: expectations, error: expectationsError } = await db
     .from('checklist_spot_check_expectations')
     .select('expected')
     .gte('business_date', from)
     .lt('business_date', today)
+  if (expectationsError) return NextResponse.json({ error: 'Could not read checklist expectations' }, { status: 500 })
   const expected = (expectations ?? []).reduce((sum, e) => sum + (e.expected as number), 0)
 
-  const { count: recorded } = await db
+  const { count: recorded, error: recordedError } = await db
     .from('checklist_spot_checks')
     .select('id', { count: 'exact', head: true })
     .gte('business_date', from)
     .lt('business_date', today)
     .eq('state', 'recorded')
+
+  if (recordedError) return NextResponse.json({ error: 'Could not read spot checks' }, { status: 500 })
 
   const breachRows = breaches
     .map(
@@ -83,27 +84,22 @@ export async function GET(request: Request) {
   </div>`
 
   const to = process.env.CHECKLIST_MANAGER_EMAIL || 'manager@the-anchor.pub'
-  await db.from('checklist_email_outbox').upsert(
-    {
-      email_type: 'weekly_summary',
-      source_type: 'week',
-      source_id: isoWeek,
-      idempotency_key: `weekly_summary:${isoWeek}`,
-      to_addresses: [to],
-      subject: `The Anchor checklists, weekly summary (${isoWeek})`,
-      body_html: bodyHtml,
-      status: settings.emailsEnabled ? 'pending' : 'held',
-      next_attempt_at: nowUtc.toISOString(),
-    },
-    { onConflict: 'idempotency_key', ignoreDuplicates: true },
-  )
-
-  if (settings.emailsEnabled) {
-    await jobQueue.enqueue('checklist_email_outbox_process', {}, { unique: `checklist_outbox:weekly:${isoWeek}` })
+  const queued = await queueManagerReportEmail({
+    section: 'checklist_summary',
+    key: today,
+    to,
+    subject: `The Anchor checklists, week to ${today}`,
+    html: bodyHtml,
+    metadata: { snapshot_date: today, completion_percent: completionPct, done, missed, late,
+      breaches: breaches.length, spot_checks_recorded: recorded ?? 0, spot_checks_expected: expected },
+  })
+  if (!queued.success) {
+    return NextResponse.json({ error: queued.error || 'Could not queue checklist summary' }, { status: 500 })
   }
 
   return NextResponse.json({
     ok: true,
+    queued: true,
     isoWeek,
     completionPct,
     breaches: breaches.length,

--- a/src/app/api/cron/leave-approval-reminders/route.ts
+++ b/src/app/api/cron/leave-approval-reminders/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authorizeCronRequest } from '@/lib/cron-auth';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { sendEmail } from '@/lib/email/emailService';
+import { queueManagerReportEmail } from '@/lib/manager-report/queue';
 import { getRotaSettings } from '@/app/actions/rota-settings';
 import { getTodayIsoDate, formatDateInLondon } from '@/lib/dateUtils';
 import { displayName } from '@/lib/employees/display-name';
@@ -13,16 +13,8 @@ import {
 } from '@/lib/leave/pending-reminders';
 
 /**
- * Daily nudge about holiday requests nobody has approved.
- *
- * Eight were sitting unapproved when this was written, the oldest raised on 17 July for leave
- * that had already started. The employee gets a "request received" email and then silence.
- *
- * The ledger table is what makes this safe to run daily: one row per request per reminder kind,
- * behind a unique index, so the same request cannot be chased twice. The row is written BEFORE
- * the email is sent, because sending twice is worse than not sending at all. A manager who never
- * hears about a request will still see it in the queue; one who gets the same nag every morning
- * will filter the sender.
+ * Collect pending holiday reminders for the Friday report. Queue keys suppress duplicates
+ * while the delivery ledger records only reminders actually included in a sent report.
  */
 export async function GET(request: NextRequest) {
   const auth = authorizeCronRequest(request);
@@ -36,6 +28,7 @@ export async function GET(request: NextRequest) {
   const result = {
     considered: 0,
     sent: 0,
+    queued: 0,
     skippedAlreadySent: 0,
     truncated: false,
     errors: [] as string[],
@@ -89,22 +82,6 @@ export async function GET(request: NextRequest) {
       const leaveRequest = byId.get(reminder.requestId);
       if (!leaveRequest) continue;
 
-      // Claim it FIRST. If the insert loses the race with another run, the unique index rejects
-      // it and we skip, rather than sending a duplicate.
-      const { error: claimError } = await supabase
-        .from('leave_reminder_log')
-        .insert({
-          request_id: reminder.requestId,
-          reminder_kind: reminder.kind,
-          sent_to: [recipient],
-        });
-
-      if (claimError) {
-        if (claimError.code === '23505') continue; // Another run already has it.
-        result.errors.push(`Could not claim reminder for ${reminder.requestId}: ${claimError.message}`);
-        continue;
-      }
-
       const who = nameFor(leaveRequest.employee_id);
       const dates = leaveRequest.start_date === leaveRequest.end_date
         ? formatDateInLondon(leaveRequest.start_date)
@@ -118,17 +95,24 @@ export async function GET(request: NextRequest) {
         ? `${who} has holiday booked for ${dates}, starting in ${reminder.daysUntilStart} day${reminder.daysUntilStart === 1 ? '' : 's'}, and it still has not been approved.`
         : `${who} asked for holiday ${dates}. It has been waiting ${reminder.daysWaiting} days.`;
 
-      const emailResult = await sendEmail({
+      const emailResult = await queueManagerReportEmail({
+        section: 'holiday_reminders',
+        key: `${reminder.requestId}:${reminder.kind}`,
         to: recipient,
         subject,
         html: buildReminderHtml(lead, who, dates),
+        metadata: {
+          leave_request_id: reminder.requestId,
+          leave_reminder_kind: reminder.kind,
+          summary: lead,
+        },
       });
 
       if (!emailResult.success) {
-        result.errors.push(`Email failed for ${reminder.requestId}: ${emailResult.error ?? 'unknown'}`);
+        result.errors.push(`Queue failed for ${reminder.requestId}: ${emailResult.error ?? 'unknown'}`);
         continue;
       }
-      result.sent += 1;
+      result.queued += 1;
     }
 
     return NextResponse.json(result);

--- a/src/app/api/cron/manager-weekly-report/route.ts
+++ b/src/app/api/cron/manager-weekly-report/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { authorizeCronRequest } from '@/lib/cron-auth'
+import { deliverManagerReport } from '@/lib/manager-report/delivery'
+
+export const dynamic = 'force-dynamic'
+export const maxDuration = 300
+
+export async function GET(request: Request): Promise<NextResponse> {
+  if (!authorizeCronRequest(request).authorized) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  try {
+    const result = await deliverManagerReport()
+    if (!result.success) console.error('Manager weekly report failed', { error: result.error })
+    return NextResponse.json(result, { status: result.success ? 200 : 500 })
+  } catch (error) {
+    console.error('Manager weekly report failed', { error: error instanceof Error ? error.message : String(error) })
+    return NextResponse.json({ success: false, error: 'Manager report delivery failed' }, { status: 500 })
+  }
+}

--- a/src/app/api/cron/private-bookings-weekly-summary/route.ts
+++ b/src/app/api/cron/private-bookings-weekly-summary/route.ts
@@ -10,7 +10,7 @@ import {
 } from '@/lib/api/idempotency'
 import { logger } from '@/lib/logger'
 import {
-  sendManagerPrivateBookingsWeeklyDigestEmail,
+  queueManagerPrivateBookingsWeeklyDigestEmail,
   type PrivateBookingWeeklyDigestEvent,
   type PrivateBookingWeeklyDigestStaleOutcome
 } from '@/lib/private-bookings/manager-notifications'
@@ -26,7 +26,8 @@ import { AuditService } from '@/services/audit'
 export const maxDuration = 60
 
 const LONDON_TIMEZONE = 'Europe/London'
-const DEFAULT_DIGEST_HOUR = 9
+// Prepare the snapshot one hour before the combined Friday report.
+const SNAPSHOT_HOUR = 8
 
 type PendingSmsRow = {
   id: string
@@ -77,31 +78,16 @@ function normalizeCustomerName(input: {
   return joined || 'Guest'
 }
 
-function parseDigestHour(): number {
-  const raw = process.env.PRIVATE_BOOKINGS_WEEKLY_DIGEST_HOUR_LONDON
-  if (!raw) return DEFAULT_DIGEST_HOUR
-  const parsed = Number.parseInt(raw, 10)
-  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 23) {
-    return DEFAULT_DIGEST_HOUR
-  }
-  return parsed
+function getEndOfWeekDateKey(dateKey: string): string {
+  const date = new Date(`${dateKey}T12:00:00Z`)
+  date.setUTCDate(date.getUTCDate() + (7 - date.getUTCDay()) % 7)
+  return date.toISOString().slice(0, 10)
 }
 
-function getEndOfWeekDateKey(mondayDateKey: string): string {
-  const monday = new Date(`${mondayDateKey}T00:00:00Z`)
-  const sunday = new Date(monday.getTime() + 6 * 24 * 60 * 60 * 1000)
-  return sunday.toISOString().slice(0, 10)
-}
-
-function formatWeekLabel(mondayDateKey: string): string {
-  const monday = new Date(`${mondayDateKey}T12:00:00.000Z`)
-  return `w/c ${new Intl.DateTimeFormat('en-GB', {
-    timeZone: LONDON_TIMEZONE,
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric'
-  }).format(monday)}`
+function formatWeekLabel(dateKey: string): string {
+  return `snapshot ${new Intl.DateTimeFormat('en-GB', {
+    timeZone: LONDON_TIMEZONE, weekday: 'short', day: 'numeric', month: 'short', year: 'numeric'
+  }).format(new Date(`${dateKey}T12:00:00Z`))}`
 }
 
 export async function GET(request: Request) {
@@ -117,7 +103,7 @@ export async function GET(request: Request) {
 
     const url = new URL(request.url)
     const force = url.searchParams.get('force') === 'true'
-    const digestHour = parseDigestHour()
+    const digestHour = SNAPSHOT_HOUR
     const now = new Date()
     const { dateKey: londonDateKey, hour: londonHour, dayOfWeek } = getLondonDateParts(now)
 
@@ -132,11 +118,11 @@ export async function GET(request: Request) {
       })
     }
 
-    if (!force && dayOfWeek !== 'Monday') {
+    if (!force && dayOfWeek !== 'Friday') {
       return NextResponse.json({
         success: true,
         skipped: true,
-        reason: 'not_monday',
+        reason: 'not_friday',
         londonDate: londonDateKey,
         dayOfWeek
       })
@@ -263,7 +249,7 @@ export async function GET(request: Request) {
       })
     }
 
-    const emailResult = await sendManagerPrivateBookingsWeeklyDigestEmail({
+    const emailResult = await queueManagerPrivateBookingsWeeklyDigestEmail({
       runDateKey: londonDateKey,
       weekLabel: formatWeekLabel(londonDateKey),
       appBaseUrl,
@@ -273,10 +259,10 @@ export async function GET(request: Request) {
       stalePendingOutcomes
     })
 
-    if (!emailResult.sent) {
+    if (!emailResult.queued) {
       await releaseIdempotencyClaim(supabase, claimKey, claimHash)
       claimHeld = false
-      logger.error('Failed to send private bookings weekly digest email', {
+      logger.error('Failed to queue private bookings weekly summary', {
         error: new Error(emailResult.error || 'unknown'),
         metadata: {
           runDate: londonDateKey,
@@ -284,7 +270,7 @@ export async function GET(request: Request) {
           actionCount: emailResult.actionCount ?? 0
         }
       })
-      return new NextResponse('Failed to send email', { status: 500 })
+      return new NextResponse('Failed to queue summary', { status: 500 })
     }
 
     // Audit log — failure should not break the cron
@@ -306,7 +292,8 @@ export async function GET(request: Request) {
 
     const responsePayload = {
       success: true,
-      sent: true,
+      sent: false,
+      queued: true,
       londonDate: londonDateKey,
       events: digestEvents.length,
       actions: emailResult.actionCount ?? 0

--- a/src/app/api/cron/rota-manager-alert/route.ts
+++ b/src/app/api/cron/rota-manager-alert/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { toZonedTime, format, formatInTimeZone } from 'date-fns-tz';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { sendEmail } from '@/lib/email/emailService';
+import { queueManagerReportEmail } from '@/lib/manager-report/queue';
 import { authorizeCronRequest } from '@/lib/cron-auth';
 import { displayName } from '@/lib/employees/display-name';
 import {
@@ -20,7 +20,7 @@ import {
 import type { PublishedShiftSnapshot, RotaPublishShift } from '@/lib/rota/publish-status';
 import { formatDateInLondon, formatTime12Hour } from '@/lib/dateUtils';
 
-// Vercel Cron: runs at 18:00 Europe/London every Sunday
+// Prepare a fresh snapshot at 08:00 London on Friday, before the combined manager report.
 const TIMEZONE = 'Europe/London';
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? '';
@@ -427,8 +427,8 @@ export async function GET(request: Request): Promise<NextResponse> {
   const nowUtc = new Date();
   const nowLocal = toZonedTime(nowUtc, TIMEZONE);
 
-  if (nowLocal.getDay() !== 0) {
-    return NextResponse.json({ skipped: true, reason: 'Not Sunday' });
+  if (nowLocal.getDay() !== 5 || nowLocal.getHours() !== 8) {
+    return NextResponse.json({ skipped: true, reason: 'Not Friday 08:00 London' });
   }
 
   const firstWeekStart = getNextMondayIso(nowUtc);
@@ -447,15 +447,6 @@ export async function GET(request: Request): Promise<NextResponse> {
   );
   const unfilledShifts = unfilledResult.shifts;
   const pendingLeave = leaveResult.leave;
-
-  const hasSomethingToSay =
-    weeksNeedingAttention.length > 0 || unfilledShifts.length > 0 || pendingLeave.length > 0;
-
-  // A failed query is itself worth an email. Treating one as "nothing to report" is
-  // exactly how a database fault used to suppress the alert without a trace.
-  if (!hasSomethingToSay && failures.length === 0) {
-    return NextResponse.json({ ok: true, action: 'no_alert_needed', firstWeekStart });
-  }
 
   const managerEmailResult = await resolveRotaManagerEmail(supabase);
   if ('error' in managerEmailResult) {
@@ -489,30 +480,22 @@ export async function GET(request: Request): Promise<NextResponse> {
   if (failures.length > 0) {
     subjectParts.push('some checks failed');
   }
-  const subject = `Rota Alert: ${subjectParts.join(', ')}`;
+  const subject = `Rota summary: ${subjectParts.join(', ') || 'no outstanding issues found'}`;
 
-  const emailResult = await sendEmail({
+  const emailResult = await queueManagerReportEmail({
+    section: 'rota',
+    key: todayIso,
+    metadata: { snapshot_date: todayIso, weeks_needing_attention: weeksNeedingAttention.length,
+      unfilled_shifts: unfilledShifts.length, pending_leave: pendingLeave.length, failed_checks: failures.length },
     to: managerEmail,
     subject,
     html: buildRotaAlertEmailHtml({ weeksNeedingAttention, unfilledShifts, pendingLeave, failures }),
   });
 
-  await supabase.from('rota_email_log').insert({
-    email_type: 'manager_alert',
-    entity_type: 'rota_week',
-    entity_id: weeksNeedingAttention.length
-      ? (readinessResult.weekIdByStart.get(weeksNeedingAttention[0].weekStart) ?? null)
-      : null,
-    to_addresses: [managerEmail],
-    subject,
-    status: emailResult.success ? 'sent' : 'failed',
-    error_message: emailResult.success ? null : (emailResult.error ?? null),
-  });
-
   return NextResponse.json(
     {
       ok: failures.length === 0 && emailResult.success,
-      action: 'alert_sent',
+      action: emailResult.success ? 'summary_queued' : 'queue_failed',
       firstWeekStart,
       horizonWeeks: HORIZON_WEEKS,
       weeksNeedingAttention: weeksNeedingAttention.map(readiness => ({
@@ -524,7 +507,8 @@ export async function GET(request: Request): Promise<NextResponse> {
       unfilledShifts: unfilledShifts.length,
       rejectedUnfilled: unfilledShifts.filter(shift => shift.rejectedByName).length,
       pendingLeave: pendingLeave.length,
-      emailSent: emailResult.success,
+      emailSent: false,
+      queued: emailResult.success,
       failures,
       localTime: format(nowLocal, 'HH:mm zzz', { timeZone: TIMEZONE }),
     },

--- a/src/app/api/cron/rota-shift-acceptance/route.ts
+++ b/src/app/api/cron/rota-shift-acceptance/route.ts
@@ -1,13 +1,17 @@
+import { createHash } from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { authorizeCronRequest } from '@/lib/cron-auth';
 import { sendEmail } from '@/lib/email/emailService';
+import { queueManagerReportEmail } from '@/lib/manager-report/queue';
+import type { ManagerReportInput } from '@/lib/manager-report/types';
 import {
   buildShiftAutoAcceptWarningEmailHtml,
   type PortalShiftEmailSummary,
 } from '@/lib/rota/email-templates';
 import { recordShiftReliabilityEvent } from '@/services/employee-reliability';
 import { displayName } from '@/lib/employees/display-name';
+import { formatDateInLondon } from '@/lib/dateUtils';
 import {
   SHIFT_ACCEPTANCE_CUTOFF_DAYS,
   isInsideAcceptanceCutoff,
@@ -99,6 +103,90 @@ async function logWarningEmail(
   });
 }
 
+const MANAGER_RETRY_PREFIX = 'manager-report-retry:';
+
+function managerRetryId(input: ManagerReportInput): string {
+  const hash = createHash('sha256').update(`rota-manager-retry:${input.key}:${input.to}`).digest('hex');
+  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${hash.slice(16, 20)}-${hash.slice(20, 32)}`;
+}
+
+async function collectManagerWarnings(
+  supabase: ReturnType<typeof createAdminClient>,
+  warnings: Array<{ input: ManagerReportInput; shiftId: string }>,
+): Promise<{ queued: number; failed: number; retryStorageErrors: number }> {
+  const result = { queued: 0, failed: 0, retryStorageErrors: 0 };
+  const attempted = new Set<string>();
+  // Failed collections survive staff delivery and later shift acceptance or deletion.
+  let retryRows: Array<{ id: string; entity_id: string; to_addresses: string[]; error_message: string }> = [];
+  try {
+    const { data, error } = await supabase.from('rota_email_log')
+      .select('id, entity_id, to_addresses, error_message')
+      .eq('email_type', 'shift_auto_accept_warning')
+      .eq('status', 'failed')
+      .like('error_message', `${MANAGER_RETRY_PREFIX}%`)
+      .order('created_at')
+      .limit(100);
+    if (error) result.retryStorageErrors += 1;
+    else retryRows = data ?? [];
+  } catch {
+    result.retryStorageErrors += 1;
+  }
+
+  const pending = [...warnings];
+  for (const row of retryRows ?? []) {
+    try {
+      const envelope = JSON.parse(row.error_message.slice(MANAGER_RETRY_PREFIX.length)) as { input: ManagerReportInput };
+      if (envelope.input.section !== 'staff_shift_reminders' || typeof envelope.input.key !== 'string'
+        || typeof envelope.input.subject !== 'string' || typeof envelope.input.html !== 'string'
+        || !row.to_addresses?.[0]) throw new Error('Invalid manager warning retry');
+      pending.push({ input: { ...envelope.input, to: row.to_addresses[0] }, shiftId: row.entity_id });
+    } catch {
+      result.retryStorageErrors += 1;
+    }
+  }
+
+  for (const { input, shiftId } of pending) {
+    const id = managerRetryId(input);
+    if (attempted.has(id)) continue;
+    attempted.add(id);
+    let queueResult: { success: boolean; error?: string };
+    try {
+      queueResult = await queueManagerReportEmail(input);
+    } catch (error) {
+      queueResult = { success: false, error: error instanceof Error ? error.message : 'Manager report collection failed' };
+    }
+    try {
+      if (queueResult.success) {
+        result.queued += 1;
+        const { error } = await supabase.from('rota_email_log')
+          .update({ error_message: 'Manager report collection recovered; entry queued for Friday delivery.' })
+          .eq('id', id)
+          .eq('status', 'failed')
+          .like('error_message', `${MANAGER_RETRY_PREFIX}%`);
+        if (error) result.retryStorageErrors += 1;
+      } else {
+        result.failed += 1;
+        const { error } = await supabase.from('rota_email_log').upsert({
+          id,
+          email_type: 'shift_auto_accept_warning',
+          entity_type: 'rota_shift',
+          entity_id: shiftId,
+          to_addresses: [input.to],
+          cc_addresses: [],
+          subject: input.subject,
+          status: 'failed',
+          error_message: `${MANAGER_RETRY_PREFIX}${JSON.stringify({ error: queueResult.error, input })}`,
+          message_id: null,
+        }, { onConflict: 'id', ignoreDuplicates: true });
+        if (error) result.retryStorageErrors += 1;
+      }
+    } catch {
+      result.retryStorageErrors += 1;
+    }
+  }
+  return result;
+}
+
 export async function GET(request: Request): Promise<NextResponse> {
   const authResult = authorizeCronRequest(request);
   if (!authResult.authorized) {
@@ -114,7 +202,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   // environment. A missing one must not stop staff being warned, so it downgrades
   // to sending without a copy to the manager and is reported in the response.
   const managerEmailResult = await resolveRotaManagerEmail(supabase);
-  const managerCc = 'email' in managerEmailResult ? [managerEmailResult.email] : [];
+  const managerEmail = 'email' in managerEmailResult ? managerEmailResult.email : null;
   const managerEmailError = 'error' in managerEmailResult ? managerEmailResult.error : null;
 
   const { data: shifts, error: shiftsError } = await supabase
@@ -173,6 +261,7 @@ export async function GET(request: Request): Promise<NextResponse> {
   }
 
   let warningSent = 0;
+  const managerWarnings: Array<{ input: ManagerReportInput; shiftId: string }> = [];
   let warningFailed = 0;
   let warningSkipped = 0;
 
@@ -184,20 +273,39 @@ export async function GET(request: Request): Promise<NextResponse> {
     }
 
     const subject = 'Please accept or reject your upcoming shifts';
+    const html = buildShiftAutoAcceptWarningEmailHtml(
+      employeeName(employee),
+      employeeShifts.map(toEmailSummary),
+    );
+    if (managerEmail) {
+      for (const shift of employeeShifts) {
+        managerWarnings.push({ shiftId: shift.id, input: {
+          section: 'staff_shift_reminders',
+          key: `${employeeId}:${shift.id}`,
+          to: managerEmail,
+          subject: `Shift acceptance reminder: ${employeeName(employee)}`,
+          html: buildShiftAutoAcceptWarningEmailHtml(employeeName(employee), [toEmailSummary(shift)]),
+          metadata: {
+            employee_id: employeeId,
+            shift_ids: [shift.id],
+            source_recorded_at: now.toISOString(),
+            summary: `${employeeName(employee)}: reminder generated ${formatDateInLondon(now)} for ${formatDateInLondon(shift.shift_date)}, ${shift.start_time}`,
+          },
+        } });
+      }
+      // A shared manager mailbox receives this cohort through the report only.
+      if (employee.email_address.trim().toLowerCase() === managerEmail.trim().toLowerCase()) continue;
+    }
     const emailResult = await sendEmail({
       to: employee.email_address,
-      ...(managerCc.length > 0 ? { cc: managerCc } : {}),
       subject,
-      html: buildShiftAutoAcceptWarningEmailHtml(
-        employeeName(employee),
-        employeeShifts.map(toEmailSummary),
-      ),
+      html,
     });
 
     await logWarningEmail(supabase, {
       shiftId: employeeShifts[0]!.id,
       to: employee.email_address,
-      cc: managerCc,
+      cc: [],
       subject,
       status: emailResult.success ? 'sent' : 'failed',
       error: emailResult.success ? null : emailResult.error ?? null,
@@ -221,6 +329,16 @@ export async function GET(request: Request): Promise<NextResponse> {
     } else {
       warningFailed += 1;
     }
+  }
+
+  // Run manager collection after immediate staff sends. Collection or storage failure
+  // cannot suppress a staff warning, and previous failures retry outside the pending-shift scan.
+  let managerCollection = { queued: 0, failed: 0, retryStorageErrors: 0 };
+  try {
+    managerCollection = await collectManagerWarnings(supabase, managerWarnings);
+  } catch (error) {
+    managerCollection.retryStorageErrors += 1;
+    console.error('[rota] Manager warning collection failed:', error instanceof Error ? error.message : 'Unknown error');
   }
 
   const acceptedAt = now.toISOString();
@@ -339,9 +457,12 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   return NextResponse.json(
     {
-      ok: autoAcceptDesynced === 0,
+      ok: autoAcceptDesynced === 0 && managerCollection.retryStorageErrors === 0,
       pendingChecked: pendingShifts.length,
       warningEmailsSent: warningSent,
+      managerCopiesQueued: managerCollection.queued,
+      managerCopiesFailed: managerCollection.failed,
+      managerRetryStorageErrors: managerCollection.retryStorageErrors,
       warningEmailsFailed: warningFailed,
       warningShiftsSkippedNoEmail: warningSkipped,
       autoAccepted,
@@ -352,8 +473,8 @@ export async function GET(request: Request): Promise<NextResponse> {
       managerEmailError,
       employeeLookupError: employeesError?.message ?? null,
     },
-    // Drift between the snapshot and the live rota cannot be repaired by running
-    // again, so it has to fail loudly rather than sit in a 200 nobody reads.
-    { status: autoAcceptDesynced > 0 ? 500 : 200 },
+    // Drift or an unavailable retry ledger needs a visible operational failure. Staff
+    // deliveries have already completed and their warning timestamps prevent resends.
+    { status: autoAcceptDesynced > 0 || managerCollection.retryStorageErrors > 0 ? 500 : 200 },
   );
 }

--- a/src/lib/checklists/__tests__/outbox.test.ts
+++ b/src/lib/checklists/__tests__/outbox.test.ts
@@ -128,17 +128,23 @@ describe('runOutboxProcess', () => {
     vi.useRealTimers()
   })
 
-  it('sends a pending row once when two outbox jobs process it concurrently', async () => {
+  it.each([
+    ['value_breach', 'instance', 'checklist_alerts'],
+    ['weekly_summary', 'week', 'checklist_summary'],
+    ['system_alert', 'closing_night', 'checklist_alerts'],
+    ['system_alert', 'season', 'checklist_alerts'],
+    ['system_alert', 'generation_run', null],
+  ])('processes %s from %s once across concurrent workers', async (emailType, sourceType, section) => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-26T10:58:35.000Z'))
 
     const db = new FakeOutboxDb({
       id: 'outbox-1',
-      email_type: 'value_breach',
-      source_type: 'instance',
+      email_type: emailType,
+      source_type: sourceType,
       source_id: 'instance-1',
       idempotency_key: 'value_breach:instance-1',
-      to_addresses: ['manager@example.com'],
+      to_addresses: [section ? 'manager@example.com' : 'peter@example.com'],
       subject: 'Checklist alert: Cellar Cooler is above the limit (15 degC)',
       body_html: '<p>Alert</p>',
       status: 'pending',
@@ -147,18 +153,49 @@ describe('runOutboxProcess', () => {
       created_at: '2026-07-26T10:58:03.000Z',
     })
     const send = vi.fn().mockResolvedValue({ success: true, messageId: 'message-1' })
+    const queue = vi.fn().mockResolvedValue({ success: true, queued: true, emailMessageId: 'queue-1' })
 
     const results = await Promise.all([
-      runOutboxProcess({ db: db as never, send }),
-      runOutboxProcess({ db: db as never, send }),
+      runOutboxProcess({ db: db as never, send, queue }),
+      runOutboxProcess({ db: db as never, send, queue }),
     ])
 
-    expect(send).toHaveBeenCalledTimes(1)
-    expect(send).toHaveBeenCalledWith(expect.objectContaining({
-      idempotencyKey: 'checklist:outbox-1',
-      commType: 'checklist_alert',
-    }))
-    expect(db.rows[0]).toMatchObject({ status: 'sent', message_id: 'message-1' })
-    expect(results.map((result) => result.sent).sort()).toEqual([0, 1])
+    if (section) {
+      expect(send).not.toHaveBeenCalled()
+      expect(queue).toHaveBeenCalledTimes(1)
+      expect(queue).toHaveBeenCalledWith(expect.objectContaining({
+        section, key: 'outbox-1', to: 'manager@example.com',
+        metadata: expect.objectContaining({ checklist_outbox_id: 'outbox-1' }),
+      }))
+      expect(db.rows[0]).toMatchObject({ status: 'held', sent_at: null, message_id: null })
+      expect(results.map((result) => result.queued).sort()).toEqual([0, 1])
+      expect(results.map((result) => result.sent)).toEqual([0, 0])
+    } else {
+      expect(queue).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledTimes(1)
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({
+        to: 'peter@example.com', idempotencyKey: 'checklist:outbox-1', commType: 'checklist_alert',
+      }))
+      expect(db.rows[0]).toMatchObject({ status: 'sent', message_id: 'message-1' })
+      expect(results.map((result) => result.sent).sort()).toEqual([0, 1])
+    }
   })
+  it('keeps a failed manager queue entry pending for retry without sending directly', async () => {
+    const db = new FakeOutboxDb({
+      id: 'outbox-1', email_type: 'value_breach', source_type: 'instance',
+      subject: 'Temperature alert', to_addresses: ['manager@example.com'],
+      status: 'pending', next_attempt_at: null, attempts: 0,
+    })
+    const send = vi.fn()
+    const queue = vi.fn().mockResolvedValue({ success: false, error: 'queue unavailable' })
+    const results = await Promise.all([
+      runOutboxProcess({ db: db as never, send, queue }),
+      runOutboxProcess({ db: db as never, send, queue }),
+    ])
+    expect(send).not.toHaveBeenCalled()
+    expect(db.rows[0]).toMatchObject({ status: 'pending', attempts: 1, error_message: 'queue unavailable' })
+    expect(db.rows[0].sent_at).toBeUndefined()
+    expect(results.map(result => result.retried).sort()).toEqual([0, 1])
+  })
+
 })

--- a/src/lib/checklists/jobs/outbox.ts
+++ b/src/lib/checklists/jobs/outbox.ts
@@ -1,12 +1,13 @@
 // src/lib/checklists/jobs/outbox.ts
 // The checklist_email_outbox_process job (spec 3.7 / 10). Claims up to 20 pending outbox rows
-// whose next_attempt_at has passed and delivers them via sendEmail. Success marks the row
-// sent; failure increments attempts with exponential backoff, and on the 5th failure the row
+// whose next_attempt_at has passed. Manager notifications are queued and held for the Friday
+// report; technical alerts are delivered immediately. Failure uses backoff, and on the 5th failure the row
 // is marked failed and one system_alert to Peter is created (guarded by a distinct key so it
 // is written once). Service-role admin client (checklist_* is deny-all under RLS).
 
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendEmail } from '@/lib/email/emailService'
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 
 const MAX_ATTEMPTS = 5
 const BATCH_SIZE = 20
@@ -15,6 +16,7 @@ const CLAIM_LEASE_MS = 10 * 60 * 1000
 type OutboxDependencies = {
   db?: ReturnType<typeof createAdminClient>
   send?: typeof sendEmail
+  queue?: typeof queueManagerReportEmail
 }
 
 function systemEmail(): string {
@@ -24,6 +26,7 @@ function systemEmail(): string {
 export async function runOutboxProcess(dependencies: OutboxDependencies = {}): Promise<Record<string, unknown>> {
   const db = dependencies.db ?? createAdminClient()
   const send = dependencies.send ?? sendEmail
+  const queue = dependencies.queue ?? queueManagerReportEmail
   const nowIso = new Date().toISOString()
 
   const { data: rows, error } = await db
@@ -36,6 +39,7 @@ export async function runOutboxProcess(dependencies: OutboxDependencies = {}): P
   if (error) throw error
 
   let sent = 0
+  let queued = 0
   let retried = 0
   let failed = 0
   let claimed = 0
@@ -59,12 +63,26 @@ export async function runOutboxProcess(dependencies: OutboxDependencies = {}): P
     claimed += 1
 
     const toAddresses = (claimedRow.to_addresses as string[] | null) ?? []
-    let result: { success: boolean; error?: string; messageId?: string }
+    const deferToReport = claimedRow.email_type === 'value_breach'
+      || claimedRow.email_type === 'weekly_summary'
+      || ['closing_night', 'season'].includes(claimedRow.source_type as string)
+    let result: { success: boolean; error?: string; messageId?: string; emailMessageId?: string | null }
     try {
       const bodyHtml =
         (claimedRow.body_html as string | null) ??
         `<div style="font-family:sans-serif;max-width:600px;margin:0 auto">${claimedRow.subject}</div>`
-      result = await send({
+      result = deferToReport ? await queue({
+        section: claimedRow.email_type === 'weekly_summary' ? 'checklist_summary' : 'checklist_alerts',
+        key: claimedRow.id as string,
+        to: toAddresses.join(', '),
+        subject: claimedRow.subject as string,
+        html: bodyHtml,
+        metadata: {
+          checklist_outbox_id: claimedRow.id as string,
+          checklist_idempotency_key: claimedRow.idempotency_key as string,
+          summary: claimedRow.subject as string,
+        },
+      }) : await send({
         to: toAddresses.join(', '),
         subject: claimedRow.subject as string,
         html: bodyHtml,
@@ -84,15 +102,18 @@ export async function runOutboxProcess(dependencies: OutboxDependencies = {}): P
     if (result.success) {
       const { data: sentRow, error: updErr } = await db
         .from('checklist_email_outbox')
-        .update({ status: 'sent', sent_at: new Date().toISOString(), message_id: result.messageId ?? null })
+        .update(deferToReport
+          ? { status: 'held', sent_at: null, message_id: null, next_attempt_at: null }
+          : { status: 'sent', sent_at: new Date().toISOString(), message_id: result.messageId ?? null })
         .eq('id', claimedRow.id as string)
         .eq('status', 'pending')
         .eq('next_attempt_at', claimUntil)
         .select('id')
         .maybeSingle()
       if (updErr) throw updErr
-      if (!sentRow) throw new Error(`Checklist outbox claim lost after sending ${claimedRow.id as string}`)
-      sent += 1
+      if (!sentRow) throw new Error(`Checklist outbox claim lost after processing ${claimedRow.id as string}`)
+      if (deferToReport) queued += 1
+      else sent += 1
       continue
     }
 
@@ -149,5 +170,5 @@ export async function runOutboxProcess(dependencies: OutboxDependencies = {}): P
     retried += 1
   }
 
-  return { candidates: (rows ?? []).length, processed: claimed, sent, retried, failed }
+  return { candidates: (rows ?? []).length, processed: claimed, sent, queued, retried, failed }
 }

--- a/src/lib/manager-report/delivery.ts
+++ b/src/lib/manager-report/delivery.ts
@@ -1,0 +1,238 @@
+import { randomUUID } from 'crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { isValidEmailAddress } from '@/lib/notifications/channel'
+import { sendEmail, type EmailOptions } from '@/lib/email/emailService'
+import { managerReportId } from './queue'
+import { managerReportPeriod } from './schedule'
+import { renderManagerReport } from './render'
+import { MANAGER_REPORT_SECTIONS, type ManagerReportEntry, type ManagerReportSection } from './types'
+
+type Db = ReturnType<typeof createAdminClient>
+interface SourceReference {
+  id: string; checklistOutboxId?: string; communicationId?: string
+  leaveRequestId?: string; leaveReminderKind?: string
+}
+interface ReportMetadata {
+  periodKey: string
+  sources: SourceReference[]
+  payload: EmailOptions
+  firstAttemptAt?: string
+  acceptedAt?: string
+  providerMessageId?: string
+}
+interface EmailRow {
+  id: string; to_address: string; subject: string | null; body_html: string | null
+  body_text: string | null; created_at: string; metadata: Record<string, unknown>
+}
+export interface ManagerReportDeliveryResult {
+  success: boolean; sent: number; skipped?: string; error?: string
+}
+export interface ManagerReportDeliveryDependencies {
+  db: Db
+  send: typeof sendEmail
+  now: () => Date
+}
+const PAGE_SIZE = 500
+const LEASE_MS = 10 * 60 * 1000
+// Leave an hour of headroom before Resend forgets an idempotency key.
+const RETRY_WINDOW_MS = 23 * 60 * 60 * 1000
+
+async function listQueued(db: Db, commType: string, before?: string): Promise<EmailRow[]> {
+  const rows: EmailRow[] = []
+  let cursor: string | undefined
+  for (;;) {
+    let query = db.from('email_messages')
+      .select('id,to_address,subject,body_html,body_text,created_at,metadata')
+      .eq('comm_type', commType).eq('status', 'queued').order('id').limit(PAGE_SIZE)
+    if (before) query = query.lte('created_at', before)
+    if (cursor) query = query.gt('id', cursor)
+    const { data, error } = await query
+    if (error) throw new Error(error.message)
+    const page = (data ?? []) as EmailRow[]
+    rows.push(...page)
+    if (page.length < PAGE_SIZE) return rows
+    cursor = page[page.length - 1].id
+  }
+}
+
+function toEntry(row: EmailRow): ManagerReportEntry {
+  const section = row.metadata.section as ManagerReportSection
+  if (!MANAGER_REPORT_SECTIONS.includes(section) || typeof row.metadata.key !== 'string') {
+    throw new Error(`Invalid manager report item ${row.id}`)
+  }
+  return {
+    id: row.id, section, key: row.metadata.key, to: row.to_address,
+    subject: row.subject ?? '', html: row.body_html ?? undefined, text: row.body_text ?? undefined,
+    createdAt: row.created_at, metadata: row.metadata,
+  }
+}
+
+async function saveReport(db: Db, id: string, metadata: ReportMetadata, status = 'queued'): Promise<void> {
+  const { data, error } = await db.from('email_messages').update({
+    metadata, status, ...(metadata.acceptedAt ? { sent_at: metadata.acceptedAt } : {}),
+  }).eq('id', id).select('id').single()
+  if (error || !data) throw new Error(error?.message ?? 'Report state was not saved')
+}
+
+async function finaliseSources(db: Db, metadata: ReportMetadata): Promise<void> {
+  for (const source of metadata.sources) {
+    if (source.leaveRequestId && source.leaveReminderKind) {
+      const { error } = await db.from('leave_reminder_log').upsert({
+        request_id: source.leaveRequestId, reminder_kind: source.leaveReminderKind,
+        sent_at: metadata.acceptedAt, sent_to: [metadata.payload.to],
+      }, { onConflict: 'request_id,reminder_kind' })
+      if (error) throw new Error(error.message)
+    }
+  }
+  // Finalise shared report outcomes in batches so a busy week fits the cron budget.
+  const communicationIds = [...new Set(metadata.sources.flatMap(source => source.communicationId ? [source.communicationId] : []))]
+  const checklistIds = [...new Set(metadata.sources.flatMap(source => source.checklistOutboxId ? [source.checklistOutboxId] : []))]
+  for (const [table, ids, values] of [
+    ['recruitment_communications', communicationIds, {
+      delivery_status: 'sent', sent_at: metadata.acceptedAt, provider: 'resend', provider_message_id: metadata.providerMessageId,
+    }],
+    ['checklist_email_outbox', checklistIds, {
+      status: 'sent', sent_at: metadata.acceptedAt, message_id: metadata.providerMessageId, error_message: null,
+    }],
+  ] as const) {
+    for (let offset = 0; offset < ids.length; offset += PAGE_SIZE) {
+      const batch = ids.slice(offset, offset + PAGE_SIZE)
+      const { data, error } = await db.from(table).update(values).in('id', batch).select('id')
+      if (error || data?.length !== batch.length) throw new Error(error?.message ?? `${table} rows were not finalised`)
+    }
+  }
+  for (let offset = 0; offset < metadata.sources.length; offset += PAGE_SIZE) {
+    const ids = metadata.sources.slice(offset, offset + PAGE_SIZE).map(source => source.id)
+    const { data, error } = await db.from('email_messages')
+      .update({ status: 'sent', sent_at: metadata.acceptedAt }).in('id', ids).select('id')
+    if (error || data?.length !== ids.length) throw new Error(error?.message ?? 'Report items were not finalised')
+  }
+}
+
+/** No report payload is rebuilt after freezing, including attachments, sender and reply-to. */
+export async function deliverManagerReport(
+  dependencies?: ManagerReportDeliveryDependencies,
+): Promise<ManagerReportDeliveryResult> {
+  const now = dependencies?.now ?? (() => new Date())
+  const period = managerReportPeriod(now())
+  if (!period) return { success: true, sent: 0, skipped: 'outside_friday_window' }
+  const db = dependencies?.db ?? createAdminClient()
+  const send = dependencies?.send ?? sendEmail
+  const owner = randomUUID()
+  let lockId: string | undefined
+  let sent = 0
+  let completed = false
+  let failureMessage: string | null = null
+  try {
+    // A single global lease also serialises recovery of previous weeks against a new batch.
+    const stamp = now().toISOString()
+    const { data: inserted, error: insertError } = await db.from('cron_job_runs').insert({
+      job_name: 'manager-weekly-report', run_key: 'delivery', status: 'running', started_at: stamp, error_message: owner,
+    }).select('id').single()
+    if (insertError && insertError.code !== '23505') throw new Error(insertError.message)
+    if (inserted) lockId = inserted.id
+    else {
+      const { data: lock, error } = await db.from('cron_job_runs').select('id,status,started_at')
+        .eq('job_name', 'manager-weekly-report').eq('run_key', 'delivery').single()
+      if (error || !lock) throw new Error(error?.message ?? 'Report lease missing')
+      if (lock.status === 'running' && now().getTime() - Date.parse(lock.started_at) < LEASE_MS) {
+        return { success: true, sent, skipped: 'already_running' }
+      }
+      const { data: claimed, error: claimError } = await db.from('cron_job_runs')
+        .update({ status: 'running', started_at: stamp, error_message: owner, finished_at: null })
+        .eq('id', lock.id).eq('status', lock.status).eq('started_at', lock.started_at).select('id').maybeSingle()
+      if (claimError) throw new Error(claimError.message)
+      if (!claimed) return { success: true, sent, skipped: 'already_running' }
+      lockId = claimed.id
+    }
+    const renew = async (): Promise<void> => {
+      const { data, error } = await db.from('cron_job_runs').update({ started_at: now().toISOString() })
+        .eq('id', lockId!).eq('error_message', owner).eq('status', 'running').select('id').single()
+      if (error || !data) throw new Error(error?.message ?? 'Report lease lost')
+    }
+    const deliver = async (row: EmailRow): Promise<void> => {
+      const metadata = row.metadata as unknown as ReportMetadata
+      if (!metadata.payload || !Array.isArray(metadata.sources)) throw new Error(`Invalid frozen report ${row.id}`)
+      if (!metadata.acceptedAt) {
+        if (metadata.firstAttemptAt && now().getTime() - Date.parse(metadata.firstAttemptAt) >= RETRY_WINDOW_MS) {
+          throw new Error(`Report ${row.id} needs provider reconciliation before retry: the idempotency window has expired`)
+        }
+        await renew()
+        metadata.firstAttemptAt ??= now().toISOString()
+        await saveReport(db, row.id, metadata)
+        const result = await send(metadata.payload)
+        // A provider id is acceptance even when emailService could not write its own log.
+        if (!result.messageId) throw new Error(result.error ?? 'Email provider did not confirm report acceptance')
+        metadata.acceptedAt = now().toISOString()
+        metadata.providerMessageId = result.messageId
+        await saveReport(db, row.id, metadata)
+        sent += 1
+      }
+      await renew()
+      await finaliseSources(db, metadata)
+      await saveReport(db, row.id, metadata, 'sent')
+    }
+    // Finish frozen reports first. An ambiguous earlier send blocks a new week's report.
+    for (const pending of await listQueued(db, 'manager_weekly_report')) await deliver(pending)
+    const entries = (await listQueued(db, 'manager_report_item', period.periodEnd)).map(toEntry)
+    const manager = (process.env.MANAGER_EMAIL || 'manager@the-anchor.pub').trim().toLowerCase()
+    if (!isValidEmailAddress(manager) || /[,;<>]/.test(manager)) throw new Error('Manager report recipient is invalid')
+    const recipients = new Map<string, ManagerReportEntry[]>([[manager, []]])
+    for (const entry of entries) recipients.set(entry.to, [...(recipients.get(entry.to) ?? []), entry])
+    for (const [to, items] of recipients) {
+      await renew()
+      const id = managerReportId(['manager_weekly_report', period.key, to])
+      const { data: existing, error: existingError } = await db.from('email_messages').select('id').eq('id', id).maybeSingle()
+      if (existingError) throw new Error(existingError.message)
+      // Late arrivals after the immutable report was frozen stay queued for next Friday.
+      if (existing) continue
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL
+      const from = process.env.EMAIL_FROM_ADDRESS
+      if (!appUrl || !from) throw new Error('Manager report app URL and email sender must be configured')
+      const rendered = renderManagerReport({ entries: items, ...period, appUrl })
+      const metadata: ReportMetadata = {
+        periodKey: period.key,
+        sources: items.map(item => ({
+          id: item.id,
+          checklistOutboxId: typeof item.metadata?.checklist_outbox_id === 'string' ? item.metadata.checklist_outbox_id : undefined,
+          communicationId: typeof item.metadata?.communication_id === 'string' ? item.metadata.communication_id : undefined,
+          leaveRequestId: typeof item.metadata?.leave_request_id === 'string' ? item.metadata.leave_request_id : undefined,
+          leaveReminderKind: typeof item.metadata?.leave_reminder_kind === 'string' ? item.metadata.leave_reminder_kind : undefined,
+        })),
+        payload: {
+          to, from, replyTo: process.env.EMAIL_REPLY_TO ?? '',
+          subject: rendered.subject, html: rendered.html, text: rendered.text,
+          provider: 'resend', commType: 'manager_weekly_report_delivery',
+          idempotencyKey: `manager-weekly-report/${id}`, suppressionMode: 'fail_closed',
+          metadata: { manager_report_id: id },
+          ...(rendered.attachment ? { attachments: [{ name: rendered.attachment.filename,
+            contentType: rendered.attachment.contentType,
+            content: Buffer.from(rendered.attachment.content, 'utf8').toString('base64'),
+          }] } : {}),
+        },
+      }
+      const { data, error } = await db.from('email_messages').insert({
+        id, to_address: to, from_address: from, comm_type: 'manager_weekly_report', status: 'queued',
+        subject: rendered.subject, body_html: rendered.html, body_text: rendered.text, metadata,
+      }).select('id,to_address,subject,body_html,body_text,created_at,metadata').single()
+      if (error || !data) throw new Error(error?.message ?? 'Report payload was not frozen')
+      await deliver(data as EmailRow)
+    }
+    completed = true
+    return { success: true, sent }
+  } catch (error) {
+    failureMessage = error instanceof Error ? error.message : 'Manager report delivery failed'
+    return { success: false, sent, error: failureMessage }
+  } finally {
+    if (lockId) {
+      try {
+        const { error } = await db.from('cron_job_runs').update({
+          status: completed ? 'completed' : 'failed', finished_at: now().toISOString(), error_message: failureMessage,
+        }).eq('id', lockId).eq('error_message', owner)
+        if (error) console.error('Manager report lease release failed', { message: error.message, code: error.code })
+      } catch (error) {
+        console.error('Manager report lease release failed', { message: error instanceof Error ? error.message : String(error) })
+      }
+    }
+  }
+}

--- a/src/lib/manager-report/queue.ts
+++ b/src/lib/manager-report/queue.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'crypto'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { isValidEmailAddress } from '@/lib/notifications/channel'
+import { MANAGER_REPORT_SECTIONS, type ManagerReportInput, type ManagerReportQueueResult } from './types'
+
+/** Stable UUIDs make insertion atomic without resetting a previously delivered item. */
+export function managerReportId(parts: string[]): string {
+  const hash = createHash('sha256').update(JSON.stringify(parts)).digest('hex')
+  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-5${hash.slice(13, 16)}-a${hash.slice(17, 20)}-${hash.slice(20, 32)}`
+}
+
+export async function queueManagerReportEmail(input: ManagerReportInput): Promise<ManagerReportQueueResult> {
+  try {
+    const to = input.to.trim().toLowerCase()
+    if (!isValidEmailAddress(to) || /[,;<>]/.test(to) || !input.key.trim() || !input.subject.trim() || !MANAGER_REPORT_SECTIONS.includes(input.section)) {
+      return { success: false, error: 'Manager report item needs a recipient, source key, subject and valid section' }
+    }
+    const id = managerReportId(['manager_report_item', input.section, input.key, to])
+    const { error } = await createAdminClient().from('email_messages').upsert({
+      id, to_address: to, comm_type: 'manager_report_item', status: 'queued',
+      subject: input.subject, body_html: input.html ?? null, body_text: input.text ?? null,
+      metadata: { ...input.metadata, section: input.section, key: input.key },
+    }, { onConflict: 'id', ignoreDuplicates: true })
+    if (error) return { success: false, error: error.message }
+    return { success: true, queued: true, emailMessageId: id }
+  } catch (error) {
+    return { success: false, error: error instanceof Error ? error.message : 'Manager report queue failed' }
+  }
+}

--- a/src/lib/manager-report/render.test.ts
+++ b/src/lib/manager-report/render.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+import { renderManagerReport } from './render'
+import { MANAGER_REPORT_SECTIONS } from './types'
+import type { ManagerReportEntry, ManagerReportRenderInput } from './types'
+
+const input: ManagerReportRenderInput = {
+  entries: [],
+  periodStart: '2026-10-23T08:00:00.000Z',
+  periodEnd: '2026-10-30T09:00:00.000Z',
+  appUrl: 'https://management.example.test',
+}
+
+function entry(overrides: Partial<ManagerReportEntry> = {}): ManagerReportEntry {
+  return {
+    id: 'synthetic-1', key: 'synthetic-1', to: 'manager@example.test',
+    section: 'table_bookings', subject: 'New table booking: TEST-123',
+    createdAt: '2026-10-26T08:15:00.000Z',
+    html: '<p>A new table booking has been created.</p><ul><li><strong>Reference:</strong> TEST-123</li><li><strong>When:</strong> Saturday 31 October 2026 at 18:30</li><li><strong>Party size:</strong> 6</li><li><strong>Guest:</strong> Alex Example</li><li><strong>Status:</strong> Confirmed</li></ul>',
+    ...overrides,
+  }
+}
+
+describe('renderManagerReport', () => {
+  it('retains the original reminder date when a failed collection is queued later', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({
+      section: 'staff_shift_reminders', createdAt: '2026-10-29T10:00:00Z',
+      metadata: { source_recorded_at: '2026-10-26T08:15:00Z' },
+    })] })
+    expect(report.text).toContain('Recorded: 26 Oct 2026, 08:15 (London)')
+    expect(report.text).not.toContain('Recorded: 29 Oct 2026')
+  })
+
+  it('renders all eight categories with truthful counts, detail, snapshot dates and management links', () => {
+    const entries = MANAGER_REPORT_SECTIONS.map((section, index) => entry({
+      id: `synthetic-${index}`, key: `synthetic-${index}`, section,
+      ...(section === 'table_bookings' ? {} : {
+        subject: `${section} synthetic update`,
+        text: `${section}: 0 outstanding items.`,
+      }),
+    }))
+    const report = renderManagerReport({ ...input, entries })
+    expect(report.text).toContain('8 queued updates')
+    for (const title of ['New table bookings', 'Staff shift reminders', 'Holiday approval reminders', 'Checklist alerts', 'Checklist summary', 'Recruitment', 'Private-booking summary', 'Rota summary']) {
+      expect(report.text).toContain(title)
+    }
+    expect(report.text).toContain('Saturday 31 October 2026 at 18:30')
+    expect(report.text).toContain('Party size: 6')
+    expect(report.text).toContain('Guest: Alex Example')
+    expect(report.text).toContain('Snapshot: 26 Oct 2026, 08:15 (London)')
+    expect(report.html).toContain('href="https://management.example.test/rota/leave"')
+    expect(report.text).toContain('0 outstanding items')
+    expect(`${report.html}${report.text}`).not.toMatch(/undefined|NaN|Invalid Date/)
+  })
+
+  it('shows an empty weekly report without claiming the business has no problems', () => {
+    const report = renderManagerReport(input)
+    expect(report.text).toContain('0 queued updates')
+    expect(report.text.match(/No queued updates in this period\./g)).toHaveLength(5)
+    expect(report.text.match(/No snapshot available for this report/g)).toHaveLength(3)
+    expect(report.attachment).toBeUndefined()
+    expect(report.text).toContain('check the management app for the current position')
+  })
+
+  it('escapes names, source markup, decoded entities and malicious links in body and attachment', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({
+      subject: '<img src=x onerror=alert(1)> & "Name"',
+      html: '<style>body{display:none}</style><script>alert("bad")</script><ul><li><strong>Guest:</strong> &lt;svg onload=alert(1)&gt; &amp; &#x1f642;</li><li><strong>When:</strong> Friday 30 October at 19:00</li><li><strong>Party size:</strong> 6</li><li><strong>Notes:</strong> <a href="javascript:alert(1)">Dietary note</a></li><li><strong>Extra:</strong> ' + 'Full details. '.repeat(100) + '</li></ul>',
+    })] })
+    for (const output of [report.html, report.attachment!.content]) {
+      expect(output).not.toMatch(/<script|<style|<img|<svg|javascript:|display:none/)
+      expect(output).toContain('&lt;img src=x onerror=alert(1)&gt;')
+      expect(output).toContain('&lt;svg onload=alert(1)&gt; &amp; 🙂')
+      const document = new DOMParser().parseFromString(output, 'text/html')
+      expect(document.querySelectorAll('script,img,svg,iframe,object,style')).toHaveLength(0)
+      for (const link of document.querySelectorAll('a')) {
+        expect(link.getAttribute('href')).toMatch(/^https:\/\/management\.example\.test\//)
+      }
+    }
+  })
+
+  it('retains every item in full details when a busy week exceeds the visible limit', () => {
+    const entries = Array.from({ length: 40 }, (_, index) => entry({
+      id: `item-${index}`, key: `item-${index}`, section: 'recruitment',
+      subject: `Applicant example ${index}`, text: `Full detail marker ${index}.`,
+      createdAt: `2026-10-${String(20 + Math.floor(index / 4)).padStart(2, '0')}T0${index % 4}:00:00Z`,
+    }))
+    const report = renderManagerReport({ ...input, entries })
+    expect(report.text).toContain('Recruitment (40 updates)')
+    expect(report.text).toContain('28 more updates are included in the attached full report.')
+    expect(report.html.match(/<article /g)).toHaveLength(12)
+    expect(report.attachment?.content.match(/<article /g)).toHaveLength(40)
+    for (let index = 0; index < 40; index++) {
+      expect(report.attachment?.content).toContain(`Full detail marker ${index}.`)
+    }
+  })
+
+  it('keeps full snapshot content in the attachment when the email excerpt is shortened', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({
+      section: 'private_bookings', subject: 'Private bookings, weekly summary',
+      text: 'Booking example. '.repeat(100) + 'Final booking: Example Hall.',
+    })] })
+    expect(report.html).not.toContain('Final booking: Example Hall.')
+    expect(report.attachment?.content).toContain('Final booking: Example Hall.')
+    expect(report.text).toContain('Some details are shortened above.')
+  })
+
+  it('keeps the report window at 09:00 London across the autumn clock change', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({ createdAt: '2026-10-23T23:30:00Z' })] })
+    expect(report.text).toContain('23 Oct 2026, 09:00 to 30 Oct 2026, 09:00 (London)')
+    expect(report.text).toContain('Recorded: 24 Oct 2026, 00:30 (London)')
+  })
+
+  it('formats the spring clock change in London and handles an invalid source date', () => {
+    const report = renderManagerReport({
+      ...input, periodStart: '2026-03-27T09:00:00Z', periodEnd: '2026-04-03T08:00:00Z',
+      entries: [entry({ createdAt: 'broken' })],
+    })
+    expect(report.text).toContain('27 Mar 2026, 09:00 to 3 Apr 2026, 09:00 (London)')
+    expect(report.text).toContain('Recorded: Date unavailable')
+    expect(report.html).not.toContain('Invalid Date')
+  })
+
+  it('rejects unsafe app URLs and invalid report dates', () => {
+    for (const appUrl of ['javascript:alert(1)', 'data:text/html,test', 'https://user:password@example.test']) {
+      expect(() => renderManagerReport({ ...input, appUrl })).toThrow()
+    }
+    expect(() => renderManagerReport({ ...input, periodEnd: 'broken' })).toThrow('valid period dates')
+  })
+
+  it('retains table detail from HTML even when its text alternative only includes a reference', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({ text: 'Booking TEST-123' })] })
+    expect(report.text).toContain('When: Saturday 31 October 2026 at 18:30')
+    expect(report.text).toContain('Party size: 6')
+  })
+
+  it('keeps HTML tables legible as plain text and never emits an em dash', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({
+      section: 'rota', subject: 'Rota \u2014 summary',
+      html: '<table><tr><th>Week</th><th>Open shifts</th></tr><tr><td>26 October</td><td>0</td></tr></table>',
+    })] })
+    expect(report.text).toContain('Week | Open shifts')
+    expect(report.text).toContain('26 October | 0')
+    expect(report.html).not.toContain('\u2014')
+  })
+
+  it('shows available snapshot metrics including zero and excludes invalid numeric metadata', () => {
+    const report = renderManagerReport({ ...input, entries: [entry({
+      section: 'rota', subject: 'Rota summary', text: 'No unfilled shifts at snapshot time.',
+      metadata: { weeks_needing_attention: 0, unfilled_shifts: 0, pending_leave: NaN },
+    }), entry({
+      id: 'private', section: 'private_bookings', subject: 'Private booking summary', text: 'Review the coming events.',
+      metadata: { event_count: 4, action_count: 1 },
+    })] })
+    expect(report.text).toContain('Weeks needing attention: 0')
+    expect(report.text).toContain('Unfilled shifts: 0')
+    expect(report.text).toContain('Events in summary: 4')
+    expect(report.text).toContain('Actions in summary: 1')
+    expect(report.text).not.toContain('NaN')
+  })
+
+  it('bounds encoded email size and accounts for all skipped entries across a very long week', () => {
+    const entries = MANAGER_REPORT_SECTIONS.flatMap((section) => Array.from({ length: 12 }, (_, index) => entry({
+      id: `${section}-${index}`, key: `${section}-${index}`, section,
+      subject: `Example ${section} ${index}: ${'&'.repeat(200)}`,
+      html: undefined, text: `Recorded details: ${'&'.repeat(1500)}`,
+    })))
+    const report = renderManagerReport({ ...input, entries })
+    expect(new TextEncoder().encode(report.html).byteLength).toBeLessThan(85_000)
+    expect(report.attachment?.content.match(/<article /g)).toHaveLength(96)
+    const visible = report.html.match(/<article /g)?.length ?? 0
+    const omitted = [...report.text.matchAll(/(\d+) more updates are included/g)]
+      .reduce((total, match) => total + Number(match[1]), 0)
+    expect(visible + omitted).toBe(96)
+  })
+})

--- a/src/lib/manager-report/render.ts
+++ b/src/lib/manager-report/render.ts
@@ -1,0 +1,194 @@
+import { formatDateInLondon, parseLondonDateTimeLocal } from '@/lib/dateUtils'
+import { MANAGER_REPORT_SECTIONS } from './types'
+import type { ManagerReportEntry, ManagerReportRenderInput, ManagerReportRendered, ManagerReportSection } from './types'
+
+const MAX_VISIBLE_ENTRIES = 12
+// Leave room for headings, links and the notice below the usual inbox clipping
+// threshold. Count encoded bytes, since escaped names can expand substantially.
+const MAX_ENTRY_HTML_BYTES = 65_000
+const SECTIONS: Record<ManagerReportSection, { title: string; path: string; snapshot?: boolean }> = {
+  table_bookings: { title: 'New table bookings', path: '/table-bookings' },
+  staff_shift_reminders: { title: 'Staff shift reminders', path: '/rota' },
+  holiday_reminders: { title: 'Holiday approval reminders', path: '/rota/leave' },
+  checklist_alerts: { title: 'Checklist alerts', path: '/checklists/manage' },
+  checklist_summary: { title: 'Checklist summary', path: '/checklists/manage', snapshot: true },
+  recruitment: { title: 'Recruitment', path: '/recruitment' },
+  private_bookings: { title: 'Private-booking summary', path: '/private-bookings', snapshot: true },
+  rota: { title: 'Rota summary', path: '/rota', snapshot: true },
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]!)
+}
+
+function cleanText(value: string): string {
+  return value
+    .replace(/\u2014/g, ', ')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .replace(/[\t ]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+// This produces plain text only. Even malformed HTML and decoded markup are
+// escaped again at every HTML output boundary; no source attributes are reused.
+function htmlToText(value: string): string {
+  const entities: Record<string, string> = {
+    amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+    pound: '£', ndash: '-', mdash: ', ', bull: '*', hellip: '...',
+  }
+  return cleanText(value
+    .replace(/<!--[\s\S]*?(?:-->|$)/g, '')
+    .replace(/<(script|style|head|iframe|object|svg|template)\b[^>]*>[\s\S]*?(?:<\/\1\s*>|$)/gi, '')
+    .replace(/<\/(?:td|th)\s*>\s*<(?:td|th)\b[^>]*>/gi, ' | ')
+    .replace(/<(?:br|hr)\b[^>]*>|<\/(?:p|div|li|tr|h[1-6]|section|table|ul|ol)\s*>/gi, '\n')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, name: string) => {
+      if (!name.startsWith('#')) return entities[name.toLowerCase()] ?? entity
+      const code = name[1].toLowerCase() === 'x' ? parseInt(name.slice(2), 16) : parseInt(name.slice(1), 10)
+      return code > 0 && code <= 0x10ffff && !(code >= 0xd800 && code <= 0xdfff)
+        ? String.fromCodePoint(code) : ''
+    }))
+}
+
+function dateLabel(value: string, includeTime = false): string {
+  const date = parseLondonDateTimeLocal(value)
+  if (!date) return 'Date unavailable'
+  return formatDateInLondon(date, {
+    day: 'numeric', month: 'short', year: 'numeric',
+    ...(includeTime ? { hour: '2-digit', minute: '2-digit', hour12: false } : {}),
+  })
+}
+
+function bodyText(entry: ManagerReportEntry): string {
+  // Booking HTML contains the When and Party size fields even when a shorter
+  // text alternative exists. Prefer it so the reference is never the only detail.
+  return entry.section === 'table_bookings' && entry.html
+    ? htmlToText(entry.html)
+    : cleanText(entry.text ?? '') || htmlToText(entry.html ?? '')
+}
+
+function summarise(entry: ManagerReportEntry, body: string): string {
+  if (entry.section === 'table_bookings') {
+    const lines = body.split('\n')
+    const details = ['When', 'Party size', 'Guest', 'Status', 'High chairs', 'Seating', 'Notes']
+      .flatMap((label) => lines.filter((line) => line.startsWith(`${label}:`)))
+    if (details.length) return details.join('\n')
+  }
+  return body
+}
+
+function snapshotMetrics(entry: ManagerReportEntry): string {
+  const fields = entry.section === 'private_bookings'
+    ? { event_count: 'Events in summary', action_count: 'Actions in summary' }
+    : entry.section === 'rota'
+      ? { weeks_needing_attention: 'Weeks needing attention', unfilled_shifts: 'Unfilled shifts', pending_leave: 'Holiday requests awaiting approval' }
+      : {}
+  return Object.entries(fields).flatMap(([key, label]) => {
+    const value = entry.metadata?.[key]
+    return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? [`${label}: ${value}`] : []
+  }).join('\n')
+}
+
+function clip(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit).trimEnd()}...`
+}
+
+function page(title: string, contents: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${escapeHtml(title)}</title></head><body style="margin:0;background:#f3f4f6;color:#1f2937;font-family:Arial,Helvetica,sans-serif;font-size:15px;line-height:1.5"><main style="max-width:680px;margin:24px auto;background:#fff;padding:28px 24px;border-radius:8px;overflow-wrap:anywhere">${contents}</main></body></html>`
+}
+
+/** Render stored notifications as escaped text; source HTML is never embedded. */
+export function renderManagerReport(input: ManagerReportRenderInput): ManagerReportRendered {
+  const appUrl = new URL(input.appUrl)
+  if (!['https:', 'http:'].includes(appUrl.protocol) || appUrl.username || appUrl.password) {
+    throw new Error('Manager report requires an HTTP or HTTPS app URL without credentials')
+  }
+  if (!parseLondonDateTimeLocal(input.periodStart) || !parseLondonDateTimeLocal(input.periodEnd)) {
+    throw new Error('Manager report requires valid period dates')
+  }
+  const period = `${dateLabel(input.periodStart, true)} to ${dateLabel(input.periodEnd, true)} (London)`
+  const subject = `The Anchor: Friday manager report, ${dateLabel(input.periodEnd)}`
+  const totalLabel = `${input.entries.length} queued ${input.entries.length === 1 ? 'update' : 'updates'}`
+  const introduction = 'Updates recorded during this period. Reminders and snapshots reflect their recorded date; check the management app for the current position.'
+  const header = `<p style="margin:0;color:#6b7280;font-size:12px;letter-spacing:1px">THE ANCHOR</p><h1 style="font-size:25px;margin:6px 0 12px">Friday manager report</h1><p>${escapeHtml(period)}<br><strong>${totalLabel}</strong></p><p style="color:#4b5563">${introduction}</p>`
+  const html: string[] = [header]
+  const full: string[] = [header, '<h2>Full details</h2>']
+  const text: string[] = [subject, period, totalLabel, introduction]
+  let needsAttachment = false
+  let visibleEntryBytes = 0
+
+  for (const section of MANAGER_REPORT_SECTIONS) {
+    const definition = SECTIONS[section]
+    const entries = input.entries.filter((entry) => entry.section === section)
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || a.id.localeCompare(b.id))
+    const url = new URL(definition.path, appUrl.origin).href
+    const unit = definition.snapshot ? 'snapshot' : 'update'
+    const label = `${definition.title} (${entries.length} ${unit}${entries.length === 1 ? '' : 's'})`
+    const link = `<a href="${escapeHtml(url)}" style="color:#1d4ed8">Open ${escapeHtml(definition.title.toLowerCase())}</a>`
+    const heading = `<h2 style="font-size:19px;border-top:1px solid #e5e7eb;padding-top:18px;margin:24px 0 12px">${escapeHtml(label)}</h2>`
+    html.push(heading)
+    full.push(heading)
+    text.push(`\n${label}`, url)
+    if (!entries.length) {
+      const empty = definition.snapshot
+        ? 'No snapshot available for this report; check the management app.'
+        : 'No queued updates in this period.'
+      html.push(`<p style="color:#6b7280">${empty}</p>`)
+      full.push(`<p>${empty}</p>`)
+      text.push(empty)
+    }
+    let visibleCount = 0
+    entries.forEach((entry) => {
+      const title = cleanText(entry.subject) || 'Update'
+      const sourceRecordedAt = typeof entry.metadata?.source_recorded_at === 'string'
+        ? entry.metadata.source_recorded_at : entry.createdAt
+      const recorded = `${definition.snapshot ? 'Snapshot' : 'Recorded'}: ${dateLabel(sourceRecordedAt, true)} (London)`
+      const body = bodyText(entry)
+      const metrics = snapshotMetrics(entry)
+      const fullBody = [metrics, body].filter(Boolean).join('\n\n')
+      const concise = clip([metrics, summarise(entry, body)].filter(Boolean).join('\n\n'), definition.snapshot ? 900 : 420)
+      const item = (details: string, itemTitle: string): string => `<article style="margin:0 0 18px"><h3 style="font-size:15px;margin:0 0 3px">${escapeHtml(itemTitle)}</h3><p style="font-size:12px;color:#6b7280;margin:0 0 6px">${escapeHtml(recorded)}</p><p style="margin:0;white-space:pre-line">${escapeHtml(details || 'See the management app for details.')}</p></article>`
+      full.push(item(fullBody, title))
+      const visibleTitle = clip(title, 150)
+      const visibleHtml = item(concise, visibleTitle)
+      const itemBytes = new TextEncoder().encode(visibleHtml).byteLength
+      if (visibleCount < MAX_VISIBLE_ENTRIES && visibleEntryBytes + itemBytes <= MAX_ENTRY_HTML_BYTES) {
+        visibleCount++
+        visibleEntryBytes += itemBytes
+        html.push(visibleHtml)
+        text.push(visibleTitle, recorded, concise || 'See the management app for details.')
+        if (concise !== fullBody || visibleTitle !== title) needsAttachment = true
+      } else {
+        needsAttachment = true
+      }
+    })
+    if (entries.length > visibleCount) {
+      const omitted = `${entries.length - visibleCount} more updates are included in the attached full report.`
+      html.push(`<p><strong>${omitted}</strong></p>`)
+      text.push(omitted)
+    }
+    html.push(`<p>${link}</p>`)
+    full.push(`<p>${link}</p>`)
+  }
+  if (needsAttachment) {
+    const note = 'Some details are shortened above. The attached full report contains every queued update and its full text.'
+    html.splice(1, 0, `<p style="padding:12px;background:#f3f4f6">${note}</p>`)
+    text.splice(4, 0, note)
+  }
+  return {
+    subject,
+    html: page(subject, html.join('\n')),
+    text: text.join('\n\n'),
+    ...(needsAttachment ? {
+      attachment: {
+        filename: 'friday-manager-report-full.html',
+        contentType: 'text/html',
+        content: page(`${subject}: full details`, full.join('\n')),
+      },
+    } : {}),
+  }
+}

--- a/src/lib/manager-report/schedule.ts
+++ b/src/lib/manager-report/schedule.ts
@@ -1,0 +1,15 @@
+import { formatInTimeZone, fromZonedTime } from 'date-fns-tz'
+import { subDays } from 'date-fns'
+
+const ZONE = 'Europe/London'
+
+export interface ManagerReportPeriod { key: string; periodStart: string; periodEnd: string }
+
+/** Hourly Friday retries are allowed after the 09:00 local delivery time. */
+export function managerReportPeriod(now: Date): ManagerReportPeriod | null {
+  if (formatInTimeZone(now, ZONE, 'i') !== '5' || Number(formatInTimeZone(now, ZONE, 'H')) < 9) return null
+  const key = formatInTimeZone(now, ZONE, 'yyyy-MM-dd')
+  const end = fromZonedTime(`${key}T09:00:00`, ZONE)
+  const previousDate = formatInTimeZone(subDays(end, 7), ZONE, 'yyyy-MM-dd')
+  return { key, periodStart: fromZonedTime(`${previousDate}T09:00:00`, ZONE).toISOString(), periodEnd: end.toISOString() }
+}

--- a/src/lib/manager-report/types.ts
+++ b/src/lib/manager-report/types.ts
@@ -1,0 +1,42 @@
+export const MANAGER_REPORT_SECTIONS = [
+  'table_bookings', 'staff_shift_reminders', 'holiday_reminders', 'checklist_alerts',
+  'checklist_summary', 'recruitment', 'private_bookings', 'rota',
+] as const
+
+export type ManagerReportSection = typeof MANAGER_REPORT_SECTIONS[number]
+
+export interface ManagerReportInput {
+  section: ManagerReportSection
+  key: string
+  to: string
+  subject: string
+  html?: string
+  text?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface ManagerReportQueueResult {
+  success: boolean
+  queued?: true
+  emailMessageId?: string
+  error?: string
+}
+
+export interface ManagerReportEntry extends ManagerReportInput {
+  id: string
+  createdAt: string
+}
+
+export interface ManagerReportRenderInput {
+  entries: ManagerReportEntry[]
+  periodStart: string
+  periodEnd: string
+  appUrl: string
+}
+
+export interface ManagerReportRendered {
+  subject: string
+  html: string
+  text: string
+  attachment?: { filename: string; contentType: string; content: string }
+}

--- a/src/lib/private-bookings/manager-notifications.ts
+++ b/src/lib/private-bookings/manager-notifications.ts
@@ -1,5 +1,6 @@
 import { formatTime12Hour } from '@/lib/dateUtils'
 import { sendEmail } from '@/lib/email/emailService'
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createGuestToken } from '@/lib/guest/tokens'
 import { logger } from '@/lib/logger'
@@ -219,9 +220,9 @@ export async function sendManagerPrivateBookingCreatedEmail(
   return { sent: true }
 }
 
-export async function sendManagerPrivateBookingsWeeklyDigestEmail(
+export async function queueManagerPrivateBookingsWeeklyDigestEmail(
   input: PrivateBookingWeeklyDigestInput
-): Promise<{ sent: boolean; error?: string; actionCount?: number; eventCount?: number }> {
+): Promise<{ queued: boolean; error?: string; actionCount?: number; eventCount?: number }> {
   const appBaseUrl = normalizeAppBaseUrl(input.appBaseUrl)
   const privateBookingsUrl = `${appBaseUrl}/private-bookings`
   const events = input.events
@@ -230,7 +231,7 @@ export async function sendManagerPrivateBookingsWeeklyDigestEmail(
   const tier2 = events.filter((e) => e.tier === 2)
   const tier3 = events.filter((e) => e.tier === 3)
   const actionCount = tier1.length + tier2.length
-  const subject = `Private bookings weekly summary — ${input.weekLabel}`
+  const subject = `Private bookings weekly summary - ${input.weekLabel}`
 
   // --- HTML builder ---
 
@@ -307,11 +308,11 @@ export async function sendManagerPrivateBookingsWeeklyDigestEmail(
       })()
     : ''
 
-  const footerHtml = `<p style="margin-top:24px;font-size:12px;color:#9ca3af;">Sent every Monday at 9am · <a href="${escapeHtml(privateBookingsUrl)}" style="color:#9ca3af;">Manage in Anchor Management Tools</a></p>`
+  const footerHtml = `<p style="margin-top:24px;font-size:12px;color:#9ca3af;">Included in the Friday manager report · <a href="${escapeHtml(privateBookingsUrl)}" style="color:#9ca3af;">Manage in Anchor Management Tools</a></p>`
 
   let bodyHtml: string
   if (events.length === 0) {
-    bodyHtml = '<p style="margin-top:16px;color:#6b7280;">All clear — no upcoming private events. Enjoy your week.</p>'
+    bodyHtml = '<p style="margin-top:16px;color:#6b7280;">All clear - no upcoming private events. Enjoy your week.</p>'
   } else {
     bodyHtml = [
       renderTierSectionHtml('Action Required', tier1, '#dc2626'),
@@ -333,13 +334,13 @@ export async function sendManagerPrivateBookingsWeeklyDigestEmail(
   // --- Plain text builder ---
 
   const textLines: string[] = [
-    `Private bookings weekly summary — ${input.weekLabel}`,
+    `Private bookings weekly summary - ${input.weekLabel}`,
     '',
     `${tier1.length} Action Required | ${tier2.length} Needs Attention | ${tier3.length} On Track`
   ]
 
   if (events.length === 0) {
-    textLines.push('', 'All clear — no upcoming private events. Enjoy your week.')
+    textLines.push('', 'All clear - no upcoming private events. Enjoy your week.')
   } else {
     if (tier1.length > 0) {
       textLines.push('', '--- ACTION REQUIRED ---')
@@ -395,11 +396,14 @@ export async function sendManagerPrivateBookingsWeeklyDigestEmail(
 
   textLines.push(
     '',
-    `Sent every Monday at 9am · Manage in Anchor Management Tools`,
+    `Included in the Friday manager report · Manage in Anchor Management Tools`,
     privateBookingsUrl
   )
 
-  const result = await sendEmail({
+  const result = await queueManagerReportEmail({
+    section: 'private_bookings',
+    key: input.runDateKey,
+    metadata: { snapshot_date: input.runDateKey, event_count: events.length, action_count: actionCount },
     to: PRIVATE_BOOKINGS_MANAGER_EMAIL,
     subject,
     html,
@@ -408,15 +412,15 @@ export async function sendManagerPrivateBookingsWeeklyDigestEmail(
 
   if (!result.success) {
     return {
-      sent: false,
-      error: result.error || 'Failed to send private-bookings weekly digest email',
+      queued: false,
+      error: result.error || 'Failed to queue private-bookings weekly summary',
       actionCount,
       eventCount: events.length
     }
   }
 
   return {
-    sent: true,
+    queued: true,
     actionCount,
     eventCount: events.length
   }

--- a/src/lib/recruitment/communications.ts
+++ b/src/lib/recruitment/communications.ts
@@ -1,3 +1,4 @@
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { sendEmail, type EmailAttachment } from '@/lib/email/emailService'
@@ -450,8 +451,11 @@ export async function sendRecruitmentManagerAlert(
       edited_by: input.currentUserId ?? null,
       sent_by: input.currentUserId ?? null,
       delivery_status: 'queued',
+      sent_at: null,
+      provider_message_id: null,
       provider: 'email_service',
       metadata: {
+        recipient_email: to,
         alert_type: input.alertType,
         role_title: application ? roleTitle(application) : null,
       },
@@ -461,41 +465,40 @@ export async function sendRecruitmentManagerAlert(
 
   if (commError) throw commError
 
-  const result = await sendEmail({
+  const result = await queueManagerReportEmail({
+    section: 'recruitment',
+    key: communication.id,
     to,
     subject,
     text: body,
-    provider: 'graph',
-    from: recruitmentFromEmail(),
-    graphSender: recruitmentFromEmail(),
-    replyTo: recruitmentFromEmail(),
-    commType: 'recruitment_manager_alert',
     metadata: {
       application_id: input.applicationId ?? null,
       candidate_id: candidateId,
       communication_id: communication.id,
+      summary: body,
     },
   })
 
-  await supabase
-    .from('recruitment_communications')
-    .update({
-      delivery_status: result.success ? 'sent' : 'failed',
-      provider_message_id: result.messageId ?? null,
-      sent_at: result.success ? new Date().toISOString() : null,
-      metadata: {
-        alert_type: input.alertType,
-        role_title: application ? roleTitle(application) : null,
-        error: result.error ?? null,
-      },
-    })
-    .eq('id', communication.id)
-
   if (!result.success) {
+    const { error: updateError } = await supabase
+      .from('recruitment_communications')
+      .update({
+        delivery_status: 'failed',
+        provider_message_id: null,
+        sent_at: null,
+        metadata: {
+          recipient_email: to,
+          alert_type: input.alertType,
+          role_title: application ? roleTitle(application) : null,
+          error: result.error ?? null,
+        },
+      })
+      .eq('id', communication.id)
+    if (updateError) throw updateError
     throw new Error(result.error || 'Recruitment manager alert failed.')
   }
 
-  return { success: true, communicationId: communication.id, messageId: result.messageId ?? null }
+  return { success: true, communicationId: communication.id, queued: true, messageId: null }
 }
 
 export async function draftRecruitmentEmailForApplication(
@@ -970,6 +973,35 @@ export async function retryRecruitmentCommunication(
 
   if (error) throw error
   if (!original) throw new Error('Communication not found.')
+
+  if (original.channel === 'email' && original.type === 'manager_alert') {
+    if (original.delivery_status === 'sent') {
+      return { success: true as const, communicationId: original.id, retryOfCommunicationId: communicationId }
+    }
+    const result = await queueManagerReportEmail({
+      section: 'recruitment',
+      key: original.id,
+      to: original.metadata?.recipient_email || process.env.RECRUITMENT_NOTIFICATION_EMAIL || 'manager@the-anchor.pub',
+      subject: original.subject || 'Recruitment alert',
+      text: original.final_body,
+      metadata: {
+        application_id: original.application_id,
+        candidate_id: original.candidate_id,
+        communication_id: original.id,
+        summary: original.final_body,
+      },
+    })
+    if (!result.success) throw new Error(result.error || 'Recruitment manager alert queue failed.')
+    // A retry reuses its source row and cannot create a second report entry.
+    if (original.delivery_status !== 'queued') {
+      const { error: updateError } = await supabase.from('recruitment_communications')
+        .update({ delivery_status: 'queued', provider_message_id: null, sent_at: null })
+        .eq('id', original.id)
+        .eq('delivery_status', original.delivery_status)
+      if (updateError) throw updateError
+    }
+    return { success: true as const, queued: true, communicationId: original.id, retryOfCommunicationId: communicationId }
+  }
 
   const candidate = original.candidate as any
   const retryBody = original.channel === 'email' && original.type !== 'manager_alert'

--- a/src/lib/table-bookings/bookings.ts
+++ b/src/lib/table-bookings/bookings.ts
@@ -1,7 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { fromZonedTime } from 'date-fns-tz'
 import { createGuestToken, hashGuestToken } from '@/lib/guest/tokens'
-import { sendEmail } from '@/lib/email/emailService'
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 import { notifyCustomer } from '@/lib/notifications/notify'
 import { sendSMS } from '@/lib/twilio'
 import { getSmartFirstName } from '@/lib/sms/bulk'
@@ -505,7 +505,7 @@ export async function sendManagerTableBookingCreatedEmailIfAllowed(
     fallbackCustomerId?: string | null
     createdVia?: string
   }
-): Promise<{ sent: boolean; skipped?: boolean; reason?: string; error?: string }> {
+): Promise<{ sent: boolean; queued?: boolean; skipped?: boolean; reason?: string; error?: string }> {
   if (!input.tableBookingId) {
     return {
       sent: false,
@@ -610,21 +610,28 @@ export async function sendManagerTableBookingCreatedEmailIfAllowed(
     '</ul>'
   ].join('')
 
-  const emailResult = await sendEmail({
+  const emailResult = await queueManagerReportEmail({
+    section: 'table_bookings',
+    key: booking.id,
     to: MANAGER_TABLE_BOOKING_EMAIL,
     subject,
-    html
+    html,
+    metadata: {
+      table_booking_id: booking.id,
+      summary: `${customerName}: ${partySize} guests, ${bookingMoment}, ${bookingReference}`,
+    },
   })
 
   if (!emailResult.success) {
     return {
       sent: false,
-      error: emailResult.error || 'Failed to send manager booking email'
+      error: emailResult.error || 'Failed to queue manager booking email'
     }
   }
 
   return {
-    sent: true
+    sent: false,
+    queued: true
   }
 }
 

--- a/src/lib/table-bookings/manager-report.test.ts
+++ b/src/lib/table-bookings/manager-report.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+const mocks = vi.hoisted(() => ({ queue: vi.fn(), send: vi.fn(), notify: vi.fn() }))
+vi.mock('@/lib/manager-report/queue', () => ({ queueManagerReportEmail: mocks.queue }))
+vi.mock('@/lib/email/emailService', () => ({ sendEmail: mocks.send }))
+vi.mock('@/lib/notifications/notify', () => ({ notifyCustomer: mocks.notify }))
+vi.mock('@/lib/twilio', () => ({ sendSMS: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
+import { sendManagerTableBookingCreatedEmailIfAllowed } from './bookings'
+
+function client(source = 'website') {
+  return { from: (table: string) => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({
+    data: table === 'table_bookings' ? {
+      id: 'booking-1', customer_id: 'customer-1', booking_reference: 'TB-1', booking_date: '2026-09-12',
+      booking_time: '18:00', start_datetime: '2026-09-12T17:00:00Z', party_size: 4, source,
+      booking_type: 'regular', status: 'confirmed',
+    } : { id: 'customer-1', first_name: 'Alex', last_name: 'Rowe', email: 'alex@example.com' }, error: null,
+  }) }) }) }) } as never
+}
+
+describe('manager table booking report source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.queue.mockResolvedValue({ success: true, queued: true })
+  })
+  it('uses the booking ID for creation and deposit-capture deduplication without immediate mail', async () => {
+    const db = client()
+    for (const createdVia of ['api', 'paypal_capture']) {
+      expect(await sendManagerTableBookingCreatedEmailIfAllowed(db, { tableBookingId: 'booking-1', createdVia }))
+        .toEqual({ sent: false, queued: true })
+    }
+    expect(mocks.queue.mock.calls.map(([input]) => input.key)).toEqual(['booking-1', 'booking-1'])
+    expect(mocks.queue).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'table_bookings', to: 'manager@the-anchor.pub', html: expect.stringContaining('Alex Rowe'),
+      metadata: expect.objectContaining({ table_booking_id: 'booking-1' }),
+    }))
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.notify).not.toHaveBeenCalled()
+  })
+  it('retains the walk-in exclusion', async () => {
+    expect(await sendManagerTableBookingCreatedEmailIfAllowed(client('walk-in'), { tableBookingId: 'booking-1' }))
+      .toMatchObject({ sent: false, skipped: true, reason: 'walk_in' })
+    expect(mocks.queue).not.toHaveBeenCalled()
+  })
+  it('reports queue failure truthfully', async () => {
+    mocks.queue.mockResolvedValue({ success: false, error: 'queue unavailable' })
+    expect(await sendManagerTableBookingCreatedEmailIfAllowed(client(), { tableBookingId: 'booking-1' }))
+      .toEqual({ sent: false, error: 'queue unavailable' })
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+})

--- a/tasks/plan-2026-09-05-friday-manager-report.md
+++ b/tasks/plan-2026-09-05-friday-manager-report.md
@@ -1,0 +1,87 @@
+# Friday manager report implementation plan
+
+> For agentic workers: use the implement-plan skill. Checkboxes track completion.
+
+**Goal:** Replace the approved individual manager emails with one Friday report at 09:00 Europe/London, while retaining the explicitly selected immediate emails.
+
+**Architecture:** Reuse the existing email_messages queued state to retain deferred notifications, with explicit category and stable source keys. A protected Friday cron assembles and sends a single report with an immutable payload and provider idempotency. Existing summaries prepare fresh snapshots before Friday delivery. No schema change is planned.
+
+**Tech stack:** Existing Next.js routes, TypeScript, Supabase, Resend and Vitest.
+
+**Spec:** Owner decisions in this task on 5 September 2026; discovery at /Users/peterpitcher/Documents/Codex/2026-09-05/manager-email-discovery/discovery.md.
+
+## Global constraints
+
+- Weekly: new table bookings, manager copies of staff shift reminders, holiday approval reminders, manager checklist alerts and summary, recruitment manager alerts, private-booking summary and weekly rota alert.
+- Immediate: private enquiries, rejected shifts, completed onboarding, private-event outcome requests, payroll earnings alerts, open-shift requests and guest feedback.
+- Other streams retain their existing policy, including daily urgent unfilled-shift alerts, birthdays, pre-order escalation, parking and website failure fallback.
+- Staff/candidate/customer emails continue normally. Only manager alerts or copies are consolidated.
+- Use 09:00 Europe/London on Friday as the scheduling assumption. No synthetic/test email may be sent to a real recipient.
+- Preserve all existing unrelated changes using isolated worktree codex/friday-manager-report.
+- Complexity 4: stage 1 adds inactive queue/report support; stage 2 connects sources and scheduling. Each stage remains independently deployable.
+
+## Task 1: Durable queue and Friday delivery
+
+Files: src/lib/manager-report/{types,queue,delivery}.ts; src/app/api/cron/manager-weekly-report/route.ts; matching tests.
+
+Interfaces: queueManagerReportEmail(input: ManagerReportInput) returns Promise<ManagerReportQueueResult>. Sections are table_bookings, staff_shift_reminders, holiday_reminders, checklist_alerts, checklist_summary, recruitment, private_bookings, rota. Renderer accepts entries and report period and returns subject/html/text.
+
+- [x] Read live schema and constraints, reuse existing queued state without schema mutation.
+- [x] Prove queue insert deduplication and failure handling with mocked database and provider.
+- [x] Freeze report payload and membership before sending, use a stable Resend idempotency key, acquire an atomic lease and never lose unsent items after failure.
+- [x] Test empty week, Friday London/DST boundaries, concurrent runs, failed sends and send-success/database-failure retry.
+- [x] Run focused checks and commit inactive foundation once integration interfaces agree. Foundation commit: 8554972c.
+
+## Task 2: Summary rendering and sources
+
+Files: src/lib/manager-report/render.ts and tests; table-booking manager helper; recruitment communication helper; leave reminder cron; rota acceptance/manager cron; checklist outbox and summary routes; private-booking weekly sender and cron; vercel.json.
+
+- [x] Render each approved category with counts, concise entries and existing management links, and label snapshot dates.
+- [x] Queue selected manager messages with stable source keys and truthful queued state; preserve immediate paths.
+- [x] Send staff shift warnings to staff without manager CC; retain a separately queued summary record with employee/shift details.
+- [x] Prepare private/rota/checklist snapshots on Friday before the 09:00 report and remove their separate sends.
+- [x] Ensure old pending checklist manager rows also go to the digest while Peter's technical alerts remain immediate.
+- [x] Test selected paths cannot send immediate manager mail and protected immediate paths remain intact.
+
+## Task 3: Verification and release
+
+- [ ] Run lint, typecheck, relevant tests in London and UTC, full tests and a clean build.
+- [x] Render a synthetic report and inspect its contents without sending. Automated HTML checks passed; browser layout inspection was blocked by the URL policy.
+- [x] Review every changed path against scope, including paired website compatibility.
+- [ ] Record exact validation and local/deployment status; carry approved changes through release where authorised.
+
+## Checks to run
+
+```sh
+npm run lint
+npx tsc --noEmit
+npx vitest run src/lib/manager-report tests
+npm test
+npm run build
+```
+
+Tests inject database and email transport substitutes. Production verification reads configuration and logs only; the Friday report is not invoked manually to generate a test send.
+
+## Verification record
+
+- Full suite: 729 files passed, 6,274 tests passed and two existing skips before the final staff retry refinement. The full coverage run includes that refinement.
+- Report rendering, delivery and snapshot checks: 56 tests passed under UTC. Source and customer regression checks: 109 tests passed under London and UTC before the final staff retry refinement.
+- Whole-source ESLint passed with zero warnings. Full uncached TypeScript check passed before the final staff retry refinement; the production build repeats it.
+- Synthetic HTML and text previews generated without database or provider calls. All eight sections, management links, escaped text, complete attachment and invalid-value checks passed. Browser visual inspection was blocked by the browser URL policy; no workaround was attempted.
+- First production build compiled but reached Node's default heap limit during type checking. Re-run uses the project's CI memory allowance.
+- Paired website checked: its enquiry fallback and customer notification contract need no changes.
+- No production database writes, emails or migrations were used for verification.
+
+## Source files changed
+
+- New report foundation: `src/lib/manager-report/types.ts`, `queue.ts`, `schedule.ts`, `delivery.ts`, `render.ts` and `src/app/api/cron/manager-weekly-report/route.ts`.
+- Source routing: `src/lib/table-bookings/bookings.ts`, `src/lib/recruitment/communications.ts`, `src/lib/checklists/jobs/outbox.ts`, `src/lib/private-bookings/manager-notifications.ts`.
+- Cron routing: `src/app/api/cron/leave-approval-reminders/route.ts`, `rota-shift-acceptance/route.ts`, `rota-manager-alert/route.ts`, `private-bookings-weekly-summary/route.ts`, `checklists-weekly-summary/route.ts`.
+- Scheduling: `vercel.json`. Matching tests, synthetic preview script, operations guide and task records accompany these changes.
+
+## Deliberately retained
+
+Immediate private enquiries and private-event outcome sends in `manager-notifications.ts` remain unchanged. Rejected shifts, onboarding completion, payroll threshold alerts, open-shift requests and guest feedback keep their existing senders. The urgent unfilled-shift cron, customer/applicant emails, website fallback and original working directory's unrelated changes are untouched.
+
+- Final staff isolation and original-date rendering checks: 21 tests passed in London and 21 in UTC.
+- Production build completed successfully with the CI memory allowance; all 154 static pages generated.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,12 @@
+# Friday manager report, 5 September 2026
+
+Detailed plan: [Friday manager report](./plan-2026-09-05-friday-manager-report.md).
+
+- [x] Discover existing manager emails and record the owner's timing decisions.
+- [x] Implement the report queue, renderer and protected delivery route without a migration.
+- [x] Connect selected manager notifications and Friday snapshots.
+- [ ] Complete regression checks and release verification.
+
 # Nav pills: make every pill a clearable to-do
 
 Goal: a pill means "there is something here you can action now", and working

--- a/tests/api/leaveApprovalRemindersCron.test.ts
+++ b/tests/api/leaveApprovalRemindersCron.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({ db: vi.fn(), queue: vi.fn(), send: vi.fn(), auth: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: mocks.db }))
+vi.mock('@/lib/manager-report/queue', () => ({ queueManagerReportEmail: mocks.queue }))
+vi.mock('@/lib/email/emailService', () => ({ sendEmail: mocks.send }))
+vi.mock('@/lib/cron-auth', () => ({ authorizeCronRequest: mocks.auth }))
+vi.mock('@/app/actions/rota-settings', () => ({ getRotaSettings: async () => ({ managerEmail: 'rota-manager@example.com' }) }))
+import { GET } from '@/app/api/cron/leave-approval-reminders/route'
+
+const request = () => new NextRequest('https://example.test/api/cron/leave-approval-reminders')
+
+describe('holiday approval report source', () => {
+  const insert = vi.fn()
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-05T10:00:00Z'))
+    mocks.auth.mockReturnValue({ authorized: true })
+    mocks.queue.mockResolvedValue({ success: true, queued: true })
+    mocks.db.mockReturnValue({ from: (table: string) => {
+      if (table === 'leave_requests') return { select: () => ({ eq: async () => ({ data: [{
+        id: 'leave-1', employee_id: 'employee-1', start_date: '2026-10-20', end_date: '2026-10-22',
+        created_at: '2026-09-01T10:00:00Z', status: 'pending',
+      }], error: null }) }) }
+      if (table === 'leave_reminder_log') return { select: async () => ({ data: [], error: null }), insert }
+      if (table === 'employees') return { select: () => ({ in: async () => ({ data: [{ employee_id: 'employee-1', first_name: 'Alex', last_name: 'Rowe' }], error: null }) }) }
+      throw new Error(`Unexpected table ${table}`)
+    } })
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it('queues a stable reminder and writes no delivery ledger before the Friday send', async () => {
+    const result = await (await GET(request())).json()
+    expect(result).toMatchObject({ sent: 0, queued: 1, errors: [] })
+    expect(mocks.queue).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'holiday_reminders', key: 'leave-1:waiting', to: 'rota-manager@example.com',
+      metadata: expect.objectContaining({ leave_request_id: 'leave-1', leave_reminder_kind: 'waiting' }),
+    }))
+    expect(insert).not.toHaveBeenCalled()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('retries queue failure on the next run without consuming the reminder', async () => {
+    mocks.queue.mockResolvedValueOnce({ success: false, error: 'queue unavailable' })
+    const first = await (await GET(request())).json()
+    const second = await (await GET(request())).json()
+    expect(first).toMatchObject({ sent: 0, queued: 0, errors: ['Queue failed for leave-1: queue unavailable'] })
+    expect(second).toMatchObject({ sent: 0, queued: 1, errors: [] })
+    expect(mocks.queue.mock.calls.map(([input]) => input.key)).toEqual(['leave-1:waiting', 'leave-1:waiting'])
+    expect(insert).not.toHaveBeenCalled()
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/managerReportSnapshots.test.ts
+++ b/tests/api/managerReportSnapshots.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(), db: vi.fn(), settings: vi.fn(), queue: vi.fn(), recipient: vi.fn(), unfilled: vi.fn(),
+}))
+vi.mock('@/lib/cron-auth', () => ({ authorizeCronRequest: mocks.auth }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: mocks.db }))
+vi.mock('@/lib/checklists/settings', () => ({ getChecklistSettings: mocks.settings }))
+vi.mock('@/lib/manager-report/queue', () => ({ queueManagerReportEmail: mocks.queue }))
+vi.mock('@/lib/rota/manager-email', () => ({ resolveRotaManagerEmail: mocks.recipient }))
+vi.mock('@/lib/rota/unfilled-shifts', async (original) => ({
+  ...await original<typeof import('@/lib/rota/unfilled-shifts')>(), getUnfilledShifts: mocks.unfilled,
+}))
+
+import { GET as checklistSnapshot } from '@/app/api/cron/checklists-weekly-summary/route'
+import { GET as rotaSnapshot } from '@/app/api/cron/rota-manager-alert/route'
+
+function fakeDb(failedTable?: string) {
+  const from = vi.fn((table: string) => {
+    const result = { data: [], count: 0, error: table === failedTable ? { message: 'Database unavailable' } : null }
+    const query: Record<string, unknown> = {
+      then: (resolve: (value: typeof result) => unknown) => Promise.resolve(result).then(resolve),
+    }
+    for (const method of ['select', 'gte', 'lt', 'lte', 'not', 'eq', 'in', 'order']) {
+      query[method] = vi.fn(() => query)
+    }
+    return query
+  })
+  return { from }
+}
+
+const request = () => new Request('https://management.orangejelly.co.uk/api/cron/test')
+
+describe('Friday manager report snapshots', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-11T07:00:00Z'))
+    mocks.auth.mockReturnValue({ authorized: true })
+    mocks.db.mockReturnValue(fakeDb())
+    mocks.settings.mockResolvedValue({ moduleEnabled: true, emailsEnabled: true })
+    mocks.queue.mockResolvedValue({ success: true, queued: true })
+    mocks.recipient.mockResolvedValue({ email: 'manager@the-anchor.pub' })
+    mocks.unfilled.mockResolvedValue({ shifts: [], failures: [] })
+  })
+  afterEach(() => vi.useRealTimers())
+
+  it.each([checklistSnapshot, rotaSnapshot])('rejects unauthorised access before reading data', async (route) => {
+    mocks.auth.mockReturnValue({ authorized: false })
+    expect((await route(request())).status).toBe(401)
+    expect(mocks.db).not.toHaveBeenCalled()
+    expect(mocks.queue).not.toHaveBeenCalled()
+  })
+
+  it.each(['2026-09-07T07:00:00Z', '2026-09-11T08:00:00Z'])('does not run at old Monday time or Friday send time: %s', async (time) => {
+    vi.setSystemTime(new Date(time))
+    await checklistSnapshot(request())
+    await rotaSnapshot(request())
+    expect(mocks.queue).not.toHaveBeenCalled()
+    expect(mocks.db).not.toHaveBeenCalled()
+  })
+
+  it.each(['2026-03-27T08:00:00Z', '2026-04-03T07:00:00Z', '2026-10-30T08:00:00Z'])('prepares both snapshots at 08:00 London across DST: %s', async (time) => {
+    vi.setSystemTime(new Date(time))
+    expect((await checklistSnapshot(request())).status).toBe(200)
+    expect((await rotaSnapshot(request())).status).toBe(200)
+    expect(mocks.queue.mock.calls.map(([input]) => input.section)).toEqual(['checklist_summary', 'rota'])
+    expect(mocks.queue.mock.calls.every(([input]) => input.to === 'manager@the-anchor.pub')).toBe(true)
+  })
+
+  it('does not turn missing checklist data into an all-clear summary', async () => {
+    mocks.db.mockReturnValue(fakeDb('checklist_task_instances'))
+    expect((await checklistSnapshot(request())).status).toBe(500)
+    expect(mocks.queue).not.toHaveBeenCalled()
+  })
+
+  it('respects the checklist email switch', async () => {
+    mocks.settings.mockResolvedValue({ moduleEnabled: true, emailsEnabled: false })
+    await checklistSnapshot(request())
+    expect(mocks.queue).not.toHaveBeenCalled()
+  })
+
+  it('reports queue failure rather than claiming either summary was sent', async () => {
+    mocks.queue.mockResolvedValue({ success: false, error: 'Queue unavailable' })
+    expect((await checklistSnapshot(request())).status).toBe(500)
+    const rota = await rotaSnapshot(request())
+    expect(rota.status).toBe(500)
+    expect(await rota.json()).toMatchObject({ emailSent: false, queued: false, action: 'queue_failed' })
+  })
+})

--- a/tests/api/privateBookingsWeeklySummaryRoute.test.ts
+++ b/tests/api/privateBookingsWeeklySummaryRoute.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/lib/api/idempotency', () => ({
 }))
 
 vi.mock('@/lib/private-bookings/manager-notifications', () => ({
-  sendManagerPrivateBookingsWeeklyDigestEmail: vi.fn(),
+  queueManagerPrivateBookingsWeeklyDigestEmail: vi.fn(),
 }))
 
 vi.mock('@/services/audit', () => ({
@@ -45,7 +45,7 @@ import {
   persistIdempotencyResponse,
   releaseIdempotencyClaim,
 } from '@/lib/api/idempotency'
-import { sendManagerPrivateBookingsWeeklyDigestEmail } from '@/lib/private-bookings/manager-notifications'
+import { queueManagerPrivateBookingsWeeklyDigestEmail } from '@/lib/private-bookings/manager-notifications'
 import { GET } from '@/app/api/cron/private-bookings-weekly-summary/route'
 
 function createSupabaseMock() {
@@ -147,8 +147,8 @@ describe('private-bookings weekly summary cron route', () => {
     ;(claimIdempotencyKey as unknown as vi.Mock).mockResolvedValue({ state: 'claimed' })
     ;(persistIdempotencyResponse as unknown as vi.Mock).mockResolvedValue(undefined)
     ;(releaseIdempotencyClaim as unknown as vi.Mock).mockResolvedValue(undefined)
-    ;(sendManagerPrivateBookingsWeeklyDigestEmail as unknown as vi.Mock).mockResolvedValue({
-      sent: true,
+    ;(queueManagerPrivateBookingsWeeklyDigestEmail as unknown as vi.Mock).mockResolvedValue({
+      queued: true,
       actionCount: 3,
       eventCount: 2,
     })
@@ -162,9 +162,9 @@ describe('private-bookings weekly summary cron route', () => {
     expect(createAdminClient).not.toHaveBeenCalled()
   })
 
-  it('skips outside the 9am London window unless forced', async () => {
+  it('skips outside the 8am London window unless forced', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-23T07:00:00.000Z')) // Monday but 7am, not 9am
+    vi.setSystemTime(new Date('2026-03-27T07:00:00.000Z')) // Friday but 7am, not 8am
     ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
 
     try {
@@ -183,23 +183,23 @@ describe('private-bookings weekly summary cron route', () => {
     }
   })
 
-  it('skips on non-Monday unless forced', async () => {
+  it('skips on non-Friday unless forced', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-25T09:00:00.000Z')) // Wednesday
+    vi.setSystemTime(new Date('2026-03-25T08:00:00.000Z')) // Wednesday
     ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
 
     try {
       const response = await GET(new Request('http://localhost/api/cron/private-bookings-weekly-summary') as any)
       const payload = await response.json()
-      expect(payload).toMatchObject({ skipped: true, reason: 'not_monday' })
+      expect(payload).toMatchObject({ skipped: true, reason: 'not_friday' })
     } finally {
       vi.useRealTimers()
     }
   })
 
-  it('sends digest on non-Monday when force=true', async () => {
+  it('queues summary on non-Friday when force=true', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-25T09:00:00.000Z')) // Wednesday
+    vi.setSystemTime(new Date('2026-03-25T08:00:00.000Z')) // Wednesday
     ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
     ;(createAdminClient as unknown as vi.Mock).mockReturnValue(createSupabaseMock())
 
@@ -208,15 +208,15 @@ describe('private-bookings weekly summary cron route', () => {
         new Request('http://localhost/api/cron/private-bookings-weekly-summary?force=true') as any
       )
       const payload = await response.json()
-      expect(payload).toMatchObject({ success: true, sent: true })
+      expect(payload).toMatchObject({ success: true, queued: true })
     } finally {
       vi.useRealTimers()
     }
   })
 
-  it('sends the digest and persists idempotency response during the 9am Monday window', async () => {
+  it('queues the summary and persists idempotency response during the 8am Friday window', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-23T09:00:00.000Z')) // Monday 9am GMT
+    vi.setSystemTime(new Date('2026-03-27T08:00:00.000Z')) // Friday 8am GMT
     ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
     ;(createAdminClient as unknown as vi.Mock).mockReturnValue(createSupabaseMock())
 
@@ -227,12 +227,12 @@ describe('private-bookings weekly summary cron route', () => {
       expect(response.status).toBe(200)
       expect(payload).toMatchObject({
         success: true,
-        sent: true,
-        londonDate: '2026-03-23',
+        queued: true,
+        londonDate: '2026-03-27',
         events: 2,
         actions: 3,
       })
-      expect(sendManagerPrivateBookingsWeeklyDigestEmail).toHaveBeenCalledTimes(1)
+      expect(queueManagerPrivateBookingsWeeklyDigestEmail).toHaveBeenCalledTimes(1)
       expect(persistIdempotencyResponse).toHaveBeenCalledTimes(1)
       expect(releaseIdempotencyClaim).not.toHaveBeenCalled()
     } finally {
@@ -240,14 +240,14 @@ describe('private-bookings weekly summary cron route', () => {
     }
   })
 
-  it('releases idempotency claim when email send fails', async () => {
+  it('releases idempotency claim when summary queue fails', async () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-03-23T09:00:00.000Z')) // Monday 9am GMT
+    vi.setSystemTime(new Date('2026-03-27T08:00:00.000Z')) // Friday 8am GMT
     ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
     const supabase = createSupabaseMock()
     ;(createAdminClient as unknown as vi.Mock).mockReturnValue(supabase)
-    ;(sendManagerPrivateBookingsWeeklyDigestEmail as unknown as vi.Mock).mockResolvedValueOnce({
-      sent: false,
+    ;(queueManagerPrivateBookingsWeeklyDigestEmail as unknown as vi.Mock).mockResolvedValueOnce({
+      queued: false,
       error: 'smtp down',
       actionCount: 3,
       eventCount: 2,
@@ -259,7 +259,7 @@ describe('private-bookings weekly summary cron route', () => {
       expect(response.status).toBe(500)
       expect(releaseIdempotencyClaim).toHaveBeenCalledWith(
         supabase,
-        'cron:private-bookings-weekly-summary:2026-03-23',
+        'cron:private-bookings-weekly-summary:2026-03-27',
         'hash-1'
       )
       expect(persistIdempotencyResponse).not.toHaveBeenCalled()

--- a/tests/api/rotaShiftAcceptanceCron.test.ts
+++ b/tests/api/rotaShiftAcceptanceCron.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const createAdminClientMock = vi.fn()
 const sendEmailMock = vi.fn()
+const queueManagerReportEmailMock = vi.fn()
 const authorizeCronRequestMock = vi.fn()
 
 vi.mock('@/lib/supabase/admin', () => ({
@@ -10,6 +11,10 @@ vi.mock('@/lib/supabase/admin', () => ({
 
 vi.mock('@/lib/email/emailService', () => ({
   sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+}))
+
+vi.mock('@/lib/manager-report/queue', () => ({
+  queueManagerReportEmail: (...args: unknown[]) => queueManagerReportEmailMock(...args),
 }))
 
 vi.mock('@/lib/cron-auth', () => ({
@@ -56,6 +61,31 @@ function makeSystemSettings(email: string | null = 'manager@the-anchor.pub') {
   }
 }
 
+function makeWarningLog(insert = vi.fn().mockResolvedValue({ error: null }), rows: Array<Record<string, unknown>> = []) {
+  const query: Record<string, unknown> = {};
+  for (const method of ['select', 'eq', 'like', 'order']) query[method] = vi.fn(() => query);
+  query.limit = vi.fn(async () => ({ data: rows.filter(row => String(row.error_message).startsWith('manager-report-retry:')), error: null }));
+  return {
+    ...query,
+    insert,
+    upsert: vi.fn(async (row: Record<string, unknown>) => {
+      if (!rows.some(existing => existing.id === row.id)) rows.push({ ...row });
+      return { error: null };
+    }),
+    update: vi.fn((patch: Record<string, unknown>) => {
+      let rowId: unknown;
+      const updateQuery = {
+        eq: vi.fn((field: string, value: unknown) => { if (field === 'id') rowId = value; return updateQuery; }),
+        like: vi.fn(async () => {
+          for (const row of rows) if (row.id === rowId) Object.assign(row, patch);
+          return { error: null };
+        }),
+      };
+      return updateQuery;
+    }),
+  };
+}
+
 describe('/api/cron/rota-shift-acceptance', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -63,6 +93,7 @@ describe('/api/cron/rota-shift-acceptance', () => {
     vi.setSystemTime(new Date('2026-06-01T00:00:00Z'))
     authorizeCronRequestMock.mockReturnValue({ authorized: true })
     sendEmailMock.mockResolvedValue({ success: true, messageId: 'email-1' })
+    queueManagerReportEmailMock.mockResolvedValue({ success: true, queued: true })
   })
 
   afterEach(() => {
@@ -158,7 +189,7 @@ describe('/api/cron/rota-shift-acceptance', () => {
         }
 
         if (table === 'rota_email_log') {
-          return { insert: emailLogInsert }
+          return makeWarningLog(emailLogInsert)
         }
 
         if (table === 'audit_logs') {
@@ -177,15 +208,24 @@ describe('/api/cron/rota-shift-acceptance', () => {
     expect(payload.autoAccepted).toBe(1)
     expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({
       to: 'alex@example.com',
-      cc: ['manager@the-anchor.pub'],
+
     }))
+    expect(sendEmailMock.mock.calls[0][0]).not.toHaveProperty('cc')
+    expect(queueManagerReportEmailMock).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'staff_shift_reminders',
+      key: 'employee-1:shift-warning',
+      to: 'manager@the-anchor.pub',
+      subject: expect.stringContaining('Alex'),
+      html: expect.stringContaining('09:00'),
+    }))
+    expect(payload.managerCopiesQueued).toBe(1)
     expect(rotaPublishedUpdate).toHaveBeenCalledWith(expect.objectContaining({
       acceptance_status: 'auto_accepted',
       acceptance_decided_by: 'employee-2',
     }))
     expect(emailLogInsert).toHaveBeenCalledWith(expect.objectContaining({
       email_type: 'shift_auto_accept_warning',
-      cc_addresses: ['manager@the-anchor.pub'],
+      cc_addresses: [],
     }))
     expect(auditLogInsert).toHaveBeenCalledWith(expect.objectContaining({
       operation_type: 'auto_accept',
@@ -258,7 +298,7 @@ describe('/api/cron/rota-shift-acceptance', () => {
         }
 
         if (table === 'rota_email_log') {
-          return { insert: vi.fn().mockResolvedValue({ error: null }) }
+          return makeWarningLog()
         }
 
         if (table === 'audit_logs') {
@@ -337,8 +377,8 @@ describe('/api/cron/rota-shift-acceptance', () => {
             }
           }
           if (table === 'rota_shifts') return { update: rotaShiftsUpdate }
-          if (table === 'rota_email_log') return { insert: vi.fn().mockResolvedValue({ error: null }) }
-          if (table === 'audit_logs') return { insert: vi.fn().mockResolvedValue({ error: null }) }
+          if (table === 'rota_email_log') return makeWarningLog()
+          if (table === 'audit_logs') return makeWarningLog()
           throw new Error(`Unexpected table: ${table}`)
         }),
       })
@@ -415,8 +455,8 @@ describe('/api/cron/rota-shift-acceptance', () => {
           }
         }
         if (table === 'rota_shifts') return { update: vi.fn(() => makeEqUpdateSelect(2, { data: { id: 'shift-on-time' }, error: null })) }
-        if (table === 'rota_email_log') return { insert: vi.fn().mockResolvedValue({ error: null }) }
-        if (table === 'audit_logs') return { insert: vi.fn().mockResolvedValue({ error: null }) }
+        if (table === 'rota_email_log') return makeWarningLog()
+        if (table === 'audit_logs') return makeWarningLog()
         throw new Error(`Unexpected table: ${table}`)
       }),
     })
@@ -426,4 +466,67 @@ describe('/api/cron/rota-shift-acceptance', () => {
     expect(payload.autoAccepted).toBe(1)
     expect(payload.heldForLatePublishGrace).toBe(0)
   })
+  it.each(['queue failure', 'same mailbox', 'shared mailbox queue failure', 'retry storage failure'])('keeps staff and manager delivery independent after %s', async (scenario) => {
+    if (scenario.includes('failure')) queueManagerReportEmailMock.mockResolvedValue({ success: false, error: 'queue unavailable' })
+    const shift = {
+      id: 'shift-warning', week_id: 'week-1', employee_id: 'employee-1', shift_date: '2026-06-16',
+      start_time: '09:00', end_time: '17:00', department: 'bar', name: 'Bar', auto_accept_warning_sent_at: null,
+    }
+    const update = vi.fn(() => ({ in: vi.fn().mockResolvedValue({ error: null }) }))
+    const insert = vi.fn().mockResolvedValue({ error: null })
+    const retryRows: Array<Record<string, unknown>> = []
+    const log = makeWarningLog(insert, retryRows)
+    if (scenario === 'retry storage failure') log.upsert.mockRejectedValueOnce(new Error('Database unavailable'))
+    const shiftQuery: Record<string, unknown> = {}
+    for (const method of ['select', 'eq', 'not', 'lte']) shiftQuery[method] = vi.fn(() => shiftQuery)
+    shiftQuery.order = vi.fn().mockReturnValueOnce(shiftQuery).mockResolvedValueOnce({ data: [shift], error: null })
+    createAdminClientMock.mockReturnValue({ from: (table: string) => {
+      if (table === 'system_settings') return makeSystemSettings()
+      if (table === 'rota_published_shifts') return { ...shiftQuery, update }
+      if (table === 'employees') return { select: () => ({ in: async () => ({ data: [{
+        employee_id: 'employee-1', first_name: 'Alex', last_name: 'Rowe',
+        email_address: scenario.includes('mailbox') ? ' MANAGER@the-anchor.pub ' : 'alex@example.com',
+      }], error: null }) }) }
+      if (table === 'rota_shifts') return { update }
+      if (table === 'rota_email_log') return log
+      throw new Error(`Unexpected table ${table}`)
+    } })
+    const response = await GET(new Request('https://example.test/api/cron/rota-shift-acceptance'))
+    const payload = await response.json()
+    if (!scenario.includes('mailbox')) {
+      expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({ to: 'alex@example.com' }))
+      expect(sendEmailMock.mock.calls[0][0]).not.toHaveProperty('cc')
+      expect(insert).toHaveBeenCalledWith(expect.objectContaining({ status: 'sent', cc_addresses: [] }))
+      expect(update).toHaveBeenCalledWith(expect.objectContaining({ auto_accept_warning_sent_at: expect.any(String) }))
+      expect(payload.warningEmailsSent).toBe(1)
+    } else {
+      expect(sendEmailMock).not.toHaveBeenCalled()
+      expect(insert).not.toHaveBeenCalled()
+      expect(update).not.toHaveBeenCalled()
+      expect(payload.warningEmailsSent).toBe(0)
+    }
+    expect(payload.managerCopiesFailed).toBe(scenario.includes('failure') ? 1 : 0)
+    expect(payload.managerCopiesQueued).toBe(scenario === 'same mailbox' ? 1 : 0)
+    expect(payload.managerRetryStorageErrors).toBe(scenario === 'retry storage failure' ? 1 : 0)
+    expect(response.status).toBe(scenario === 'retry storage failure' ? 500 : 200)
+    if (scenario.includes('queue failure')) {
+      expect(log.upsert).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'failed', to_addresses: ['manager@the-anchor.pub'], cc_addresses: [],
+        error_message: expect.stringContaining('manager-report-retry:'),
+      }), expect.any(Object))
+      // The shift can leave the pending scan after acceptance, reassignment or deletion.
+      // Its saved manager payload must still be recovered without another staff send.
+      const originalQueuedInput = queueManagerReportEmailMock.mock.calls[0][0]
+      queueManagerReportEmailMock.mockResolvedValue({ success: true, queued: true })
+      sendEmailMock.mockClear()
+      shiftQuery.order = vi.fn().mockReturnValueOnce(shiftQuery).mockResolvedValueOnce({ data: [], error: null })
+      const retryResponse = await GET(new Request('https://example.test/api/cron/rota-shift-acceptance'))
+      const retryPayload = await retryResponse.json()
+      expect(sendEmailMock).not.toHaveBeenCalled()
+      expect(queueManagerReportEmailMock).toHaveBeenLastCalledWith(originalQueuedInput)
+      expect(retryPayload).toMatchObject({ warningEmailsSent: 0, managerCopiesQueued: 1, managerRetryStorageErrors: 0 })
+      expect(retryRows[0]).toMatchObject({ status: 'failed', error_message: 'Manager report collection recovered; entry queued for Friday delivery.' })
+    }
+  })
+
 })

--- a/tests/lib/manager-report/delivery.test.ts
+++ b/tests/lib/manager-report/delivery.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { deliverManagerReport } from '@/lib/manager-report/delivery'
+import { queueManagerReportEmail } from '@/lib/manager-report/queue'
+import { managerReportPeriod } from '@/lib/manager-report/schedule'
+import type { createAdminClient } from '@/lib/supabase/admin'
+import type { EmailOptions } from '@/lib/email/emailService'
+
+const mocks = vi.hoisted(() => ({ admin: vi.fn() }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: mocks.admin }))
+vi.mock('@/lib/email/emailService', () => ({ sendEmail: vi.fn(() => { throw new Error('No real transport allowed') }) }))
+vi.mock('@/lib/manager-report/render', () => ({
+  renderManagerReport: ({ entries }: { entries: { subject: string }[] }) => ({
+    subject: `Weekly report: ${entries.length}`, html: entries.map(e => e.subject).join('<br>'),
+    text: entries.map(e => e.subject).join('\n'),
+    attachment: { filename: 'details.html', contentType: 'text/html', content: '<p>All details</p>' },
+  }),
+}))
+
+type Row = Record<string, unknown>
+interface Failure { table: string; operation: string; matches?: (payload: Row) => boolean }
+class MemoryDb {
+  rows: Record<string, Row[]> = { email_messages: [], cron_job_runs: [], recruitment_communications: [], checklist_email_outbox: [], leave_reminder_log: [] }
+  failures: Failure[] = []
+  calls: { table: string; operation: string; payload: Row }[] = []
+  from = (table: string): MemoryQuery => new MemoryQuery(this, table)
+  asDb(): ReturnType<typeof createAdminClient> { return this as unknown as ReturnType<typeof createAdminClient> }
+}
+class MemoryQuery implements PromiseLike<{ data: Row[] | Row | null; error: { code?: string; message: string } | null }> {
+  operation = 'select'; payload: Row = {}; filters: ((row: Row) => boolean)[] = []
+  max = Infinity; singleResult = false; ignore = false; conflict = 'id'; sort = ''
+  constructor(private db: MemoryDb, private table: string) {}
+  select(): this { return this }
+  insert(row: Row): this { this.operation = 'insert'; this.payload = row; return this }
+  upsert(row: Row, options: { ignoreDuplicates?: boolean; onConflict?: string } = {}): this {
+    this.operation = 'upsert'; this.payload = row; this.ignore = options.ignoreDuplicates ?? false; this.conflict = options.onConflict ?? 'id'; return this
+  }
+  update(row: Row): this { this.operation = 'update'; this.payload = row; return this }
+  eq(key: string, value: unknown): this { this.filters.push(row => row[key] === value); return this }
+  gt(key: string, value: string): this { this.filters.push(row => String(row[key]) > value); return this }
+  lte(key: string, value: string): this { this.filters.push(row => String(row[key]) <= value); return this }
+  in(key: string, values: unknown[]): this { this.filters.push(row => values.includes(row[key])); return this }
+  order(key: string): this { this.sort = key; return this }
+  limit(value: number): this { this.max = value; return this }
+  single(): this { this.singleResult = true; return this }
+  maybeSingle(): this { this.singleResult = true; return this }
+  then<TResult1 = { data: Row[] | Row | null; error: { code?: string; message: string } | null }, TResult2 = never>(
+    onfulfilled?: ((value: { data: Row[] | Row | null; error: { code?: string; message: string } | null }) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve().then(() => {
+      this.db.calls.push({ table: this.table, operation: this.operation, payload: structuredClone(this.payload) })
+      const failIndex = this.db.failures.findIndex(f => f.table === this.table && f.operation === this.operation && (!f.matches || f.matches(this.payload)))
+      if (failIndex >= 0) {
+        this.db.failures.splice(failIndex, 1)
+        return { data: null, error: { message: 'Injected database failure' } }
+      }
+      const rows = this.db.rows[this.table]
+      let results: Row[]
+      if (this.operation === 'insert' || this.operation === 'upsert') {
+        const duplicate = rows.find(row => this.table === 'cron_job_runs'
+          ? row.job_name === this.payload.job_name && row.run_key === this.payload.run_key
+          : this.conflict.split(',').every(key => row[key] === this.payload[key]))
+        if (duplicate && this.operation === 'insert') return { data: null, error: { code: '23505', message: 'Duplicate' } }
+        if (duplicate) {
+          if (!this.ignore) Object.assign(duplicate, structuredClone(this.payload))
+          results = this.ignore ? [] : [duplicate]
+        } else {
+          const row = { id: `generated-${rows.length}`, created_at: '2026-09-04T07:00:00.000Z', ...structuredClone(this.payload) }
+          rows.push(row); results = [row]
+        }
+      } else {
+        results = rows.filter(row => this.filters.every(filter => filter(row)))
+        if (this.operation === 'update') for (const row of results) Object.assign(row, structuredClone(this.payload))
+        if (this.sort) results.sort((a, b) => String(a[this.sort]).localeCompare(String(b[this.sort])))
+        results = results.slice(0, this.max)
+      }
+      return { data: structuredClone(this.singleResult ? results[0] ?? null : results), error: null }
+    }).then(onfulfilled, onrejected)
+  }
+}
+
+let db: MemoryDb
+let date: Date
+let send: ReturnType<typeof vi.fn<(options: EmailOptions) => Promise<{ success: boolean; messageId?: string; error?: string }>>>
+function run() { return deliverManagerReport({ db: db.asDb(), send, now: () => date }) }
+async function queue(key = 'booking-1', metadata?: Row, to = 'manager@example.test') {
+  return queueManagerReportEmail({ section: 'table_bookings', key, to, subject: `Booking ${key}`, html: '<p>Booking</p>', metadata })
+}
+const reportRows = () => db.rows.email_messages.filter(row => row.comm_type === 'manager_weekly_report')
+const itemRows = () => db.rows.email_messages.filter(row => row.comm_type === 'manager_report_item')
+
+beforeEach(() => {
+  db = new MemoryDb(); date = new Date('2026-09-04T08:00:00Z')
+  send = vi.fn(async () => ({ success: true, messageId: 'provider-1' }))
+  mocks.admin.mockReturnValue(db.asDb())
+  vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://management.example.test')
+  vi.stubEnv('EMAIL_FROM_ADDRESS', 'reports@example.test')
+  vi.stubEnv('MANAGER_EMAIL', 'manager@example.test')
+})
+
+describe('manager report queue', () => {
+  it('atomically deduplicates recipient/source/section without resetting sent items', async () => {
+    const first = await queue()
+    itemRows()[0].status = 'sent'
+    const retry = await queue(undefined, undefined, ' Manager@Example.Test ')
+    expect(retry.emailMessageId).toBe(first.emailMessageId)
+    expect(itemRows()).toHaveLength(1)
+    expect(itemRows()[0].status).toBe('sent')
+    await queue('booking-1', undefined, 'other@example.test')
+    expect(itemRows()).toHaveLength(2)
+  })
+  it('reports persistence failure and invalid input truthfully', async () => {
+    db.failures.push({ table: 'email_messages', operation: 'upsert' })
+    expect(await queue()).toMatchObject({ success: false, error: 'Injected database failure' })
+    expect(await queue('')).toMatchObject({ success: false })
+    expect(await queue('bad-recipient', undefined, 'one@example.test,other.test')).toMatchObject({ success: false })
+    expect(itemRows()).toHaveLength(0)
+  })
+})
+
+describe('Friday local schedule', () => {
+  it.each([
+    ['2026-09-04T07:59:59Z', false], ['2026-09-04T08:00:00Z', true],
+    ['2026-01-02T08:59:59Z', false], ['2026-01-02T09:00:00Z', true],
+    ['2026-09-04T22:00:00Z', true], ['2026-09-04T23:00:00Z', false],
+    ['2026-09-05T09:00:00Z', false],
+  ])('%s has eligibility %s', (value, expected) => expect(Boolean(managerReportPeriod(new Date(value)))).toBe(expected))
+  it('keeps both report boundaries at 09:00 through the DST transition', () => {
+    expect(managerReportPeriod(new Date('2026-04-03T08:00:00Z'))).toMatchObject({
+      periodStart: '2026-03-27T09:00:00.000Z', periodEnd: '2026-04-03T08:00:00.000Z',
+    })
+  })
+})
+
+describe('durable delivery', () => {
+  it('skips outside Friday and sends an empty weekly report once', async () => {
+    date = new Date('2026-09-05T08:00:00Z')
+    expect(await run()).toMatchObject({ success: true, skipped: 'outside_friday_window' })
+    expect(db.calls).toHaveLength(0)
+    date = new Date('2026-09-04T08:00:00Z')
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+    expect(send.mock.calls[0][0].subject).toBe('Weekly report: 0')
+    await run()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+  it('sends one report per recipient, freezing sender, attachment and membership', async () => {
+    await queue('one'); await queue('two'); await queue('three', undefined, 'other@example.test')
+    expect(await run()).toMatchObject({ success: true, sent: 2 })
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[0][0]).toMatchObject({ provider: 'resend', from: 'reports@example.test',
+      attachments: [{ content: Buffer.from('<p>All details</p>').toString('base64') }] })
+    expect(itemRows().every(row => row.status === 'sent')).toBe(true)
+    expect(await run()).toMatchObject({ success: true, sent: 0 })
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+  it('paginates beyond the database page limit', async () => {
+    for (let i = 0; i < 1001; i++) await queue(`booking-${i}`)
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+    expect(send.mock.calls[0][0].subject).toBe('Weekly report: 1001')
+    expect(itemRows().filter(row => row.status === 'sent')).toHaveLength(1001)
+  })
+  it('excludes simultaneous attempts using the unique lease and CAS stale takeover', async () => {
+    await queue()
+    db.rows.cron_job_runs.push({ id: 'old-lock', job_name: 'manager-weekly-report', run_key: 'delivery', status: 'running', started_at: '2026-09-04T07:00:00Z' })
+    const results = await Promise.all([run(), run()])
+    expect(results.some(result => result.skipped === 'already_running')).toBe(true)
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+  it('retries provider failure with the identical immutable payload and keeps late arrivals for next week', async () => {
+    await queue('first')
+    send.mockResolvedValueOnce({ success: false, error: 'Provider unavailable' })
+    expect(await run()).toMatchObject({ success: false })
+    const firstPayload = structuredClone(send.mock.calls[0][0])
+    expect(itemRows()[0].status).toBe('queued')
+    await queue('late')
+    vi.stubEnv('EMAIL_FROM_ADDRESS', 'changed@example.test')
+    date = new Date('2026-09-04T09:00:00Z')
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+    expect(send.mock.calls[1][0]).toEqual(firstPayload)
+    expect(itemRows().filter(row => row.status === 'queued')).toHaveLength(1)
+    date = new Date('2026-09-11T08:00:00Z')
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+    expect(itemRows().every(row => row.status === 'sent')).toBe(true)
+  })
+  it('reuses the same provider key and payload after acceptance persistence fails', async () => {
+    await queue()
+    db.failures.push({ table: 'email_messages', operation: 'update', matches: payload => Boolean((payload.metadata as Row)?.acceptedAt) })
+    expect(await run()).toMatchObject({ success: false })
+    expect(itemRows()[0].status).toBe('queued')
+    date = new Date('2026-09-04T09:00:00Z')
+    expect(await run()).toMatchObject({ success: true })
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(send.mock.calls[1][0]).toEqual(send.mock.calls[0][0])
+  })
+  it('finalises recorded acceptance without calling provider again after item update failure', async () => {
+    await queue()
+    db.failures.push({ table: 'email_messages', operation: 'update', matches: payload => payload.status === 'sent' && !payload.metadata })
+    expect(await run()).toMatchObject({ success: false })
+    date = new Date('2026-09-11T08:00:00Z')
+    expect(await run()).toMatchObject({ success: true })
+    expect(send).toHaveBeenCalledTimes(2)
+    expect(itemRows()[0].status).toBe('sent')
+  })
+  it('blocks ambiguous sends outside the provider deduplication window, preserving backlog', async () => {
+    await queue()
+    send.mockResolvedValueOnce({ success: false, error: 'Network timeout' })
+    await run()
+    date = new Date('2026-09-11T08:00:00Z')
+    await queue('next-week')
+    expect(await run()).toMatchObject({ success: false, error: expect.stringContaining('needs provider reconciliation') })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(itemRows().every(row => row.status === 'queued')).toBe(true)
+  })
+  it('treats a provider id as acceptance even when the transport log reports failure', async () => {
+    await queue()
+    send.mockResolvedValueOnce({ success: false, messageId: 'accepted-provider-id', error: 'Logging failed' })
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+    expect(itemRows()[0].status).toBe('sent')
+    await run()
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+  it('does not send when the immutable payload could not be persisted', async () => {
+    await queue()
+    db.failures.push({ table: 'email_messages', operation: 'insert' })
+    expect(await run()).toMatchObject({ success: false })
+    expect(send).not.toHaveBeenCalled()
+    expect(itemRows()[0].status).toBe('queued')
+    expect(db.rows.cron_job_runs[0]).toMatchObject({ status: 'failed', error_message: 'Injected database failure' })
+    expect(await run()).toMatchObject({ success: true, sent: 1 })
+  })
+  it('retries source finalisation failure without sending the accepted payload again', async () => {
+    db.rows.checklist_email_outbox.push({ id: 'checklist', status: 'held' })
+    await queue('references', { checklist_outbox_id: 'checklist' })
+    db.failures.push({ table: 'checklist_email_outbox', operation: 'update' })
+    expect(await run()).toMatchObject({ success: false })
+    expect(itemRows()[0].status).toBe('queued')
+    expect(await run()).toMatchObject({ success: true })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(db.rows.checklist_email_outbox[0].status).toBe('sent')
+  })
+  it('finalises recruitment, checklist and holiday ledgers only after provider acceptance', async () => {
+    db.rows.recruitment_communications.push({ id: 'communication', delivery_status: 'queued' })
+    db.rows.checklist_email_outbox.push({ id: 'checklist', status: 'held' })
+    await queue('references', { communication_id: 'communication', checklist_outbox_id: 'checklist', leave_request_id: 'leave', leave_reminder_kind: 'pending' })
+    send.mockResolvedValueOnce({ success: false, error: 'Unavailable' })
+    await run()
+    expect(db.rows.leave_reminder_log).toHaveLength(0)
+    expect(db.rows.checklist_email_outbox[0].status).toBe('held')
+    expect(db.rows.recruitment_communications[0].delivery_status).toBe('queued')
+    expect(await run()).toMatchObject({ success: true })
+    expect(db.rows.leave_reminder_log[0]).toMatchObject({ request_id: 'leave', reminder_kind: 'pending', sent_to: ['manager@example.test'] })
+    expect(db.rows.checklist_email_outbox[0].status).toBe('sent')
+    expect(db.rows.recruitment_communications[0].delivery_status).toBe('sent')
+    expect(reportRows()[0].status).toBe('sent')
+  })
+})

--- a/tests/lib/manager-report/route.test.ts
+++ b/tests/lib/manager-report/route.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/cron/manager-weekly-report/route'
+
+const mocks = vi.hoisted(() => ({ deliver: vi.fn() }))
+vi.mock('@/lib/manager-report/delivery', () => ({ deliverManagerReport: mocks.deliver }))
+
+beforeEach(() => {
+  vi.stubEnv('CRON_SECRET', 'fixture-secret')
+  mocks.deliver.mockReset()
+})
+
+describe('manager report cron boundary', () => {
+  it('rejects unauthorised requests and a forged cron header before delivery', async () => {
+    const response = await GET(new Request('https://example.test/api/cron/manager-weekly-report', { headers: { 'x-vercel-cron': '1' } }))
+    expect(response.status).toBe(401)
+    expect(mocks.deliver).not.toHaveBeenCalled()
+  })
+  it('returns an explicit failure when dependency setup throws', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.deliver.mockRejectedValue(new Error('Missing configuration'))
+    const response = await GET(new Request('https://example.test/api/cron/manager-weekly-report', { headers: { authorization: 'Bearer fixture-secret' } }))
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({ success: false })
+    errorSpy.mockRestore()
+  })
+  it('returns delivery failure to the scheduler so it is visible and retryable', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    mocks.deliver.mockResolvedValue({ success: false, sent: 0, error: 'Fixture failure' })
+    const response = await GET(new Request('https://example.test/api/cron/manager-weekly-report', { headers: { authorization: 'Bearer fixture-secret' } }))
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({ success: false, error: 'Fixture failure' })
+    errorSpy.mockRestore()
+  })
+})

--- a/tests/lib/privateBookingWeeklyReportQueue.test.ts
+++ b/tests/lib/privateBookingWeeklyReportQueue.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ send: vi.fn(), queue: vi.fn() }))
+vi.mock('@/lib/email/emailService', () => ({ sendEmail: mocks.send }))
+vi.mock('@/lib/manager-report/queue', () => ({ queueManagerReportEmail: mocks.queue }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
+vi.mock('@/lib/guest/tokens', () => ({ createGuestToken: vi.fn() }))
+
+import {
+  queueManagerPrivateBookingsWeeklyDigestEmail,
+  sendManagerPrivateBookingCreatedEmail,
+} from '@/lib/private-bookings/manager-notifications'
+
+describe('private booking manager email policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.queue.mockResolvedValue({ success: true, queued: true })
+    mocks.send.mockResolvedValue({ success: true, messageId: 'provider-1' })
+  })
+
+  const input = {
+    runDateKey: '2026-09-11', weekLabel: 'snapshot Fri, 11 Sept 2026',
+    appBaseUrl: 'https://management.orangejelly.co.uk', events: [], pendingSmsCount: 0,
+    smsQueueUrl: 'https://management.orangejelly.co.uk/private-bookings/sms-queue',
+  }
+
+  it('queues even an empty weekly snapshot without sending another email', async () => {
+    expect(await queueManagerPrivateBookingsWeeklyDigestEmail(input)).toMatchObject({ queued: true, eventCount: 0 })
+    expect(mocks.send).not.toHaveBeenCalled()
+    expect(mocks.queue).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'private_bookings', key: '2026-09-11',
+      text: expect.stringContaining('Included in the Friday manager report'),
+    }))
+    expect(mocks.queue.mock.calls[0][0].text).not.toMatch(/Monday|undefined|Invalid Date|NaN/)
+  })
+
+  it('returns queue failure truthfully', async () => {
+    mocks.queue.mockResolvedValue({ success: false, error: 'Queue unavailable' })
+    expect(await queueManagerPrivateBookingsWeeklyDigestEmail(input)).toMatchObject({ queued: false, error: 'Queue unavailable' })
+    expect(mocks.send).not.toHaveBeenCalled()
+  })
+
+  it('still sends a new private enquiry immediately', async () => {
+    expect(await sendManagerPrivateBookingCreatedEmail({ booking: {
+      id: 'private-1', booking_reference: 'PB-1', customer_name: 'Example Guest',
+      event_date: '2026-09-12', start_time: '19:00', guest_count: 20,
+    } })).toEqual({ sent: true })
+    expect(mocks.send).toHaveBeenCalledWith(expect.objectContaining({ subject: 'New private booking enquiry: PB-1' }))
+    expect(mocks.queue).not.toHaveBeenCalled()
+  })
+})

--- a/tests/lib/recruitmentCommunications.test.ts
+++ b/tests/lib/recruitmentCommunications.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const sendEmail = vi.hoisted(() => vi.fn())
+const queueManagerReportEmail = vi.hoisted(() => vi.fn())
+vi.mock('@/lib/manager-report/queue', () => ({ queueManagerReportEmail }))
 const sendSMS = vi.hoisted(() => vi.fn())
 const draftRecruitmentEmail = vi.hoisted(() => vi.fn())
 
@@ -21,6 +23,7 @@ import {
   retryRecruitmentCommunication,
   sendRecruitmentApplicationReceivedEmail,
   sendRecruitmentSms,
+  sendRecruitmentManagerAlert,
   sendRecruitmentTemplateEmail,
 } from '@/lib/recruitment/communications'
 
@@ -105,8 +108,69 @@ const application = {
 describe('recruitment communications safety', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    queueManagerReportEmail.mockResolvedValue({ success: true, queued: true, emailMessageId: 'queue-1' })
     process.env.RECRUITMENT_FROM_EMAIL = 'peter@orangejelly.co.uk'
     process.env.RECRUITMENT_NOTIFICATION_EMAIL = 'manager@the-anchor.pub'
+  })
+
+  it('queues manager recruitment alerts without claiming delivery', async () => {
+    const communications = insertUpdateChain()
+    const supabase = mockSupabase({
+      recruitment_email_templates: maybeSingleChain({ data: null, error: null }),
+      recruitment_communications: communications,
+    })
+    const result = await sendRecruitmentManagerAlert({
+      alertType: 'Interview booked', alertBody: 'Jane booked an interview.', candidateId: 'candidate-1',
+    }, supabase)
+    expect(result).toMatchObject({ success: true, queued: true, messageId: null })
+    expect(sendEmail).not.toHaveBeenCalled()
+    expect(queueManagerReportEmail).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'recruitment', key: 'comm-1', to: 'manager@the-anchor.pub',
+      metadata: expect.objectContaining({ communication_id: 'comm-1' }),
+    }))
+    expect(communications.insert).toHaveBeenCalledWith(expect.objectContaining({ delivery_status: 'queued', sent_at: null, provider_message_id: null }))
+    expect(communications.update).not.toHaveBeenCalled()
+  })
+
+  it('records failed recruitment queue acceptance as failed and permits retry', async () => {
+    queueManagerReportEmail.mockResolvedValue({ success: false, error: 'queue unavailable' })
+    const communications = insertUpdateChain()
+    const supabase = mockSupabase({
+      recruitment_email_templates: maybeSingleChain({ data: null, error: null }),
+      recruitment_communications: communications,
+    })
+    await expect(sendRecruitmentManagerAlert({
+      alertType: 'Review', alertBody: 'Review Jane.', candidateId: 'candidate-1',
+    }, supabase)).rejects.toThrow('queue unavailable')
+    expect(communications.update).toHaveBeenCalledWith(expect.objectContaining({ delivery_status: 'failed', sent_at: null }))
+    expect(sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('retries manager alerts with the original key and recipient without creating duplicate communications', async () => {
+    const communications = retryCommunicationChain({
+      id: 'comm-original', type: 'manager_alert', channel: 'email', subject: 'Review Jane',
+      final_body: 'Review Jane.', candidate_id: 'candidate-1', application_id: 'application-1',
+      delivery_status: 'failed', metadata: { recipient_email: 'original@example.com' },
+    })
+    const supabase = mockSupabase({ recruitment_communications: communications })
+    await retryRecruitmentCommunication('comm-original', 'user-1', supabase)
+    expect(communications.insert).not.toHaveBeenCalled()
+    expect(sendEmail).not.toHaveBeenCalled()
+    expect(queueManagerReportEmail).toHaveBeenCalledWith(expect.objectContaining({
+      section: 'recruitment', key: 'comm-original', to: 'original@example.com',
+      metadata: expect.objectContaining({ communication_id: 'comm-original' }),
+    }))
+    expect(communications.update).toHaveBeenCalledWith(expect.objectContaining({ delivery_status: 'queued', sent_at: null }))
+  })
+
+  it('does not queue a delivered manager alert again', async () => {
+    const communications = retryCommunicationChain({
+      id: 'comm-original', type: 'manager_alert', channel: 'email', delivery_status: 'sent',
+    })
+    await retryRecruitmentCommunication('comm-original', 'user-1', mockSupabase({ recruitment_communications: communications }))
+    expect(queueManagerReportEmail).not.toHaveBeenCalled()
+    expect(sendEmail).not.toHaveBeenCalled()
+    expect(communications.update).not.toHaveBeenCalled()
   })
 
   it('sends recruitment SMS without creating or linking customers', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -223,7 +223,7 @@
     },
     {
       "path": "/api/cron/private-bookings-weekly-summary",
-      "schedule": "0 * * * *"
+      "schedule": "0 7,8 * * 5"
     },
     {
       "path": "/api/cron/generate-slots",
@@ -251,7 +251,7 @@
     },
     {
       "path": "/api/cron/rota-manager-alert",
-      "schedule": "0 18 * * 0"
+      "schedule": "0 7,8 * * 5"
     },
     {
       "path": "/api/cron/rota-unfilled-urgent",
@@ -303,7 +303,7 @@
     },
     {
       "path": "/api/cron/checklists-weekly-summary",
-      "schedule": "0 * * * 1"
+      "schedule": "0 7,8 * * 5"
     },
     {
       "path": "/api/cron/checklists-retention",
@@ -328,6 +328,10 @@
     {
       "path": "/api/cron/marketing-campaigns",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/cron/manager-weekly-report",
+      "schedule": "0 * * * 5"
     }
   ]
 }


### PR DESCRIPTION
## What changed
Manager alerts for table bookings, shift reminders, holiday approval, checklists, recruitment, private booking summaries and the weekly rota now feed one Friday report. Private enquiries, rejected shifts, onboarding completion, private-event outcomes, payroll thresholds, open-shift requests and guest feedback retain immediate delivery. Staff warnings and applicant/customer messages keep their timing.

The report freezes its content before sending, retains unsent items, retries with a stable provider key and records source delivery only after provider acceptance. Staff warning delivery remains independent of manager collection failures.

## Why
Reduce manager inbox volume while keeping time-sensitive enquiries and decisions immediate. Scheduling assumption: Friday 09:00 Europe/London, with fresh summaries prepared at 08:00. Existing recipient overrides are retained.

## Testing done
- Full local coverage suite: 729 files passed, 6,277 tests passed with two existing skips; final staff retry and original-date checks also passed 21 focused tests in London and UTC.
- Report delivery, rendering and snapshot tests passed under UTC; source/customer regression tests passed in both zones.
- Whole-source lint and uncached TypeScript checks passed. Production build completed using the project's CI memory allowance.
- Synthetic HTML/text previews and attachment checks passed without any live sends. Browser visual inspection was blocked by URL policy.
- Read-only live schema, constraints, recipient settings and current Vercel configuration checked. No database or email mutation used for verification.
- Coverage passed all floors: lines 53.32%, branches 42.84%, functions 60.96%. GitHub CI will be checked before merge.

## Complexity score
L, split into inactive report foundation and source/schedule activation commits.

## Breaking changes
Selected individual manager emails stop after release and appear in the Friday report. The old PRIVATE_BOOKINGS_WEEKLY_DIGEST_HOUR_LONDON override no longer controls the private summary schedule. The first report contains newly collected updates, not a replay of old email. The paired website requires no changes; its enquiry failure fallback remains immediate.

## Migration risk
None. Existing communication and cron tables are reused. An uncertain provider outcome older than 23 hours blocks further sends until reconciled, avoiding duplicate reports. Simultaneous manager queue and fallback storage failure returns HTTP 500 and requires reconstruction from source records. Operational recovery and the complete policy are documented in docs/manager-weekly-report.md.
