### PR TITLE
fix: reconcile private booking invoice payments

### DIFF
--- a/scripts/testing/private-booking-settlement-postgres.py
+++ b/scripts/testing/private-booking-settlement-postgres.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run settlement migrations against an isolated Unix-socket PostgreSQL cluster.
+
+Uses a non-PII live-schema snapshot, real PostgreSQL functions and real ledger
+constraints. Authentication is a fixture and unrelated production triggers and
+foreign keys are deliberately excluded. No connection string or network port is
+accepted, so this harness cannot connect to production.
+"""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = ROOT / 'tests/fixtures/private-booking-settlement'
+MIGRATIONS = ROOT / 'supabase/migrations'
+PG_BIN = Path(os.environ.get('PG_BIN', '/opt/homebrew/bin'))
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix='booking-ledger-pg-') as folder:
+        work = Path(folder)
+        cluster = work / 'db'
+        socket = work / 'socket'
+        socket.mkdir()
+        subprocess.run([str(PG_BIN / 'initdb'), '-D', str(cluster), '-A', 'trust', '--no-locale'], check=True, capture_output=True)
+        subprocess.run([str(PG_BIN / 'pg_ctl'), '-D', str(cluster), '-l', str(work / 'postgres.log'),
+                        '-o', f"-k {socket} -c listen_addresses=''", '-w', 'start'], check=True, capture_output=True)
+        command = [str(PG_BIN / 'psql'), '-h', str(socket), '-d', 'postgres', '-X', '-v', 'ON_ERROR_STOP=1', '-q']
+
+        def sql(source):
+            completed = subprocess.run(command, input=source, text=True, capture_output=True)
+            if completed.returncode:
+                raise RuntimeError(completed.stderr)
+            return '\n'.join(line.strip() for line in completed.stdout.splitlines() if 'PASS ' in line)
+
+        try:
+            snapshot = json.loads((FIXTURES / 'live-schema-before.json').read_text())
+            columns = snapshot['columns'] + json.loads((FIXTURES / 'live-extra-columns.json').read_text())
+            setup = """
+CREATE ROLE anon; CREATE ROLE authenticated; CREATE ROLE service_role BYPASSRLS;
+CREATE SCHEMA auth;
+CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql AS $$ SELECT nullif(current_setting('fixture.user_id',true),'')::uuid $$;
+CREATE FUNCTION public.user_has_permission(uuid,text,text) RETURNS boolean LANGUAGE sql AS $$
+  SELECT $1 IS NOT NULL AND ($2 || '.' || $3) = current_setting('fixture.permission',true) $$;
+CREATE TABLE public.customers(id uuid PRIMARY KEY, mobile_number text);
+"""
+            for table in dict.fromkeys(c['table_name'] for c in columns):
+                definitions = []
+                for column in [c for c in columns if c['table_name'] == table]:
+                    definition = column['column_name'] + ' ' + column['data_type']
+                    if column.get('generation_expression'):
+                        definition += ' GENERATED ALWAYS AS (' + column['generation_expression'] + ') STORED'
+                    elif column['column_default']:
+                        definition += ' DEFAULT ' + column['column_default']
+                    if column['is_nullable'] == 'NO':
+                        definition += ' NOT NULL'
+                    definitions.append(definition)
+                setup += 'CREATE TABLE public.' + table + '(' + ','.join(definitions) + ');\n'
+            # All live CHECKs and keys; unrelated external foreign keys are omitted.
+            for constraint in snapshot['constraints']:
+                if not constraint['def'].startswith('FOREIGN KEY'):
+                    setup += f"ALTER TABLE public.{constraint['tab']} ADD CONSTRAINT {constraint['conname']} {constraint['def']};\n"
+            setup += """
+ALTER TABLE public.invoice_payments ADD FOREIGN KEY (invoice_id) REFERENCES public.invoices(id) ON DELETE CASCADE;
+ALTER TABLE public.private_booking_payments ADD FOREIGN KEY (booking_id) REFERENCES public.private_bookings(id) ON DELETE CASCADE;
+ALTER TABLE public.invoice_payments ADD FOREIGN KEY (source_payment_id) REFERENCES public.private_booking_payments(id) ON DELETE SET NULL;
+ALTER TABLE public.private_bookings ADD FOREIGN KEY (invoice_id) REFERENCES public.invoices(id);
+CREATE UNIQUE INDEX private_bookings_invoice_id_key ON public.private_bookings(invoice_id) WHERE invoice_id IS NOT NULL;
+CREATE UNIQUE INDEX invoice_payments_invoice_source_key ON public.invoice_payments(invoice_id, source_payment_id) WHERE source_payment_id IS NOT NULL;
+CREATE UNIQUE INDEX invoice_payments_invoice_deposit_key ON public.invoice_payments(invoice_id) WHERE source_kind = 'booking_deposit';
+CREATE UNIQUE INDEX invoice_payments_paypal_capture_key ON public.invoice_payments(reference) WHERE source_kind = 'paypal';
+CREATE TABLE public.invoice_line_items(id uuid DEFAULT gen_random_uuid(), invoice_id uuid, catalog_item_id uuid,
+description text, quantity numeric, unit_price numeric, discount_percentage numeric, vat_rate numeric, display_order integer);
+CREATE SEQUENCE fixture_invoice_sequence;
+CREATE FUNCTION public.get_and_increment_invoice_series(text) RETURNS TABLE(next_sequence integer)
+LANGUAGE sql AS $$ SELECT nextval('fixture_invoice_sequence')::integer $$;
+"""
+            sql(setup)
+            sql((FIXTURES / 'live-functions-before.sql').read_text())
+            claims = "SET request.jwt.claims = '{\"role\":\"service_role\"}';\n"
+            sql(claims + (FIXTURES / 'regression-before.sql').read_text())
+            migration = (MIGRATIONS / '20260905192946_private_booking_invoice_settlement.sql').read_text()
+            sql('BEGIN;\n' + migration + '\nROLLBACK;')
+            print(sql("SELECT fixture_assert(to_regprocedure('public.private_booking_settlement_rows(uuid)') IS NULL,'DDL rollback removed new helper'); SELECT 'PASS full DDL transaction rollback';"))
+            sql('BEGIN;\n' + migration + '\nCOMMIT;')
+            print(sql(claims + (FIXTURES / 'regression-after.sql').read_text()))
+            repair = (MIGRATIONS / '20260905192951_reconcile_verified_private_booking_capture.sql').read_text()
+            sql(claims + 'BEGIN;\n' + repair + '\nCOMMIT;')
+            sql(claims + 'BEGIN;\n' + repair + '\nCOMMIT;')
+            print(sql(claims + (FIXTURES / 'regression-repair.sql').read_text()))
+            # Concurrent entry points take booking then invoice locks. Different
+            # capture ids must both survive; the same capture must be stored once.
+            captures = [f"SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010', 10, 'CONCURRENT-{i % 2}', NULL, '2026-09-04T13:00:00Z');" for i in range(8)]
+            processes = [subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True) for _ in captures]
+            for process, statement in zip(processes, captures):
+                process.stdin.write(claims + 'SET statement_timeout=\'10s\';' + statement)
+                process.stdin.close()
+            for process in processes:
+                process.wait(timeout=15)
+                if process.returncode:
+                    raise RuntimeError(process.stderr.read())
+            print(sql(claims + "SELECT fixture_assert((SELECT count(*)=2 FROM invoice_payments WHERE reference LIKE 'CONCURRENT-%'), 'concurrent retry uniqueness'); SELECT 'PASS concurrent captures';"))
+            # Overlap a manual booking payment and a manual invoice payment.
+            left = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            right = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            left.stdin.write(claims + "BEGIN; SELECT record_balance_payment('00000000-0000-0000-0000-000000000020',10,'cash'); SELECT pg_sleep(0.2); COMMIT;")
+            left.stdin.close()
+            right.stdin.write(claims + "SET statement_timeout='10s'; SELECT record_invoice_payment_transaction('{\"invoice_id\":\"00000000-0000-0000-0000-000000000010\",\"amount\":10,\"payment_method\":\"cash\",\"payment_date\":\"2026-09-04\"}');")
+            right.stdin.close()
+            for process in (left, right):
+                process.wait(timeout=15)
+                if process.returncode:
+                    raise RuntimeError(process.stderr.read())
+            print(sql(claims + "SELECT fixture_assert((SELECT paid_amount=40 FROM invoices WHERE id='00000000-0000-0000-0000-000000000010'), 'concurrent manual ledger total'); SELECT 'PASS concurrent manual booking and invoice payments';"))
+            print('PASS isolated PostgreSQL settlement migrations and recovery')
+        finally:
+            subprocess.run([str(PG_BIN / 'pg_ctl'), '-D', str(cluster), '-m', 'immediate', '-w', 'stop'], check=True, capture_output=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/app/(authenticated)/private-bookings/[id]/PaymentHistoryTable.test.tsx
+++ b/src/app/(authenticated)/private-bookings/[id]/PaymentHistoryTable.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import PaymentHistoryTable from './PaymentHistoryTable'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }))
+vi.mock('@/app/actions/privateBookingActions', () => ({ editPrivateBookingPayment: vi.fn(), deletePrivateBookingPayment: vi.fn() }))
+vi.mock('@/ds', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+  Button: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props} />,
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Select: (props: React.SelectHTMLAttributes<HTMLSelectElement>) => <select {...props} />,
+  ConfirmDialog: () => null,
+}))
+
+describe('booking payment history from a linked invoice', () => {
+  it('shows settlement including an applied deposit and keeps invoice money read-only', () => {
+    render(<PaymentHistoryTable bookingId="booking" canEditPayments totalAmount={994.8} payments={[
+      { id: 'deposit', type: 'deposit', amount: 250, appliedAmount: 250, method: 'paypal', date: '2026-08-28', readonly: true, invoice_id: 'invoice' },
+      { id: 'capture', type: 'balance', amount: 744.8, method: 'paypal', date: '2026-09-05', readonly: true, invoice_id: 'invoice' },
+    ]} />)
+    expect(screen.getByText('Paid to date').parentElement).toHaveTextContent('£994.80')
+    expect(screen.getByText('Outstanding').parentElement).toHaveTextContent('£0.00')
+    expect(screen.getAllByRole('link', { name: 'View invoice' })).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: 'Edit balance payment' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Delete deposit payment' })).not.toBeInTheDocument()
+  })
+
+  it('does not count a separately held deposit against the event balance', () => {
+    render(<PaymentHistoryTable bookingId="booking" canEditPayments totalAmount={994.8} payments={[
+      { id: 'deposit', type: 'deposit', amount: 250, method: 'cash', date: '2026-08-28' },
+      { id: 'cash', type: 'balance', amount: 100, method: 'cash', date: '2026-09-05' },
+    ]} />)
+    expect(screen.getByText('Paid to date').parentElement).toHaveTextContent('£100.00')
+    expect(screen.getByText('Outstanding').parentElement).toHaveTextContent('£894.80')
+    expect(screen.getByRole('button', { name: 'Edit balance payment' })).toBeInTheDocument()
+  })
+})

--- a/src/app/(authenticated)/private-bookings/[id]/PaymentHistoryTable.tsx
+++ b/src/app/(authenticated)/private-bookings/[id]/PaymentHistoryTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { PencilIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline'
 import { formatDateInLondon } from '@/lib/dateUtils'
@@ -41,9 +42,8 @@ export default function PaymentHistoryTable({
   // Global lock: while any save or delete is in flight, all action buttons are disabled
   const isLocked = savingId !== null || deletingId !== null
 
-  // Summary figures — computed regardless of payments.length
-  // Booking and damage deposit — separate from event balance, only balance payments reduce outstanding
-  const paidToDate = payments.filter(p => p.type === 'balance').reduce((sum, p) => sum + p.amount, 0)
+  // Held deposits stay separate; only an actual invoice deposit credit reduces the event balance.
+  const paidToDate = payments.reduce((sum, payment) => sum + (payment.type === 'balance' ? payment.amount : payment.appliedAmount ?? 0), 0)
   const outstanding = Math.max(0, totalAmount - paidToDate)
 
   function formatMethodLabel(method: string): string {
@@ -52,6 +52,9 @@ export default function PaymentHistoryTable({
       card: 'Card',
       invoice: 'Invoice',
       paypal: 'PayPal',
+      bank_transfer: 'Bank transfer',
+      cheque: 'Cheque',
+      other: 'Other',
     }
     return labels[method] ?? method
   }
@@ -237,14 +240,17 @@ export default function PaymentHistoryTable({
               >
                 <span className="min-w-0">
                   {formatDateInLondon(entry.date, { day: 'numeric', month: 'short', year: 'numeric' })}
-                  {' — '}
-                  <span className="capitalize">{entry.type}</span>
+                  {' - '}
+                  <span className="capitalize">{entry.type === 'deposit' && (entry.appliedAmount ?? 0) > 0 ? 'Deposit applied to invoice' : entry.type}</span>
                   {' · '}
                   {formatMethodLabel(entry.method)}
                 </span>
                 <div className="flex items-center gap-2">
                   <span className="font-medium">{formatCurrency(entry.amount)}</span>
-                  {canEditPayments && (
+                  {entry.invoice_id && (
+                    <Link href={`/invoices/${entry.invoice_id}`} className="text-blue-600 underline">View invoice</Link>
+                  )}
+                  {canEditPayments && !entry.readonly && (
                     <div className="flex gap-1">
                       <button
                         type="button"

--- a/src/app/(authenticated)/private-bookings/[id]/PrivateBookingDetailClient.tsx
+++ b/src/app/(authenticated)/private-bookings/[id]/PrivateBookingDetailClient.tsx
@@ -2359,6 +2359,8 @@ export default function PrivateBookingDetailClient({
     : null
   const depositAmount = toNumber(booking.deposit_amount, 0);
   const depositRequired = depositAmount > 0;
+  const appliedDepositAmount = toNumber(booking.applied_deposit_amount, 0);
+  const depositAppliedToInvoice = Boolean(booking.invoice_id && booking.invoice_deposit_treatment === "deducted");
 
   // Stored prices are NET (SOP 2026-07) — customer-payable figures are gross.
   // Computed locally from items so the summary stays live during edits.
@@ -3031,12 +3033,12 @@ export default function PrivateBookingDetailClient({
               <div className="space-y-3 pt-3 border-t">
                 <div className="bg-blue-50 p-3 rounded-lg">
                   <p className="text-xs font-medium text-blue-900 mb-2">
-                    Refundable Deposit
+                    {depositAppliedToInvoice ? "Deposit applied to invoice" : "Refundable Deposit"}
                   </p>
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
                       <p className="text-sm font-medium text-gray-700">
-                        Security Deposit
+                        {depositAppliedToInvoice ? "Applied towards event price" : "Security Deposit"}
                       </p>
                       <p className="text-xs text-gray-500">
                         {!depositRequired
@@ -3121,7 +3123,7 @@ export default function PrivateBookingDetailClient({
                     ) : (
                       <div className="flex items-center gap-1 justify-end">
                         <p className="text-sm font-medium text-gray-900">
-                          {depositRequired ? formatMoney(depositAmount) : "No deposit"}
+                          {depositAppliedToInvoice ? formatMoney(appliedDepositAmount) : depositRequired ? formatMoney(depositAmount) : "No deposit"}
                         </p>
                         {!booking.deposit_paid_date && canManageDeposits && (
                           <button
@@ -3189,7 +3191,7 @@ export default function PrivateBookingDetailClient({
                   </div>
                   {depositRequired && (
                     <p className="text-xs text-gray-600 mt-2">
-                      Returned after event (subject to terms)
+                      {depositAppliedToInvoice ? "This deposit has been applied to the invoice. Any refund needs an invoice review." : "Returned after event (subject to terms)"}
                     </p>
                   )}
                   {/* Refund status badge */}
@@ -3204,7 +3206,7 @@ export default function PrivateBookingDetailClient({
                     </div>
                   )}
                   {/* Refund button */}
-                  {depositRequired && canRefund && booking.deposit_paid_date && refundTotals.totalRefunded < depositAmount && (
+                  {depositRequired && !depositAppliedToInvoice && canRefund && booking.deposit_paid_date && refundTotals.totalRefunded < depositAmount && (
                     <div className="mt-2">
                       <Button
                         variant="secondary"
@@ -3226,24 +3228,24 @@ export default function PrivateBookingDetailClient({
                   )}
                 </div>
 
-                {/* SOP: gross event total plus the refundable deposit (unless waived) */}
+                {/* Only a separately held deposit is additional to the event price. */}
                 <div className="flex justify-between text-sm pt-3 border-t">
                   <span className="font-medium text-gray-900">
                     Total to pay before event
                   </span>
                   <span className="font-semibold text-gray-900">
                     {formatMoney(
-                      bookingMoney.grossTotal + (depositRequired ? depositAmount : 0),
+                      bookingMoney.grossTotal + (depositRequired && !depositAppliedToInvoice ? depositAmount : 0),
                     )}
                   </span>
                 </div>
 
                 {(() => {
                   const payments: PrivateBookingPayment[] = booking.payments ?? [];
-                  const totalPaid = payments.reduce((sum, p) => sum + (p.amount ?? 0), 0);
+                  const totalPaid = payments.reduce((sum, p) => sum + (p.amount ?? 0), 0) + appliedDepositAmount;
                   // Balance is VAT-inclusive: stored prices are net
                   const bookingTotal = bookingMoney.grossTotal;
-                  // Booking and damage deposit — separate from event balance
+                  // An applied invoice deposit is already included in totalPaid.
                   const remaining = Math.max(0, bookingTotal - totalPaid);
                   return (
                     <>
@@ -3266,17 +3268,17 @@ export default function PrivateBookingDetailClient({
                             <p className="text-sm font-medium text-gray-900">To be confirmed</p>
                           ) : (
                             <>
-                              {totalPaid > 0 && !booking.final_payment_date && (
+                              {totalPaid > 0 && remaining > 0 && (
                                 <p className="text-xs text-gray-500 mb-0.5">
                                   {formatMoney(totalPaid)} of {formatMoney(bookingTotal)} paid
                                 </p>
                               )}
                               <p className="text-sm font-medium text-gray-900">
-                                {booking.final_payment_date ? formatMoney(0) : formatMoney(remaining)}
+                                {formatMoney(remaining)}
                               </p>
                             </>
                           )}
-                          {!isDateTbd && !booking.final_payment_date && remaining > 0 && canManageDeposits && (
+                          {!isDateTbd && remaining > 0 && canManageDeposits && (
                             <Button
                               type="button"
                               variant="primary"
@@ -3299,7 +3301,7 @@ export default function PrivateBookingDetailClient({
                         />
                       </div>
 
-                      {booking.final_payment_date && (
+                      {booking.final_payment_date && remaining === 0 && (
                         <div className="pt-3 border-t">
                           <div className="flex items-center justify-between">
                             <span className="text-sm text-green-600 font-medium">
@@ -3550,8 +3552,8 @@ export default function PrivateBookingDetailClient({
 
       {canManageDeposits && (() => {
         const payments: PrivateBookingPayment[] = booking?.payments ?? [];
-        const totalPaid = payments.reduce((sum, p) => sum + (p.amount ?? 0), 0);
-        // Booking and damage deposit — separate from event balance (gross, inc. VAT)
+        const totalPaid = payments.reduce((sum, p) => sum + (p.amount ?? 0), 0) + appliedDepositAmount;
+        // An applied invoice deposit is already included in totalPaid. (gross, inc. VAT)
         const remaining = Math.max(0, bookingMoney.grossTotal - totalPaid);
         return (
           <PaymentModal

--- a/src/app/(authenticated)/private-bookings/[id]/page.tsx
+++ b/src/app/(authenticated)/private-bookings/[id]/page.tsx
@@ -88,8 +88,10 @@ export default async function PrivateBookingDetailPage({ params }: PageProps) {
   if (bookingData) {
     try {
       paymentHistory = await getBookingPaymentHistory(bookingData.id)
-    } catch (_err) {
-      // Non-fatal: page still renders, payment history will be empty
+    } catch (error) {
+      console.error('Failed to load booking payment history', error)
+      errors.push('Payment history could not be loaded. Refresh before recording a payment.')
+      bookingData = null
     }
   }
 

--- a/src/app/actions/__tests__/invoice-paypal.test.ts
+++ b/src/app/actions/__tests__/invoice-paypal.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+vi.mock('server-only', () => ({}))
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }))
 vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
 vi.mock('@/app/actions/rbac', () => ({ checkUserPermission: vi.fn() }))
@@ -16,6 +17,7 @@ vi.mock('@/lib/paypal', () => ({
   createSimplePayPalOrder: vi.fn(),
   capturePayPalPayment: vi.fn(),
   getPayPalOrder: vi.fn(),
+  isPayPalOrderAlreadyCapturedError: vi.fn().mockReturnValue(false),
 }))
 vi.mock('@/lib/email/invoice-payment-emails', () => ({
   sendInvoicePaymentLinkEmail: vi.fn().mockResolvedValue({ success: true }),
@@ -28,12 +30,15 @@ import {
   getInvoicePortalLink,
   sendInvoicePaymentLink,
   createInvoicePaymentOrderByToken,
-  applyInvoicePayPalCapture,
+  captureInvoicePaymentByToken,
 } from '@/app/actions/invoicePayPalActions'
+import { applyInvoicePayPalCapture } from '@/lib/invoices/paypal-capture'
+import { logger } from '@/lib/logger'
+import { logAuditEvent } from '@/app/actions/audit'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { createClient } from '@/lib/supabase/server'
 import { checkUserPermission } from '@/app/actions/rbac'
-import { createSimplePayPalOrder, getPayPalOrder } from '@/lib/paypal'
+import { createSimplePayPalOrder, getPayPalOrder, capturePayPalPayment, isPayPalOrderAlreadyCapturedError } from '@/lib/paypal'
 import { generateInvoiceToken } from '@/lib/invoices/invoice-token'
 import { sendInvoicePaymentLinkEmail } from '@/lib/email/invoice-payment-emails'
 
@@ -228,9 +233,10 @@ describe('createInvoicePaymentOrderByToken', () => {
   })
 
   it('opens a new order when the outstanding amount has moved since', async () => {
-    vi.mocked(createAdminClient).mockReturnValue(mockAdmin(invoice({ paypal_order_id: 'ORDER-STALE' })))
+    const admin = mockAdmin(invoice({ paypal_order_id: 'ORDER-STALE' }))
+    vi.mocked(createAdminClient).mockReturnValue(admin)
     vi.mocked(getPayPalOrder).mockResolvedValue({
-      status: 'APPROVED',
+      status: 'CREATED',
       purchase_units: [{
         reference_id: INVOICE_ID,
         custom_id: `inv-pay-${INVOICE_ID}`,
@@ -246,6 +252,7 @@ describe('createInvoicePaymentOrderByToken', () => {
       expect.objectContaining({ amount: 725.6 }),
     )
     expect(result.approveUrl).toContain('ORDER-1')
+    expect(admin.update).toHaveBeenCalledTimes(1)
   })
 
   it('refuses to bill an order belonging to a different invoice', async () => {
@@ -262,8 +269,8 @@ describe('createInvoicePaymentOrderByToken', () => {
 
     await createInvoicePaymentOrderByToken(generateInvoiceToken(INVOICE_ID))
 
-    // Not reused: a fresh order is opened for this invoice instead.
-    expect(createSimplePayPalOrder).toHaveBeenCalled()
+    // Keep uncertain references available for investigation.
+    expect(createSimplePayPalOrder).not.toHaveBeenCalled()
   })
 })
 
@@ -286,6 +293,7 @@ describe('applyInvoicePayPalCapture', () => {
       p_amount: 725.6,
       p_capture_id: 'CAPTURE-1',
       p_order_id: 'ORDER-1',
+      p_captured_at: null,
     })
   })
 
@@ -308,5 +316,157 @@ describe('applyInvoicePayPalCapture', () => {
 
     expect(result.success).toBe(true)
     expect(result.alreadyRecorded).toBe(true)
+  })
+})
+
+function paypalOrder(status = 'APPROVED', amount = '725.60', captureStatus = 'COMPLETED') {
+  return {
+    id: 'ORDER-1', status,
+    purchase_units: [{
+      reference_id: INVOICE_ID, custom_id: `inv-pay-${INVOICE_ID}`,
+      amount: { value: amount, currency_code: 'GBP' },
+      ...(status === 'COMPLETED' ? { payments: { captures: [{
+        id: 'CAPTURE-1', status: captureStatus,
+        create_time: '2026-09-04T13:38:30Z',
+        amount: { value: amount, currency_code: 'GBP' },
+      }] } } : {}),
+    }],
+  }
+}
+
+describe('invoice capture recovery and guards', () => {
+  it.each(['void', 'written_off', 'paid', 'draft'])('does not capture an approved order for a %s invoice', async status => {
+    vi.mocked(createAdminClient).mockReturnValue(mockAdmin(invoice({ status, sent_at: null })))
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder())
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.error).toBeTruthy()
+    expect(capturePayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('refuses even a one penny stale amount before capture', async () => {
+    vi.mocked(createAdminClient).mockReturnValue(mockAdmin(invoice()))
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('APPROVED', '725.61'))
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.error).toContain('amount due has changed')
+    expect(capturePayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('recovers an already captured payment without taking money again', async () => {
+    const admin = mockAdmin(invoice())
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('COMPLETED'))
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.success).toBe(true)
+    expect(capturePayPalPayment).not.toHaveBeenCalled()
+    expect(admin.rpc).toHaveBeenCalledWith('record_invoice_paypal_payment_atomic', expect.objectContaining({
+      p_capture_id: 'CAPTURE-1', p_amount: 725.6, p_captured_at: '2026-09-04T13:38:30Z',
+    }))
+  })
+
+  it('does not credit a pending capture on a completed order', async () => {
+    const admin = mockAdmin(invoice())
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('COMPLETED', '725.60', 'PENDING'))
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.error).toBeTruthy()
+    expect(admin.rpc).not.toHaveBeenCalled()
+  })
+
+  it('re-reads the actual capture after taking an approved payment', async () => {
+    const admin = mockAdmin(invoice())
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValueOnce(paypalOrder()).mockResolvedValueOnce(paypalOrder('COMPLETED'))
+    vi.mocked(capturePayPalPayment).mockResolvedValue({ transactionId: 'CAPTURE-1', amount: '725.60', status: 'COMPLETED' } as never)
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.success).toBe(true)
+    expect(capturePayPalPayment).toHaveBeenCalledTimes(1)
+    expect(getPayPalOrder).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers when another path captured the same order first', async () => {
+    const admin = mockAdmin(invoice())
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValueOnce(paypalOrder()).mockResolvedValueOnce(paypalOrder('COMPLETED'))
+    vi.mocked(capturePayPalPayment).mockRejectedValueOnce(new Error('ORDER_ALREADY_CAPTURED'))
+    vi.mocked(isPayPalOrderAlreadyCapturedError).mockReturnValueOnce(true)
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.success).toBe(true)
+    expect(admin.rpc).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['PENDING', 'REFUNDED', 'DECLINED'])('does not credit a %s capture returned after approval', async status => {
+    const admin = mockAdmin(invoice())
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValueOnce(paypalOrder()).mockResolvedValueOnce(paypalOrder('COMPLETED', '725.60', status))
+    vi.mocked(capturePayPalPayment).mockResolvedValue({ status: 'COMPLETED' } as never)
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.error).toBeTruthy()
+    expect(admin.rpc).not.toHaveBeenCalled()
+  })
+
+  it('retains all money from an already completed overpayment and flags the excess', async () => {
+    const admin = mockAdmin(invoice(), {
+      recorded: true, already_recorded: false, status: 'paid', invoice_number: 'INV-003WJ', overpaid_amount: 74.4,
+    })
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('COMPLETED', '800.00'))
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.success).toBe(true)
+    expect(result.error).toBeUndefined()
+    expect(admin.rpc).toHaveBeenCalledWith('record_invoice_paypal_payment_atomic', expect.objectContaining({ p_amount: 800 }))
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('exceeds the invoice total'), expect.objectContaining({ metadata: expect.objectContaining({ overpaidAmount: 74.4 }) }))
+    expect(logAuditEvent).toHaveBeenCalledWith(expect.objectContaining({ new_values: expect.objectContaining({ overpaid_amount: 74.4 }) }))
+    expect(capturePayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('does not raise the excess alert again on an idempotent replay', async () => {
+    const admin = mockAdmin(invoice(), {
+      recorded: false, already_recorded: true, status: 'paid', invoice_number: 'INV-003WJ', overpaid_amount: 74.4,
+    })
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    const result = await applyInvoicePayPalCapture({ invoiceId: INVOICE_ID, amount: 800, captureId: 'CAPTURE-1', source: 'webhook' })
+    expect(result.success).toBe(true)
+    expect(result.overpaidAmount).toBeUndefined()
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
+  it('reports a recording failure after capture without offering another payment', async () => {
+    const admin = mockAdmin(invoice())
+    admin.rpc.mockResolvedValue({ data: null, error: { message: 'constraint failed' } })
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('COMPLETED'))
+    const result = await captureInvoicePaymentByToken(generateInvoiceToken(INVOICE_ID), 'ORDER-1')
+    expect(result.error).toContain('could not record')
+    expect(capturePayPalPayment).not.toHaveBeenCalled()
+  })
+
+  it('records a completed old order before allowing any new payment link', async () => {
+    const admin = mockAdmin(invoice({ paypal_order_id: 'ORDER-1' }))
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('COMPLETED'))
+    const result = await createInvoicePaymentOrderByToken(generateInvoiceToken(INVOICE_ID))
+    expect(result.error).toContain('previous payment has been recorded')
+    expect(admin.rpc).toHaveBeenCalledTimes(1)
+    expect(createSimplePayPalOrder).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an approved order with a changed amount', async () => {
+    const admin = mockAdmin(invoice({ paypal_order_id: 'ORDER-1' }))
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockResolvedValue(paypalOrder('APPROVED', '975.60'))
+    const result = await createInvoicePaymentOrderByToken(generateInvoiceToken(INVOICE_ID))
+    expect(result.error).toContain('previous payment needs checking')
+    expect(admin.update).not.toHaveBeenCalled()
+    expect(createSimplePayPalOrder).not.toHaveBeenCalled()
+  })
+
+  it('retains the existing reference on a provider lookup failure', async () => {
+    const admin = mockAdmin(invoice({ paypal_order_id: 'ORDER-1' }))
+    vi.mocked(createAdminClient).mockReturnValue(admin)
+    vi.mocked(getPayPalOrder).mockRejectedValueOnce(new Error('PayPal unavailable'))
+    const result = await createInvoicePaymentOrderByToken(generateInvoiceToken(INVOICE_ID))
+    expect(result.error).toContain('could not check')
+    expect(admin.update).not.toHaveBeenCalled()
+    expect(createSimplePayPalOrder).not.toHaveBeenCalled()
   })
 })

--- a/src/app/actions/__tests__/refundActions.test.ts
+++ b/src/app/actions/__tests__/refundActions.test.ts
@@ -55,6 +55,30 @@ describe('refundActions', () => {
   })
 
   describe('processPayPalRefund', () => {
+    it.each(['paypal', 'manual'] as const)('does not refund an applied invoice deposit through the %s bond flow', async (method) => {
+      vi.mocked(createClient).mockResolvedValue({
+        auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }) },
+      } as never)
+      const db = mockSupabaseChain({
+        id: 'booking-1',
+        deposit_amount: 250,
+        deposit_paid_date: new Date().toISOString(),
+        paypal_deposit_capture_id: 'CAPTURE-1',
+        invoice_id: 'invoice-1',
+        invoice_deposit_treatment: 'deducted',
+      })
+      vi.mocked(createAdminClient).mockReturnValue(db as never)
+
+      const actions = await import('../refundActions')
+      const result = method === 'paypal'
+        ? await actions.processPayPalRefund('private_booking', 'booking-1', 250, 'Return deposit')
+        : await actions.processManualRefund('private_booking', 'booking-1', 250, 'Return deposit', 'cash')
+
+      expect(result).toEqual({ error: expect.stringContaining('applied to the invoice') })
+      expect(db.rpc).not.toHaveBeenCalled()
+      expect(refundPayPalPayment).not.toHaveBeenCalled()
+    })
+
     it('should reject if user lacks refund permission', async () => {
       vi.mocked(checkUserPermission).mockResolvedValue(false)
 

--- a/src/app/actions/invoicePayPalActions.ts
+++ b/src/app/actions/invoicePayPalActions.ts
@@ -23,7 +23,6 @@ import { logger } from '@/lib/logger'
 import { getErrorMessage } from '@/lib/errors'
 import {
   PAYPAL_DEFAULT_CURRENCY,
-  capturePayPalPayment,
   createSimplePayPalOrder,
   getPayPalOrder,
 } from '@/lib/paypal'
@@ -31,6 +30,7 @@ import { generateInvoiceToken, verifyInvoiceToken } from '@/lib/invoices/invoice
 import { sendInvoicePaymentLinkEmail } from '@/lib/email/invoice-payment-emails'
 import { resolveVendorInvoiceRecipients } from '@/lib/invoice-recipients'
 import { invoicePaymentCustomId } from '@/lib/invoices/paypal-custom-id'
+import { settleInvoicePayPalOrder } from '@/lib/invoices/paypal-capture'
 
 /** Statuses where asking the customer for money is legitimate. */
 const PAYABLE_STATUSES = new Set(['sent', 'overdue', 'partially_paid'])
@@ -118,7 +118,7 @@ function approveUrl(order: any): string | null {
 }
 
 function amountsMatch(actual: number, expected: number): boolean {
-  return Math.abs(actual - expected) <= 0.01
+  return Math.round(actual * 100) === Math.round(expected * 100)
 }
 
 function orderBelongsToInvoice(order: any, invoiceId: string): boolean {
@@ -155,6 +155,17 @@ async function ensurePayPalOrder(
   if (invoice.paypal_order_id) {
     try {
       const existing = await getPayPalOrder(invoice.paypal_order_id)
+      if (!orderBelongsToInvoice(existing, invoice.id)) {
+        return { error: 'The previous payment reference does not match this invoice. Please contact us before paying again.' }
+      }
+      if (existing?.status === 'COMPLETED') {
+        const recovered = await settleInvoicePayPalOrder(invoice, invoice.paypal_order_id, 'portal', existing)
+        if (recovered.error) return { error: recovered.error }
+        return { error: 'Your previous payment has been recorded. Reload to see the updated balance before paying again.' }
+      }
+      if (existing?.purchase_units?.some((unit: { payments?: { captures?: unknown[] } }) => unit.payments?.captures?.length)) {
+        return { error: 'Your previous payment is still being checked. Please contact us before paying again.' }
+      }
       const amount = orderAmount(existing)
       const url = approveUrl(existing)
 
@@ -169,17 +180,21 @@ async function ensurePayPalOrder(
         return { approveUrl: url, orderId: invoice.paypal_order_id }
       }
 
-      // Stale: the amount moved, or PayPal has retired it. Drop the link so the
-      // reconciliation cron stops polling something nobody can pay.
-      await admin
-        .from('invoices')
-        .update({ paypal_order_id: null, updated_at: new Date().toISOString() })
-        .eq('id', invoice.id)
-        .eq('paypal_order_id', invoice.paypal_order_id)
+      if (!['CREATED', 'PAYER_ACTION_REQUIRED', 'APPROVED', 'VOIDED'].includes(existing?.status)) {
+        return { error: 'Your previous payment is still being checked. Please contact us before paying again.' }
+      }
+      if (existing.status === 'APPROVED') {
+        return { error: 'Your previous payment needs checking. Please contact us before paying again.' }
+      }
+
+      // Keep the previous reference until a replacement order is attached by
+      // the conditional update below. Failed creation leaves it recoverable.
     } catch (error) {
-      logger.warn?.('[InvoicePayPal] Could not read the existing order, creating a new one', {
+      logger.error('[InvoicePayPal] Could not verify the existing order', {
+        error: error instanceof Error ? error : new Error(String(error)),
         metadata: { invoiceId: invoice.id, orderId: invoice.paypal_order_id },
       })
+      return { error: 'We could not check your previous payment. Please try again shortly before paying again.' }
     }
   }
 
@@ -206,6 +221,9 @@ async function ensurePayPalOrder(
       .from('invoices')
       .update({ paypal_order_id: result.orderId, updated_at: new Date().toISOString() })
       .eq('id', invoice.id)
+      .eq('updated_at', invoice.updated_at)
+      .eq('paid_amount', invoice.paid_amount)
+      .eq('total_amount', invoice.total_amount)
       .not('status', 'in', '("void","written_off","paid")')
       .select('id')
       .maybeSingle()
@@ -415,33 +433,8 @@ export async function captureInvoicePaymentByToken(
     const invoice = await loadInvoice(invoiceId)
     if (!invoice) return { error: 'That invoice could not be found.' }
 
-    const order = await getPayPalOrder(paypalOrderId)
-    if (!orderBelongsToInvoice(order, invoiceId)) {
-      logger.error('[InvoicePayPal] Order does not belong to this invoice', {
-        error: new Error('paypal_order_invoice_mismatch'),
-        metadata: { invoiceId, paypalOrderId },
-      })
-      return { error: 'That payment does not match this invoice.' }
-    }
+    return await settleInvoicePayPalOrder(invoice, paypalOrderId, 'portal')
 
-    if (orderCurrency(order) !== PAYPAL_DEFAULT_CURRENCY) {
-      return { error: 'That payment was not in pounds, so it has not been applied.' }
-    }
-
-    const capture = await capturePayPalPayment(paypalOrderId, PAYPAL_DEFAULT_CURRENCY)
-    const amount = Number(capture.amount)
-
-    if (!Number.isFinite(amount) || amount <= 0) {
-      return { error: 'PayPal reported a payment we could not read. We will chase it up.' }
-    }
-
-    return await applyInvoicePayPalCapture({
-      invoiceId,
-      amount,
-      captureId: capture.transactionId,
-      orderId: paypalOrderId,
-      source: 'portal',
-    })
   } catch (error) {
     logger.error('[InvoicePayPal] Portal capture failed', {
       error: error instanceof Error ? error : new Error(String(error)),
@@ -449,59 +442,4 @@ export async function captureInvoicePaymentByToken(
     })
     return { error: 'We could not confirm that payment. Please contact us before paying again.' }
   }
-}
-
-/**
- * The one writer. The portal, the webhook and the reconciliation cron all come
- * through here so the capture id stays the single idempotency key.
- */
-export async function applyInvoicePayPalCapture(params: {
-  invoiceId: string
-  amount: number
-  captureId: string
-  orderId?: string | null
-  source: 'portal' | 'webhook' | 'reconciliation'
-}): Promise<{ success?: boolean; alreadyRecorded?: boolean; error?: string }> {
-  const admin = createAdminClient()
-
-  const { data, error } = await (admin.rpc as unknown as (
-    fn: string,
-    args: Record<string, unknown>,
-  ) => Promise<{
-    data: { recorded: boolean; already_recorded: boolean; status: string; invoice_number: string } | null
-    error: { message: string } | null
-  }>)('record_invoice_paypal_payment_atomic', {
-    p_invoice_id: params.invoiceId,
-    p_amount: params.amount,
-    p_capture_id: params.captureId,
-    p_order_id: params.orderId ?? null,
-  })
-
-  if (error || !data) {
-    logger.error('[InvoicePayPal] Could not record the capture', {
-      error: error instanceof Error ? error : new Error(error?.message || 'unknown'),
-      metadata: { ...params },
-    })
-    return { error: 'The payment was taken but we could not record it. We will sort this out.' }
-  }
-
-  await logAuditEvent({
-    operation_type: 'payment',
-    resource_type: 'invoice',
-    resource_id: params.invoiceId,
-    operation_status: 'success',
-    new_values: {
-      action: `invoice_paypal_captured_via_${params.source}`,
-      invoice_number: data.invoice_number,
-      amount: params.amount,
-      capture_id: params.captureId,
-      already_recorded: data.already_recorded,
-      status: data.status,
-    },
-  })
-
-  revalidatePath(`/invoices/${params.invoiceId}`)
-  revalidatePath('/invoices')
-
-  return { success: true, alreadyRecorded: data.already_recorded }
 }

--- a/src/app/actions/invoices.ts
+++ b/src/app/actions/invoices.ts
@@ -618,6 +618,7 @@ export async function updateInvoiceStatus(formData: FormData) {
 
     revalidatePath('/invoices')
     revalidatePath(`/invoices/${invoiceId}`)
+    revalidatePath('/private-bookings', 'layout')
     revalidateTag('dashboard')
 
     return { success: true }
@@ -877,6 +878,7 @@ export async function recordPayment(formData: FormData) {
     revalidatePath(`/invoices/${invoiceId}`)
     revalidateTag('dashboard')
 
+    revalidatePath('/private-bookings', 'layout')
     return { payment, success: true, remittanceAdvice }
   } catch (error: unknown) {
     console.error('Error in recordPayment:', error)

--- a/src/app/actions/refundActions.ts
+++ b/src/app/actions/refundActions.ts
@@ -41,6 +41,7 @@ interface SourceBookingData {
   customerEmail: string | null
   customerPhone: string | null
   currency: string
+  appliedInvoiceId?: string | null
 }
 
 async function getAuthenticatedUser(): Promise<{ userId: string } | { error: string }> {
@@ -63,7 +64,7 @@ async function loadSourceBooking(
   if (sourceType === 'private_booking') {
     const { data } = await db
       .from('private_bookings')
-      .select('id, paypal_deposit_capture_id, deposit_paid_date, deposit_amount, customer_id, customer_name, contact_email, contact_phone')
+      .select('id, paypal_deposit_capture_id, deposit_paid_date, deposit_amount, customer_id, customer_name, contact_email, contact_phone, invoice_id, invoice_deposit_treatment')
       .eq('id', sourceId)
       .maybeSingle()
     if (!data) return null
@@ -77,6 +78,7 @@ async function loadSourceBooking(
       customerEmail: data.contact_email,
       customerPhone: data.contact_phone,
       currency: PAYPAL_DEFAULT_CURRENCY,
+      appliedInvoiceId: data.invoice_deposit_treatment === 'deducted' ? data.invoice_id : null,
     }
   }
 
@@ -367,6 +369,9 @@ export async function processPayPalRefund(
   // 3. Load booking
   const booking = await loadSourceBooking(db, sourceType, sourceId)
   if (!booking) return { error: 'Booking not found' }
+  if (booking.appliedInvoiceId) {
+    return { error: 'This deposit has been applied to the invoice. Resolve the invoice credit before refunding it as a separate deposit.' }
+  }
 
   // 3b. The seasonal refund promise, enforced rather than merely displayed.
   const policyCheck = await enforceSeasonalRefundPolicy(db, sourceType, sourceId, userId, reason, options)
@@ -645,6 +650,9 @@ export async function processManualRefund(
   // 3. Load booking
   const booking = await loadSourceBooking(db, sourceType, sourceId)
   if (!booking) return { error: 'Booking not found' }
+  if (booking.appliedInvoiceId) {
+    return { error: 'This deposit has been applied to the invoice. Resolve the invoice credit before refunding it as a separate deposit.' }
+  }
 
   // 3b. The same seasonal promise applies however the money goes back. Handing cash across the bar
   // inside the window is exactly as much a breach of the stated terms as a PayPal refund is.

--- a/src/app/api/cron/invoice-paypal-reconciliation/route.ts
+++ b/src/app/api/cron/invoice-paypal-reconciliation/route.ts
@@ -2,15 +2,12 @@ import { NextRequest, NextResponse } from 'next/server'
 import { authorizeCronRequest } from '@/lib/cron-auth'
 import { createAdminClient } from '@/lib/supabase/admin'
 import {
-  PAYPAL_DEFAULT_CURRENCY,
-  capturePayPalPayment,
   getPayPalOrder,
-  isPayPalOrderNotFoundError,
-  isPayPalOrderAlreadyCapturedError,
   PayPalApiError,
 } from '@/lib/paypal'
+import { reportCronFailure } from '@/lib/cron/alerting'
 import { logger } from '@/lib/logger'
-import { applyInvoicePayPalCapture } from '@/app/actions/invoicePayPalActions'
+import { settleInvoicePayPalOrder } from '@/lib/invoices/paypal-capture'
 
 /**
  * Settles invoice PayPal orders the return trip and the webhook both missed.
@@ -27,9 +24,6 @@ import { applyInvoicePayPalCapture } from '@/app/actions/invoicePayPalActions'
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
-/** After this many failures the order is dropped and staff issue a new link. */
-const MAX_ATTEMPTS = 5
-
 // Drafts are included because an invoice emailed by the auto-send run can carry
 // an order while its status flip is still catching up. Only genuinely
 // uncollectable states are excluded, and the RPC refuses those anyway.
@@ -42,6 +36,7 @@ type PendingInvoice = {
   total_amount: number | null
   paid_amount: number | null
   status: string | null
+  sent_at: string | null
   paypal_reconciliation_attempts: number | null
 }
 
@@ -53,18 +48,6 @@ function summariseError(error: unknown): string {
   return String(error).slice(0, 500)
 }
 
-function capturedAmount(order: any): { amount: number; captureId: string; currency: string | null } | null {
-  const capture = order?.purchase_units?.[0]?.payments?.captures?.[0]
-  const raw = capture?.amount?.value
-  const amount = typeof raw === 'string' ? Number.parseFloat(raw) : NaN
-  const captureId = typeof capture?.id === 'string' ? capture.id : null
-  if (!captureId || !Number.isFinite(amount) || amount <= 0) return null
-  const currency = typeof capture?.amount?.currency_code === 'string'
-    ? capture.amount.currency_code.toUpperCase()
-    : null
-  return { amount, captureId, currency }
-}
-
 async function clearOrder(
   admin: ReturnType<typeof createAdminClient>,
   invoiceId: string,
@@ -72,7 +55,7 @@ async function clearOrder(
   reason: string,
 ) {
   // Guarded on the order id so a newer one created since is left alone.
-  await admin
+  const { error } = await admin
     .from('invoices')
     .update({
       paypal_order_id: null,
@@ -82,6 +65,7 @@ async function clearOrder(
     })
     .eq('id', invoiceId)
     .eq('paypal_order_id', orderId)
+  if (error) throw error
 }
 
 export async function GET(request: NextRequest) {
@@ -96,7 +80,7 @@ export async function GET(request: NextRequest) {
   try {
     const { data, error } = await admin
       .from('invoices')
-      .select('id, invoice_number, paypal_order_id, total_amount, paid_amount, status, paypal_reconciliation_attempts')
+      .select('id, invoice_number, paypal_order_id, total_amount, paid_amount, status, sent_at, paypal_reconciliation_attempts')
       .not('paypal_order_id', 'is', null)
       .in('status', PAYABLE_STATUSES)
       .is('deleted_at', null)
@@ -114,67 +98,16 @@ export async function GET(request: NextRequest) {
         const order = await getPayPalOrder(orderId)
         const status = order?.status
 
-        if (status === 'COMPLETED') {
-          const captured = capturedAmount(order)
-          if (!captured) {
-            await clearOrder(admin, invoice.id, orderId, 'Completed order had no readable capture')
-            summary.cleared += 1
-            continue
-          }
-          if (captured.currency && captured.currency !== PAYPAL_DEFAULT_CURRENCY) {
-            logger.error('[InvoiceReconciliation] Capture not in GBP, left for a human', {
-              error: new Error('invoice_capture_wrong_currency'),
-              metadata: { invoiceId: invoice.id, currency: captured.currency },
-            })
-            summary.failed += 1
-            continue
-          }
-
-          const result = await applyInvoicePayPalCapture({
-            invoiceId: invoice.id,
-            amount: captured.amount,
-            captureId: captured.captureId,
-            orderId,
-            source: 'reconciliation',
-          })
-
-          if (result.error) {
-            summary.failed += 1
-          } else {
-            summary.settled += 1
-          }
+        if (status === 'COMPLETED' || status === 'APPROVED') {
+          const result = await settleInvoicePayPalOrder(invoice, orderId, 'reconciliation', order)
+          if (result.error) throw new Error(result.error)
+          summary.settled += 1
+          // The full capture remains credited. An excess needs staff review.
+          if ((result.overpaidAmount ?? 0) > 0) summary.failed += 1
           continue
         }
 
-        if (status === 'APPROVED') {
-          // The customer approved but the capture never ran, usually because
-          // they closed the tab on the way back. Finish it here.
-          const capture = await capturePayPalPayment(orderId, PAYPAL_DEFAULT_CURRENCY)
-          const amount = Number(capture.amount)
-
-          if (!Number.isFinite(amount) || amount <= 0) {
-            summary.failed += 1
-            continue
-          }
-
-          const result = await applyInvoicePayPalCapture({
-            invoiceId: invoice.id,
-            amount,
-            captureId: capture.transactionId,
-            orderId,
-            source: 'reconciliation',
-          })
-
-          if (result.error) {
-            summary.failed += 1
-          } else {
-            summary.settled += 1
-          }
-          continue
-        }
-
-        // VOIDED, or created and never approved and now long gone. Nothing to
-        // collect, so stop polling it.
+        // Only an explicitly voided order proves there is nothing to collect.
         if (status === 'VOIDED') {
           await clearOrder(admin, invoice.id, orderId, 'Order voided at PayPal')
           summary.cleared += 1
@@ -184,19 +117,6 @@ export async function GET(request: NextRequest) {
         // CREATED / PAYER_ACTION_REQUIRED: the customer simply has not paid
         // yet. Left alone, and not counted as a failure.
       } catch (error) {
-        if (isPayPalOrderNotFoundError(error)) {
-          await clearOrder(admin, invoice.id, orderId, 'Order no longer exists at PayPal')
-          summary.cleared += 1
-          continue
-        }
-
-        if (isPayPalOrderAlreadyCapturedError(error)) {
-          // Someone else captured it between the read and the capture. The
-          // webhook or the portal will have recorded it; nothing to do.
-          summary.cleared += 1
-          continue
-        }
-
         const attempts = (invoice.paypal_reconciliation_attempts ?? 0) + 1
         summary.failed += 1
 
@@ -205,33 +125,30 @@ export async function GET(request: NextRequest) {
           metadata: { invoiceId: invoice.id, orderId, attempts },
         })
 
-        if (attempts >= MAX_ATTEMPTS) {
-          await clearOrder(
-            admin,
-            invoice.id,
-            orderId,
-            `Given up after ${attempts} attempts: ${summariseError(error)}`,
-          )
-          summary.cleared += 1
-        } else {
-          await admin
-            .from('invoices')
-            .update({
-              paypal_reconciliation_attempts: attempts,
-              paypal_reconciliation_last_error: summariseError(error),
-              updated_at: new Date().toISOString(),
-            })
-            .eq('id', invoice.id)
-            .eq('paypal_order_id', orderId)
-        }
+        // A timeout, missing order or unreadable capture does not prove that
+        // no money moved. Keep its reference available for the next recovery.
+        const { error: updateError } = await admin
+          .from('invoices')
+          .update({
+            paypal_reconciliation_attempts: attempts,
+            paypal_reconciliation_last_error: summariseError(error),
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', invoice.id)
+          .eq('paypal_order_id', orderId)
+        if (updateError) throw updateError
       }
     }
 
-    return NextResponse.json({ success: true, ...summary })
+    if (summary.failed > 0) {
+      await reportCronFailure('invoice-paypal-reconciliation', new Error('Invoice payments need reconciliation'), summary)
+    }
+    return NextResponse.json({ success: summary.failed === 0, ...summary }, { status: summary.failed > 0 ? 500 : 200 })
   } catch (error) {
     logger.error('[InvoiceReconciliation] Run failed', {
       error: error instanceof Error ? error : new Error(String(error)),
     })
+    await reportCronFailure('invoice-paypal-reconciliation', error, summary)
     return NextResponse.json({ success: false, error: 'Reconciliation failed' }, { status: 500 })
   }
 }

--- a/src/app/api/webhooks/paypal/invoices/route.ts
+++ b/src/app/api/webhooks/paypal/invoices/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { resolveWebhookIdForUrl, verifyPayPalWebhook } from '@/lib/paypal'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
-import { applyInvoicePayPalCapture } from '@/app/actions/invoicePayPalActions'
+import { applyInvoicePayPalCapture, positivePennies } from '@/lib/invoices/paypal-capture'
 import { INVOICE_PAYMENT_CUSTOM_ID_PREFIX } from '@/lib/invoices/paypal-custom-id'
 import {
   claimIdempotencyKey,
@@ -157,9 +157,12 @@ export async function POST(request: NextRequest) {
       IDEMPOTENCY_TTL_HOURS,
     )
 
-    // Anything but a fresh claim means this event is already being handled or
-    // has been: acknowledge so PayPal stops retrying, and do no work.
-    if (claim.state !== 'claimed') {
+    // Only a completed delivery can be acknowledged as a duplicate. A held
+    // claim may still fail, so PayPal must retry it.
+    if (claim.state === 'in_progress' || claim.state === 'conflict') {
+      return NextResponse.json({ error: 'Webhook processing has not completed' }, { status: 503 })
+    }
+    if (claim.state === 'replay') {
       await logWebhook(supabase, { status: 'duplicate', headers, body, eventId, eventType })
       return NextResponse.json({ received: true, duplicate: true })
     }
@@ -173,7 +176,8 @@ export async function POST(request: NextRequest) {
       case 'PAYMENT.CAPTURE.COMPLETED': {
         const captureId = typeof event?.resource?.id === 'string' ? event.resource.id : null
         const rawAmount = event?.resource?.amount?.value
-        const amount = typeof rawAmount === 'string' ? Number.parseFloat(rawAmount) : NaN
+        const pennies = positivePennies(rawAmount)
+        const amount = pennies === null ? NaN : pennies / 100
         const currency = event?.resource?.amount?.currency_code
 
         if (!captureId || !Number.isFinite(amount) || amount <= 0) {
@@ -181,22 +185,25 @@ export async function POST(request: NextRequest) {
             error: new Error('invoice_capture_unreadable'),
             metadata: { eventId, invoiceId, captureId, rawAmount },
           })
-          break
+          throw new Error('invoice_capture_unreadable')
         }
 
-        if (currency && String(currency).toUpperCase() !== 'GBP') {
+        if (currency !== 'GBP') {
           logger.error('[InvoicePayPal webhook] Capture was not in GBP, not applied', {
             error: new Error('invoice_capture_wrong_currency'),
             metadata: { eventId, invoiceId, currency },
           })
-          break
+          throw new Error('invoice_capture_wrong_currency')
         }
+        if (event.resource.status !== 'COMPLETED') throw new Error('invoice_capture_not_completed')
 
         const result = await applyInvoicePayPalCapture({
           invoiceId,
           amount,
           captureId,
           source: 'webhook',
+          capturedAt: event.resource.create_time ?? null,
+          orderId: event.resource.supplementary_data?.related_ids?.order_id ?? null,
         })
 
         if (result.error) {
@@ -204,6 +211,7 @@ export async function POST(request: NextRequest) {
             error: new Error(result.error),
             metadata: { eventId, invoiceId, captureId },
           })
+          throw new Error(result.error)
         }
         break
       }
@@ -217,20 +225,22 @@ export async function POST(request: NextRequest) {
           : null
 
         if (orderId) {
-          await supabase
+          const { error: releaseError } = await supabase
             .from('invoices')
             .update({ paypal_order_id: null, updated_at: new Date().toISOString() })
             .eq('id', invoiceId)
             .eq('paypal_order_id', orderId)
+          if (releaseError) throw releaseError
         }
 
-        await supabase.from('audit_logs').insert({
+        const { error: auditError } = await supabase.from('audit_logs').insert({
           operation_type: 'paypal_capture_denied',
           resource_type: 'invoice',
           resource_id: invoiceId,
           operation_status: 'failure',
           additional_info: { event_id: eventId, event_type: eventType, order_id: orderId },
         })
+        if (auditError) throw auditError
         break
       }
 

--- a/src/lib/__tests__/contract-template.test.ts
+++ b/src/lib/__tests__/contract-template.test.ts
@@ -675,3 +675,25 @@ describe('matchesSelfCateringPackageName', () => {
     expect(matchesSelfCateringPackageName(undefined)).toBe(false)
   })
 })
+
+
+describe('linked invoice settlement in rendered contracts', () => {
+  it('shows the applied deposit within the event price and zero outstanding once paid', () => {
+    const booking = makeBooking([makeItem({ quantity: 1, unit_price: 829, line_total: 829, vat_rate: 20 })], {
+      invoice_id: 'invoice-id',
+      invoice_deposit_treatment: 'deducted',
+      deposit_amount: 250,
+      deposit_paid_date: '2026-08-28',
+      applied_deposit_amount: 250,
+      payments: [{ id: 'paypal-payment', booking_id: 'booking-id', amount: 744.8, method: 'paypal', created_at: '2026-09-05', source: 'invoice', readonly: true }],
+    })
+    const html = generateContractHTML(baseData(booking))
+    expect(html).toContain('Deposit applied to invoice')
+    expect(html).toContain('Total to pay before the event</span><span class="fv">£994.80')
+    expect(html).toContain('Event balance outstanding</span><span class="fv">£0.00')
+    expect(html).not.toContain('£1,244.80')
+    expect(html).not.toContain('process the deposit refund within')
+    expect(html).not.toContain('deposit refund is processed within')
+    expect(html).not.toContain('deposit is separate from and additional to the event price')
+  })
+})

--- a/src/lib/contract-template.ts
+++ b/src/lib/contract-template.ts
@@ -174,7 +174,16 @@ export function generateContractHTML(data: ContractData): string {
   const depositAmount = Number.isFinite(rawDepositAmount) ? Number(rawDepositAmount) : 0
   const depositRequired = depositAmount > 0
   const eventPriceGross = money.grossTotal
-  const totalToPay = round2(eventPriceGross + depositAmount)
+  const appliedDepositAmount = booking.invoice_id && booking.invoice_deposit_treatment === 'deducted'
+    ? Number(booking.applied_deposit_amount ?? 0)
+    : 0
+  const depositApplied = appliedDepositAmount > 0
+  const separateDepositAmount = depositApplied ? 0 : depositAmount
+  const eventPaidAmount = round2((booking.payments ?? []).reduce(
+    (sum: number, payment: { amount: number }) => sum + Number(payment.amount), 0,
+  ) + appliedDepositAmount)
+  const eventOutstanding = Math.max(0, round2(eventPriceGross - eventPaidAmount))
+  const totalToPay = round2(eventPriceGross + separateDepositAmount)
 
   // Balance-due date — the stored column is the single source of truth. The contract
   // never computes its own date: a stored date wins even over a stale TBD marker,
@@ -209,7 +218,13 @@ export function generateContractHTML(data: ContractData): string {
 
   // ---- deposit-dependent fragments ----
   // When no deposit is stored the contract must not demand one; wording stays calm.
-  const depositBoxHtml = depositRequired
+  const depositBoxHtml = depositApplied
+    ? `<div class="deposit-box">
+              <span class="db-l">Deposit applied to invoice</span>
+              <span class="db-r">${formatCurrency(appliedDepositAmount)}</span>
+              <small>The deposit has been applied towards the event price at the operator's instruction. It is not an additional amount payable or a separate refundable bond.</small>
+            </div>`
+    : depositRequired
     ? `<div class="deposit-box">
               <span class="db-l">Booking &amp; damage deposit</span>
               <span class="db-r">${formatCurrency(depositAmount)}</span>
@@ -223,7 +238,9 @@ export function generateContractHTML(data: ContractData): string {
               <small>No booking deposit is payable for this event.${booking.deposit_paid_date ? ` A deposit payment was recorded on ${formatDate(booking.deposit_paid_date)}.` : ''}</small>
             </div>`
   // Customer note (rewording pack §31)
-  const depositCalloutHtml = depositRequired
+  const depositCalloutHtml = depositApplied
+    ? `<p class="callout">For this booking, ${formatCurrency(appliedDepositAmount)} of the deposit has been applied to the invoice at the operator's instruction. This recorded arrangement replaces references in these terms to that amount being held separately or excluded from the event balance. Any refund requires review against the invoice.</p>`
+    : depositRequired
     ? `<p class="callout">The booking and damage deposit is separate from the event price. It cannot be used towards the event balance, bar spend, catering, entertainment, venue hire, supplier charges or any other event cost. If the event proceeds as booked, the deposit will be processed for refund within 48 hours after the event, less any documented deductions.</p>`
     : `<p class="callout">No booking and damage deposit is payable for this event. The full event balance remains payable by the due date.</p>`
 
@@ -406,7 +423,9 @@ export function generateContractHTML(data: ContractData): string {
   // will read the schedule total as everything owed. It is named in words only.
   const scheduleFootnotesHtml = `
             <p class="callout">All values in the table above exclude VAT. The VAT shown is the VAT included in the event price on page 1, and the event price, excluding deposit, is the same figure as the financial summary on page 1.${bookingDiscountSentence}</p>
-            <p class="callout" style="margin-bottom:0;">${depositRequired
+            <p class="callout" style="margin-bottom:0;">${depositApplied
+              ? `This schedule covers the event price. The deposit of ${formatCurrency(appliedDepositAmount)} has been applied towards that price and is not an additional charge.`
+              : depositRequired
               ? `This schedule covers the event price only. The booking and damage deposit of ${formatCurrency(depositAmount)} is not part of the event price and is not included in the figures above. It is shown separately on page 1, where it is added to give the total to pay before the event.`
               : 'This schedule covers the event price only. No booking and damage deposit is payable for this event.'}</p>`
 
@@ -532,7 +551,7 @@ ${scheduleFootnotesHtml}` : ''}</div>
   /* financial summary + deposit side by side */
   .money{ display:grid; grid-template-columns:1fr 1fr; gap:6mm; margin:0 0 4mm; align-items:start; }
   .fin{ border:1px solid var(--ink); }
-  .fin-row{ display:flex; justify-content:space-between; align-items:baseline; padding:2.2mm 3.6mm; border-bottom:1px solid var(--rule); font-size:11px; color:var(--ink-soft); }
+  .fin-row{ display:flex; justify-content:space-between; align-items:baseline; padding:1.4mm 3.6mm; border-bottom:1px solid var(--rule); font-size:11px; color:var(--ink-soft); }
   .fin-row:last-child{ border-bottom:0; }
   .fin-row .fv{ font-weight:600; color:var(--ink); font-variant-numeric:tabular-nums; }
   .fin-row.total{ background:#f4f1ea; }
@@ -683,9 +702,11 @@ ${scheduleFootnotesHtml}` : ''}</div>
               <div class="fin-row"><span class="fk">Discounts (excl. VAT)</span><span class="fv">${discountTotal > 0 ? `&minus;${formatCurrency(discountTotal)}` : formatCurrency(0)}</span></div>
               <div class="fin-row"><span class="fk">Event price, excluding deposit</span><span class="fv">${formatCurrency(eventPriceGross)}</span></div>
               <div class="fin-row"><span class="fk">VAT included in event price</span><span class="fv">${formatCurrency(money.vatAmount)}</span></div>
-              <div class="fin-row"><span class="fk">Booking and damage deposit (held separately)</span><span class="fv">${depositRequired ? formatCurrency(depositAmount) : 'None'}</span></div>
+              <div class="fin-row"><span class="fk">${depositApplied ? 'Deposit applied to invoice' : 'Booking and damage deposit (held separately)'}</span><span class="fv">${depositRequired ? formatCurrency(depositApplied ? appliedDepositAmount : depositAmount) : 'None'}</span></div>
               <div class="fin-row total"><span class="fk">Total to pay before the event</span><span class="fv">${formatCurrency(totalToPay)}</span></div>
-              <div class="fin-row"><span class="fk">Amount potentially returnable after the event</span><span class="fv">${formatCurrency(depositAmount)}</span></div>
+              <div class="fin-row"><span class="fk">Event payments received</span><span class="fv">${formatCurrency(eventPaidAmount)}</span></div>
+              <div class="fin-row"><span class="fk">Event balance outstanding</span><span class="fv">${formatCurrency(eventOutstanding)}</span></div>
+              <div class="fin-row"><span class="fk">Amount potentially returnable after the event</span><span class="fv">${formatCurrency(separateDepositAmount)}</span></div>
             </div>
             ${depositBoxHtml}
           </div>
@@ -723,8 +744,8 @@ ${scheduleSheetsHtml}
           <div class="tc">
 ${depositRequired ? `            <p>A booking and damage deposit is required to secure the date and time shown in this contract. The deposit secures the booking, removes the date and time from general availability, and protects The Anchor against reasonable cancellation losses, damage, missing items, specialist cleaning, unauthorised overtime, unpaid charges, supplier costs, special-order items and other sums arising from the event.</p>
             <p>The booking is not confirmed until the deposit has been received in cleared funds and The Anchor has issued written confirmation. Before payment, The Anchor may place a provisional hold on the date and time. A provisional hold is not a confirmed booking and may be released if the deposit is not received in cleared funds by the hold expiry date, unless The Anchor agrees otherwise in writing.</p>
-            <p>The deposit is separate from and additional to the event price. It cannot be used as payment towards the event balance, bar spend, catering, entertainment, venue hire, supplier charges or any other event cost.</p>
-            <p>If the event proceeds as booked, The Anchor will process the deposit refund within <b>48 hours</b> after the event, provided the full balance has been paid, all agreed charges have been settled, and no deductions are required. The Anchor may use this 48-hour period to inspect the premises and complete cleaning checks.</p>
+            ${depositApplied ? '<p>The recorded arrangement for this booking applies the deposit towards the invoice. It is not held as a separate refundable bond. Any refund requires review against the invoice.</p>' : '<p>The deposit is separate from and additional to the event price. It cannot be used as payment towards the event balance, bar spend, catering, entertainment, venue hire, supplier charges or any other event cost.</p>'}
+            ${depositApplied ? '' : '<p>If the event proceeds as booked, The Anchor will process the deposit refund within <b>48 hours</b> after the event, provided the full balance has been paid, all agreed charges have been settled, and no deductions are required. The Anchor may use this 48-hour period to inspect the premises and complete cleaning checks.</p>'}
             <p>Any proposed deduction will be documented and discussed with the Host before it is made. Ordinary incidental wear and minor glass breakages are not charged. Where sums owed exceed the deposit, the Host must pay the balance on demand.</p>` : `            <p>No booking deposit is required for this event. The booking is confirmed once agreed in writing with The Anchor.</p>
             <p>The Host remains responsible for reasonable costs arising from the event, including damage, missing items, specialist cleaning, unauthorised overtime, unpaid charges, supplier costs and special-order items, which are payable on demand. Ordinary incidental wear and minor glass breakages are not charged. Any proposed charge will be documented and discussed with the Host before it is made.</p>`}
           </div>
@@ -732,7 +753,9 @@ ${depositRequired ? `            <p>A booking and damage deposit is required to 
           <p class="section-label gap">Agreement</p>
           <div class="tc">
 ${depositRequired ? `            <p>I, <b>${safeCustomerName}</b>, agree to engage Orange Jelly Limited trading as The Anchor Pub to host my event described as <b>&ldquo;${safeEventType}&rdquo;</b> on <b>${eventDate}</b> from <b>${startTime}</b> to <b>${endTime}</b> at ${venue}.</p>
-            <p>I agree to pay the event price of <b>${formatCurrency(eventPriceGross)}</b> (including VAT) and the separate booking and damage deposit of <b>${formatCurrency(depositAmount)}</b>. I understand that the deposit is separate from and additional to the event price and cannot be used towards the event balance or any other charge.</p>
+            ${depositApplied
+              ? `<p>I agree to pay the event price of <b>${formatCurrency(eventPriceGross)}</b> (including VAT). The deposit of <b>${formatCurrency(appliedDepositAmount)}</b> has been applied towards the invoice under the recorded arrangement for this booking.</p>`
+              : `<p>I agree to pay the event price of <b>${formatCurrency(eventPriceGross)}</b> (including VAT) and the separate booking and damage deposit of <b>${formatCurrency(depositAmount)}</b>. I understand that the deposit is separate from and additional to the event price and cannot be used towards the event balance or any other charge.</p>`}
             <p>The full event balance, final guest numbers, catering choices, supplier details, entertainment details, decoration plans, running order, allergy information, dietary requirements and accessibility requirements are due no later than <b>${balanceDueDate}</b>, unless The Anchor has agreed a different written deadline.</p>
             <p>If I provide final details late, I understand The Anchor will try to help where reasonably possible, but preferred menus, suppliers, layouts, timings, equipment or other options may no longer be available. If essential details or payment remain outstanding after reminder and General Manager review, The Anchor may treat the booking as cancelled by me.</p>
             <p>By signing below, paying the deposit, or otherwise confirming the booking in writing after receiving this Agreement, I confirm that I have read, understood and agree to be bound by this Agreement and its terms and conditions.</p>` : `            <p>I, <b>${safeCustomerName}</b>, agree to engage Orange Jelly Limited trading as The Anchor Pub to host my event described as <b>&ldquo;${safeEventType}&rdquo;</b> on <b>${eventDate}</b> from <b>${startTime}</b> to <b>${endTime}</b> at ${venue}.</p>
@@ -781,7 +804,7 @@ ${depositRequired ? `            <p>I, <b>${safeCustomerName}</b>, agree to enga
             <div class="tc-sec">
               <p class="tc-h">Reservation and deposit</p>
               <p>A booking and damage deposit is required to secure the date and time shown in the booking schedule, unless the financial summary states that no deposit is payable. Before payment, The Anchor may place a provisional hold on the date and time. A provisional hold is not a confirmed booking and may be released if the deposit is not received in cleared funds by the hold expiry date, unless The Anchor agrees otherwise in writing. The booking is confirmed only when the deposit has been received in cleared funds and The Anchor has issued written confirmation.</p>
-              <p>The deposit is separate from and additional to the event price and cannot be used towards the event balance, bar spend, catering, entertainment, venue hire, supplier charges or any other event cost. If the event proceeds as booked, the deposit refund is processed within 48 hours after the event, provided the full balance has been paid, all agreed charges have been settled and no deductions are required. The Anchor may use this 48-hour period to inspect the premises and complete cleaning checks.</p>
+              ${depositApplied ? '<p>The recorded arrangement for this booking applies the deposit towards the invoice. It is not held as a separate refundable bond. Any refund requires review against the invoice.</p>' : '<p>The deposit is separate from and additional to the event price and cannot be used towards the event balance, bar spend, catering, entertainment, venue hire, supplier charges or any other event cost. If the event proceeds as booked, the deposit refund is processed within 48 hours after the event, provided the full balance has been paid, all agreed charges have been settled and no deductions are required. The Anchor may use this 48-hour period to inspect the premises and complete cleaning checks.</p>'}
               <p>Any proposed deduction will be documented and discussed with the Host before it is made. Ordinary incidental wear and minor glass breakages are not charged. Where sums owed exceed the deposit, the Host must pay the balance on demand.</p>
             </div>
             <div class="tc-sec">

--- a/src/lib/invoices/paypal-capture.ts
+++ b/src/lib/invoices/paypal-capture.ts
@@ -1,0 +1,162 @@
+import 'server-only'
+
+import { revalidatePath } from 'next/cache'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { logAuditEvent } from '@/app/actions/audit'
+import { logger } from '@/lib/logger'
+import { capturePayPalPayment, getPayPalOrder, isPayPalOrderAlreadyCapturedError, PAYPAL_DEFAULT_CURRENCY } from '@/lib/paypal'
+import { invoicePaymentCustomId } from './paypal-custom-id'
+
+type InvoicePaymentState = {
+  id: string
+  status: string | null
+  total_amount: number | null
+  paid_amount: number | null
+  sent_at?: string | null
+}
+
+type InvoiceOrder = {
+  id?: string
+  status?: string
+  purchase_units?: Array<{
+    reference_id?: string
+    custom_id?: string
+    amount?: { value?: string; currency_code?: string }
+    payments?: { captures?: Array<{
+      id?: string
+      status?: string
+      create_time?: string
+      amount?: { value?: string; currency_code?: string }
+    }> }
+  }>
+}
+
+type CaptureSource = 'portal' | 'webhook' | 'reconciliation'
+type CaptureResult = { success?: boolean; alreadyRecorded?: boolean; overpaidAmount?: number; error?: string }
+
+export function positivePennies(value: unknown): number | null {
+  if (typeof value !== 'number' && typeof value !== 'string') return null
+  const raw = String(value)
+  if (!/^\d+(?:\.\d{1,2})?$/.test(raw)) return null
+  const pennies = Math.round(Number(raw) * 100)
+  return Number.isSafeInteger(pennies) && pennies > 0 ? pennies : null
+}
+
+/** Trusted callers supply an invoice read from the database, never request input. */
+export async function settleInvoicePayPalOrder(
+  invoice: InvoicePaymentState,
+  orderId: string,
+  source: CaptureSource,
+  observedOrder?: InvoiceOrder,
+): Promise<CaptureResult> {
+  let order: InvoiceOrder = observedOrder ?? await getPayPalOrder(orderId)
+  const unit = order.purchase_units?.[0]
+  if (order.purchase_units?.length !== 1 || unit?.reference_id !== invoice.id
+    || unit.custom_id !== invoicePaymentCustomId(invoice.id) || (order.id && order.id !== orderId)) {
+    return { error: 'That payment does not match this invoice.' }
+  }
+  if (unit.amount?.currency_code !== PAYPAL_DEFAULT_CURRENCY) {
+    return { error: 'That payment was not in pounds, so it has not been applied.' }
+  }
+
+  if (order.status !== 'COMPLETED') {
+    const payable = ['sent', 'overdue', 'partially_paid'].includes(invoice.status ?? '')
+      || (invoice.status === 'draft' && Boolean(invoice.sent_at))
+    if (!payable) return { error: 'This invoice cannot be paid online.' }
+    const due = Math.round((Number(invoice.total_amount) - Number(invoice.paid_amount)) * 100)
+    if (due <= 0 || positivePennies(unit.amount?.value) !== due) {
+      return { error: 'The amount due has changed. Reload the invoice before paying.' }
+    }
+    if (order.status !== 'APPROVED' || unit.payments?.captures?.length) {
+      return { error: 'PayPal has not confirmed this payment. Please contact us before paying again.' }
+    }
+    try {
+      await capturePayPalPayment(orderId, PAYPAL_DEFAULT_CURRENCY)
+    } catch (error) {
+      if (!isPayPalOrderAlreadyCapturedError(error)) throw error
+    }
+    // The order-level result can be COMPLETED while an individual capture is
+    // still PENDING. Read PayPal's capture state before crediting any money.
+    order = await getPayPalOrder(orderId)
+    return settleInvoicePayPalOrder(invoice, orderId, source, order.status === 'COMPLETED' ? order : {
+      ...order, status: 'PENDING',
+    })
+  }
+
+  const captures = unit.payments?.captures
+  if (captures?.length !== 1) return { error: 'PayPal returned an unexpected capture. Please contact us before paying again.' }
+  const capture = captures[0]
+  const pennies = positivePennies(capture.amount?.value)
+  if (capture.status !== 'COMPLETED' || !capture.id || pennies === null
+    || capture.amount?.currency_code !== PAYPAL_DEFAULT_CURRENCY) {
+    return { error: 'PayPal has not confirmed a completed payment in pounds. Please contact us before paying again.' }
+  }
+  return applyInvoicePayPalCapture({ invoiceId: invoice.id, amount: pennies / 100, captureId: capture.id, orderId, source, capturedAt: capture.create_time ?? null })
+}
+
+export async function applyInvoicePayPalCapture(params: {
+  invoiceId: string
+  amount: number
+  captureId: string
+  orderId?: string | null
+  source: 'portal' | 'webhook' | 'reconciliation'
+  capturedAt?: string | null
+}): Promise<{ success?: boolean; alreadyRecorded?: boolean; overpaidAmount?: number; error?: string }> {
+  const admin = createAdminClient()
+
+  const { data, error } = await (admin.rpc as unknown as (
+    fn: string,
+    args: Record<string, unknown>,
+  ) => Promise<{
+    data: { recorded: boolean; already_recorded: boolean; status: string; invoice_number: string; private_booking_id?: string | null; overpaid_amount?: number | string } | null
+    error: { message: string } | null
+  }>)('record_invoice_paypal_payment_atomic', {
+    p_invoice_id: params.invoiceId,
+    p_amount: params.amount,
+    p_capture_id: params.captureId,
+    p_order_id: params.orderId ?? null,
+    p_captured_at: params.capturedAt ?? null,
+  })
+
+  if (error || !data) {
+    logger.error('[InvoicePayPal] Could not record the capture', {
+      error: error instanceof Error ? error : new Error(error?.message || 'unknown'),
+      metadata: { ...params },
+    })
+    return { error: 'The payment was taken but we could not record it. We will sort this out.' }
+  }
+
+  const overpaidAmount = Number(data.overpaid_amount ?? 0)
+  const newlyOverpaid = data.recorded && Number.isFinite(overpaidAmount) && overpaidAmount > 0
+  if (newlyOverpaid) {
+    logger.error('[InvoicePayPal] Captured payment exceeds the invoice total; review the excess', {
+      error: new Error('invoice_paypal_overpayment'),
+      metadata: { invoiceId: params.invoiceId, captureId: params.captureId, overpaidAmount },
+    })
+  }
+
+  await logAuditEvent({
+    operation_type: 'payment',
+    resource_type: 'invoice',
+    resource_id: params.invoiceId,
+    operation_status: 'success',
+    new_values: {
+      action: `invoice_paypal_captured_via_${params.source}`,
+      invoice_number: data.invoice_number,
+      amount: params.amount,
+      capture_id: params.captureId,
+      already_recorded: data.already_recorded,
+      status: data.status,
+      overpaid_amount: overpaidAmount,
+    },
+  })
+
+  revalidatePath(`/invoices/${params.invoiceId}`)
+  revalidatePath('/invoices')
+  if (data.private_booking_id) {
+    revalidatePath(`/private-bookings/${data.private_booking_id}`)
+    revalidatePath('/private-bookings')
+  }
+
+  return { success: true, alreadyRecorded: data.already_recorded, ...(newlyOverpaid ? { overpaidAmount } : {}) }
+}

--- a/src/lib/private-bookings/contract-lifecycle.ts
+++ b/src/lib/private-bookings/contract-lifecycle.ts
@@ -1,3 +1,4 @@
+import { readBookingPaymentLedger } from '@/lib/private-bookings/payment-ledger'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { generateContractHTML, bookingRequiresWaiverAnnex } from '@/lib/contract-template'
 import { CONTRACT_LOGO_DATA_URI } from '@/lib/private-bookings/contract-logo'
@@ -65,6 +66,10 @@ export async function renderContractPreview(bookingId: string): Promise<Generate
     throw new Error('Booking not found')
   }
 
+  const ledger = await readBookingPaymentLedger(bookingId)
+  booking.payments = ledger.payments
+  booking.applied_deposit_amount = ledger.appliedDepositAmount
+
   const version = Number((booking as { contract_version?: number | null }).contract_version ?? 0)
 
   const html = generateContractHTML({
@@ -100,6 +105,10 @@ export async function generateContractDocument(
   if (error || !booking) {
     throw new Error('Booking not found')
   }
+
+  const ledger = await readBookingPaymentLedger(bookingId)
+  booking.payments = ledger.payments
+  booking.applied_deposit_amount = ledger.appliedDepositAmount
 
   const { data: incrementedVersion, error: versionError } = await admin.rpc(
     'increment_private_booking_contract_version',

--- a/src/lib/private-bookings/payment-ledger.test.ts
+++ b/src/lib/private-bookings/payment-ledger.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { readBookingPaymentLedger, readBookingPaymentLedgers } from './payment-ledger'
+
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
+
+function database(options: { treatment?: string; invoiceError?: boolean; bookingError?: boolean; paymentError?: boolean; invoiceMissing?: boolean } = {}) {
+  const from = vi.fn((table: string) => ({
+    select: vi.fn(() => ({
+      in: vi.fn(async (_column: string, ids: string[]) => {
+        if (table === 'private_bookings') return {
+          data: ids.map(id => ({ id, invoice_id: `invoice-${id}`, invoice_deposit_treatment: options.treatment ?? 'deducted' })),
+          error: options.bookingError ? { message: 'unavailable' } : null,
+        }
+        if (table === 'private_booking_payments') return {
+          data: ids.map(id => ({ id: `cash-${id}`, booking_id: id, amount: 100, method: 'cash', created_at: '2026-09-01' })),
+          error: options.paymentError ? { message: 'unavailable' } : null,
+        }
+        if (table === 'invoices') return { data: options.invoiceMissing ? [] : ids.map(id => ({ id, status: 'paid', deleted_at: null })), error: null }
+        return {
+          data: ids.flatMap(id => [
+            { id: `copy-${id}`, invoice_id: id, amount: 100, source_kind: 'booking_payment' },
+            { id: `deposit-${id}`, invoice_id: id, amount: 250, source_kind: 'booking_deposit' },
+            { id: `paypal-${id}`, invoice_id: id, amount: '644.80', source_kind: 'paypal', payment_method: 'paypal', payment_date: '2026-09-05', created_at: '2026-09-05T12:00:00Z' },
+            { id: `manual-${id}`, invoice_id: id, amount: 20, source_kind: null, payment_method: 'bank_transfer', payment_date: '2026-09-04', created_at: '2026-09-04T12:00:00Z' },
+          ]),
+          error: options.invoiceError ? { message: 'unavailable' } : null,
+        }
+      }),
+    })),
+  }))
+  vi.mocked(createAdminClient).mockReturnValue({ from } as unknown as ReturnType<typeof createAdminClient>)
+  return from
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('linked booking payment ledger', () => {
+  it('counts original money once and applies only the actual invoice deposit credit', async () => {
+    database()
+    const ledger = await readBookingPaymentLedger('booking')
+    expect(ledger.balancePaymentsTotal).toBe(764.8)
+    expect(ledger.appliedDepositAmount).toBe(250)
+    expect(ledger.eventPaidTotal).toBe(1014.8)
+    expect(ledger.payments).toHaveLength(3)
+    expect(ledger.payments.find(payment => payment.method === 'paypal')).toMatchObject({ readonly: true, source: 'invoice', invoice_id: 'invoice-booking', amount: 644.8 })
+  })
+
+  it('keeps a held deposit separate from the event balance', async () => {
+    database({ treatment: 'held_separately' })
+    const ledger = await readBookingPaymentLedger('booking')
+    expect(ledger.appliedDepositAmount).toBe(0)
+    expect(ledger.eventPaidTotal).toBe(764.8)
+  })
+
+  it('loads multiple bookings in four batch queries without mixing their money', async () => {
+    const from = database()
+    const ledgers = await readBookingPaymentLedgers(['one', 'two', 'one'])
+    expect(from).toHaveBeenCalledTimes(4)
+    expect(ledgers.size).toBe(2)
+    expect(ledgers.get('one')?.eventPaidTotal).toBe(1014.8)
+    expect(ledgers.get('two')?.payments.every(payment => payment.booking_id === 'two')).toBe(true)
+  })
+
+  it('fails closed when a linked invoice is missing', async () => {
+    database({ invoiceMissing: true })
+    await expect(readBookingPaymentLedger('booking')).rejects.toThrow('missing or withdrawn')
+  })
+
+  it.each(['bookingError', 'paymentError', 'invoiceError'] as const)('fails closed on %s', async key => {
+    database({ [key]: true })
+    await expect(readBookingPaymentLedger('booking')).rejects.toThrow('Failed to load')
+  })
+})

--- a/src/lib/private-bookings/payment-ledger.ts
+++ b/src/lib/private-bookings/payment-ledger.ts
@@ -1,0 +1,114 @@
+import 'server-only'
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import type { PrivateBookingPayment } from '@/types/private-bookings'
+
+export interface BookingPaymentLedger {
+  payments: PrivateBookingPayment[]
+  appliedDepositAmount: number
+  balancePaymentsTotal: number
+  eventPaidTotal: number
+}
+
+interface BookingLink {
+  id: string
+  invoice_id: string | null
+  invoice_deposit_treatment: string | null
+}
+
+interface InvoicePaymentRow {
+  id: string
+  invoice_id: string
+  amount: number | string
+  payment_method: string | null
+  payment_date: string
+  created_at: string
+  notes: string | null
+  source_kind: string | null
+}
+
+function money(value: unknown): number {
+  const amount = Number(value)
+  if (!Number.isFinite(amount)) throw new Error('A booking payment has an invalid amount')
+  return Math.round((amount + Number.EPSILON) * 100) / 100
+}
+
+/** Read both money ledgers once per batch. Invoice copies are never new money.
+ * Callers must first authorise access to the requested bookings. The admin
+ * client lets booking staff see linked payments without invoice-management rights.
+ */
+export async function readBookingPaymentLedgers(
+  bookingIds: string[],
+): Promise<Map<string, BookingPaymentLedger>> {
+  const ids = [...new Set(bookingIds)]
+  const result = new Map<string, BookingPaymentLedger>()
+  if (ids.length === 0) return result
+  const db = createAdminClient()
+  const [bookingsResult, paymentsResult] = await Promise.all([
+    db.from('private_bookings').select('id, invoice_id, invoice_deposit_treatment').in('id', ids),
+    db.from('private_booking_payments').select('*').in('booking_id', ids),
+  ])
+  if (bookingsResult.error) throw new Error(`Failed to load booking payment links: ${bookingsResult.error.message}`)
+  if (paymentsResult.error) throw new Error(`Failed to load booking payments: ${paymentsResult.error.message}`)
+  const bookings = (bookingsResult.data ?? []) as BookingLink[]
+  if (bookings.length !== ids.length) throw new Error('A booking payment ledger could not be loaded')
+  const invoiceIds = bookings.flatMap(booking => booking.invoice_id ? [booking.invoice_id] : [])
+  let invoicePayments: InvoicePaymentRow[] = []
+  if (invoiceIds.length > 0) {
+    const [invoiceResult, linkedInvoicesResult] = await Promise.all([
+      db.from('invoice_payments')
+        .select('id, invoice_id, amount, payment_method, payment_date, created_at, notes, source_kind')
+        .in('invoice_id', invoiceIds),
+      db.from('invoices').select('id, status, deleted_at').in('id', invoiceIds),
+    ])
+    if (invoiceResult.error) throw new Error(`Failed to load linked invoice payments: ${invoiceResult.error.message}`)
+    if (linkedInvoicesResult.error) throw new Error(`Failed to load linked invoices: ${linkedInvoicesResult.error.message}`)
+    const validInvoiceIds = new Set((linkedInvoicesResult.data ?? [])
+      .filter(invoice => !invoice.deleted_at && !['void', 'written_off'].includes(invoice.status))
+      .map(invoice => invoice.id))
+    if (invoiceIds.some(id => !validInvoiceIds.has(id))) {
+      throw new Error('The booking invoice is missing or withdrawn. Review its payment link before continuing.')
+    }
+    invoicePayments = (invoiceResult.data ?? []) as InvoicePaymentRow[]
+  }
+  for (const booking of bookings) {
+    const payments: PrivateBookingPayment[] = (paymentsResult.data ?? [])
+      .filter(payment => payment.booking_id === booking.id)
+      .map(payment => ({ ...payment, amount: money(payment.amount), source: 'booking' as const }))
+    let appliedDepositAmount = 0
+    for (const payment of invoicePayments) {
+      if (payment.invoice_id !== booking.invoice_id) continue
+      if (payment.source_kind === 'booking_payment') continue
+      if (payment.source_kind === 'booking_deposit') {
+        if (booking.invoice_deposit_treatment === 'deducted') appliedDepositAmount += money(payment.amount)
+        continue
+      }
+      payments.push({
+        id: payment.id,
+        booking_id: booking.id,
+        amount: money(payment.amount),
+        method: (payment.payment_method ?? 'other') as PrivateBookingPayment['method'],
+        notes: payment.notes ?? undefined,
+        created_at: payment.payment_date,
+        source: 'invoice',
+        invoice_id: payment.invoice_id,
+        readonly: true,
+      })
+    }
+    payments.sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))
+    const balancePaymentsTotal = money(payments.reduce((sum, payment) => sum + payment.amount, 0))
+    result.set(booking.id, {
+      payments,
+      appliedDepositAmount: money(appliedDepositAmount),
+      balancePaymentsTotal,
+      eventPaidTotal: money(balancePaymentsTotal + appliedDepositAmount),
+    })
+  }
+  return result
+}
+
+export async function readBookingPaymentLedger(bookingId: string): Promise<BookingPaymentLedger> {
+  const ledger = (await readBookingPaymentLedgers([bookingId])).get(bookingId)
+  if (!ledger) throw new Error('Booking payment ledger could not be loaded')
+  return ledger
+}

--- a/src/services/private-bookings.test.ts
+++ b/src/services/private-bookings.test.ts
@@ -37,12 +37,14 @@ function mockAdminClient({ booking, payments, paymentsError = false }: MockAdmin
           select: vi.fn().mockReturnThis(),
           eq: vi.fn().mockReturnThis(),
           single: vi.fn().mockResolvedValue({ data: booking, error: null }),
+          in: vi.fn(async (_key: string, ids: string[]) => ({ data: booking ? ids.map(id => ({ ...booking, id, invoice_id: null })) : [], error: null })),
         }
       }
       if (table === 'private_booking_payments') {
         return {
           select: vi.fn().mockReturnThis(),
           eq: vi.fn().mockReturnThis(),
+          in: vi.fn(async (_key: string, ids: string[]) => ({ data: payments.map(payment => ({ ...payment, booking_id: ids[0] })), error: paymentsError ? { message: 'db error' } : null })),
           order: vi.fn().mockResolvedValue({
             data: paymentsError ? null : payments,
             error: paymentsError ? { message: 'db error' } : null,

--- a/src/services/private-bookings/financial.ts
+++ b/src/services/private-bookings/financial.ts
@@ -1,3 +1,4 @@
+import { readBookingPaymentLedger } from '@/lib/private-bookings/payment-ledger'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
 
@@ -49,9 +50,9 @@ export type PrivateBookingCancellationOutcome = {
  *
  * `deposit_paid` is sourced from `private_bookings.deposit_amount` and is only
  * counted when `deposit_paid_date` is set (i.e. the deposit has actually
- * landed). `balance_payments_total` sums every row in
- * `private_booking_payments` (these are non-deposit top-up payments recorded
- * after the deposit).
+ * landed). `balance_payments_total` includes original booking payments and
+ * money received directly against the linked invoice. Invoice copies and the
+ * applied deposit credit are excluded here so actual receipts count once.
  *
  * Dispute detection is sourced from `private_bookings.has_open_dispute`; staff
  * and future webhook handlers should set that structured flag rather than
@@ -72,34 +73,15 @@ export async function getPrivateBookingPaidTotals(
     logger.error('getPrivateBookingPaidTotals: booking not found', {
       metadata: { bookingId, error: bookingError?.message ?? null },
     })
-    return {
-      deposit_paid: 0,
-      balance_payments_total: 0,
-      total_paid: 0,
-      has_open_dispute: false,
-      event_date: null,
-    }
+    throw new Error('Could not load booking payment totals')
   }
 
   const depositPaid = booking.deposit_paid_date
     ? Number(booking.deposit_amount ?? 0)
     : 0
 
-  const { data: payments, error: paymentsError } = await db
-    .from('private_booking_payments')
-    .select('amount, notes')
-    .eq('booking_id', bookingId)
-
-  if (paymentsError) {
-    logger.error('getPrivateBookingPaidTotals: failed to load payments', {
-      metadata: { bookingId, error: paymentsError.message ?? null },
-    })
-  }
-
-  const balancePaymentsTotal = (payments ?? []).reduce(
-    (sum, p) => sum + Number(p?.amount ?? 0),
-    0,
-  )
+  const ledger = await readBookingPaymentLedger(bookingId)
+  const balancePaymentsTotal = ledger.balancePaymentsTotal
 
   return {
     deposit_paid: depositPaid,

--- a/src/services/private-bookings/payments.ts
+++ b/src/services/private-bookings/payments.ts
@@ -1,3 +1,4 @@
+import { readBookingPaymentLedger } from '@/lib/private-bookings/payment-ledger';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { formatDateInLondon, toLocalIsoDate } from '@/lib/dateUtils';
@@ -568,9 +569,9 @@ export async function recordDeposit(bookingId: string, amount: number, method: s
 //
 // The column is owned by the database: record_balance_payment inserts the
 // payment and stamps it, apply_balance_payment_status re-derives it whenever
-// payments or items change. Both compare the VAT-inclusive gross total against
-// private_booking_payments only, so the returnable booking and damage deposit
-// never counts towards the event balance.
+// payments or items change. Settlement includes booking and linked invoice
+// payments once, plus any deposit actually applied to the linked invoice.
+// A separately held deposit never counts towards the event balance.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
@@ -774,25 +775,22 @@ export async function getBookingPaymentHistory(bookingId: string): Promise<Payme
 
   const { data: booking, error: bookingError } = await db
     .from('private_bookings')
-    .select('deposit_paid_date, deposit_amount, deposit_payment_method')
+    .select('deposit_paid_date, deposit_amount, deposit_payment_method, invoice_id, invoice_deposit_treatment')
     .eq('id', bookingId)
     .single()
 
   if (bookingError) throw new Error(`Failed to fetch booking: ${bookingError.message}`)
 
-  const { data: payments, error: paymentsError } = await db
-    .from('private_booking_payments')
-    .select('id, amount, method, created_at')
-    .eq('booking_id', bookingId)
-    .order('created_at', { ascending: true })
-
-  if (paymentsError) throw new Error(`Failed to fetch payments: ${paymentsError.message}`)
+  const ledger = await readBookingPaymentLedger(bookingId)
 
   const entries: PaymentHistoryEntry[] = []
 
   if (booking.deposit_paid_date) {
     entries.push({
       id: 'deposit',
+      appliedAmount: ledger.appliedDepositAmount,
+      readonly: Boolean(booking.invoice_id),
+      invoice_id: booking.invoice_id ?? undefined,
       type: 'deposit',
       amount: booking.deposit_amount,
       method: booking.deposit_payment_method as DepositPaymentEntry['method'],
@@ -800,9 +798,11 @@ export async function getBookingPaymentHistory(bookingId: string): Promise<Payme
     })
   }
 
-  for (const payment of payments ?? []) {
+  for (const payment of ledger.payments) {
     entries.push({
       id: payment.id,
+      readonly: payment.readonly,
+      invoice_id: payment.invoice_id,
       type: 'balance',
       amount: payment.amount,
       method: payment.method as BalancePaymentEntry['method'],

--- a/src/services/private-bookings/queries.ts
+++ b/src/services/private-bookings/queries.ts
@@ -1,3 +1,4 @@
+import { readBookingPaymentLedger, readBookingPaymentLedgers } from '@/lib/private-bookings/payment-ledger';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { toLocalIsoDate } from '@/lib/dateUtils';
@@ -225,19 +226,13 @@ export async function fetchPrivateBookings(options: {
 
   const bookingIds = (data || []).map((booking) => booking.id).filter(Boolean);
   const holdExpiryById = new Map<string, string | null>();
-  const paymentSumById = new Map<string, number>();
+  const ledgers = await readBookingPaymentLedgers(bookingIds);
 
   if (bookingIds.length > 0) {
-    const [holdExpiryResult, paymentsResult] = await Promise.all([
-      supabase
+    const holdExpiryResult = await supabase
         .from('private_bookings')
         .select('id, hold_expiry')
-        .in('id', bookingIds),
-      supabase
-        .from('private_booking_payments')
-        .select('booking_id, amount')
-        .in('booking_id', bookingIds),
-    ]);
+        .in('id', bookingIds);
 
     if (holdExpiryResult.error) {
       logger.error('Error fetching hold expiry dates for private bookings:', { error: holdExpiryResult.error instanceof Error ? holdExpiryResult.error : new Error(String(holdExpiryResult.error)) });
@@ -246,19 +241,13 @@ export async function fetchPrivateBookings(options: {
         holdExpiryById.set(row.id, row.hold_expiry ?? null);
       }
     }
-
-    if (paymentsResult.data) {
-      for (const row of paymentsResult.data) {
-        paymentSumById.set(row.booking_id, (paymentSumById.get(row.booking_id) ?? 0) + toNumber(row.amount));
-      }
-    }
   }
 
   const enriched = (data || []).map((booking) => {
     // Customer-payable total is VAT-inclusive (stored prices are net)
     const bookingTotal = toNumber(booking.gross_total ?? booking.calculated_total ?? booking.total_amount);
-    const paymentSum = paymentSumById.get(booking.id) ?? 0;
-    const balanceRemaining = booking.final_payment_date ? 0 : Math.max(0, bookingTotal - paymentSum);
+    const paymentSum = ledgers.get(booking.id)?.eventPaidTotal ?? 0;
+    const balanceRemaining = Math.max(0, bookingTotal - paymentSum);
     return {
       ...booking,
       hold_expiry: holdExpiryById.get(booking.id) ?? undefined,
@@ -366,6 +355,7 @@ export async function getBookingById(id: string): Promise<PrivateBookingWithDeta
     payments?: PrivateBookingPayment[];
   };
 
+  const ledger = await readBookingPaymentLedger(id);
   const items = bookingCore.items ?? [];
 
    
@@ -392,7 +382,8 @@ export async function getBookingById(id: string): Promise<PrivateBookingWithDeta
     deposit_status: depositStatus,
     days_until_event: daysUntilEvent,
     audit_trail: auditTrail,
-    payments: (paymentsData ?? []) as PrivateBookingPayment[]
+    payments: ledger.payments,
+    applied_deposit_amount: ledger.appliedDepositAmount
   };
 
   return bookingWithDetails;
@@ -530,28 +521,13 @@ export async function getBookingByIdForMessages(id: string): Promise<PrivateBook
     throw new Error(smsError.message || 'Failed to fetch booking messages');
   }
 
-  // The balance reminder SMS prefills {balance_due} from this. Without the
-  // payments subtracted it quoted the whole booking total, so every reminder
-  // asked the customer for money they had already paid.
-  // Summed the same way as balance_remaining on the list query above, so the
-  // messages screen and the list never disagree about what is owed.
-  const { data: payments, error: paymentsError } = await supabase
-    .from('private_booking_payments')
-    .select('amount')
-    .eq('booking_id', id);
-
-  if (paymentsError) {
-    logger.error('Error fetching private booking payments for messages:', { error: paymentsError instanceof Error ? paymentsError : new Error(String(paymentsError)) });
-    throw new Error(paymentsError.message || 'Failed to fetch booking payments');
-  }
-
+  const ledger = await readBookingPaymentLedger(id);
   const bookingTotal = toNumber(booking.gross_total ?? booking.calculated_total ?? booking.total_amount);
-  const paymentSum = (payments ?? []).reduce((sum, row) => sum + toNumber(row.amount), 0);
 
   return {
     ...(booking as PrivateBookingWithDetails),
     deposit_status: normalizeDepositStatus(booking),
-    balance_remaining: booking.final_payment_date ? 0 : Math.max(0, bookingTotal - paymentSum),
+    balance_remaining: Math.max(0, bookingTotal - ledger.eventPaidTotal),
     sms_queue: smsQueue ?? [],
   };
 }

--- a/src/services/private-bookings/scheduled-sms.ts
+++ b/src/services/private-bookings/scheduled-sms.ts
@@ -1,3 +1,4 @@
+import { readBookingPaymentLedger } from '@/lib/private-bookings/payment-ledger'
 import { createAdminClient } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
 import { isBookingDateTbd } from '@/lib/private-bookings/tbd-detection'
@@ -166,15 +167,8 @@ export async function getBookingScheduledSms(
     .select('idempotency_key')
     .eq('booking_id', bookingId)
 
-  const { data: balancePaymentRows } = await db
-    .from('private_booking_payments')
-    .select('amount')
-    .eq('booking_id', bookingId)
-
-  const balancePaymentsTotal = (balancePaymentRows ?? []).reduce(
-    (sum, row) => sum + Number(row.amount ?? 0),
-    0,
-  )
+  const ledger = await readBookingPaymentLedger(bookingId)
+  const balancePaymentsTotal = ledger.eventPaidTotal
 
   const alreadySent = new Set(
     (idempRows ?? []).map((r) => String(r.idempotency_key)),
@@ -293,7 +287,7 @@ export async function getBookingScheduledSms(
       booking.gross_total ?? booking.calculated_total ?? booking.total_amount ?? 0,
     )
     const balanceOutstanding =
-      !booking.final_payment_date && totalAmount > 0
+      totalAmount > 0
         ? Math.max(0, totalAmount - balancePaymentsTotal)
         : 0
 

--- a/src/types/database.generated.ts
+++ b/src/types/database.generated.ts
@@ -19124,6 +19124,10 @@ export type Database = {
         Args: { p_campaign_id: string; p_user_id: string }
         Returns: number
       }
+      cancel_private_booking_invoice_atomic: {
+        Args: { p_actor_id: string; p_booking_id: string; p_reason: string }
+        Returns: Json
+      }
       categorize_historical_events: { Args: never; Returns: number }
       check_and_reserve_capacity: {
         Args: {
@@ -20122,6 +20126,10 @@ export type Database = {
           space_name: string
         }[]
       }
+      get_private_booking_settlement_total: {
+        Args: { p_booking_id: string }
+        Returns: number
+      }
       get_quarter_date_range: {
         Args: { p_quarter: number; p_year: number }
         Returns: {
@@ -20342,6 +20350,10 @@ export type Database = {
         Args: { p_auth_user_id: string; p_token: string }
         Returns: Json
       }
+      lock_invoice_settlement: {
+        Args: { p_invoice_id: string }
+        Returns: string
+      }
       log_audit_event: {
         Args: {
           p_additional_info?: Json
@@ -20555,6 +20567,14 @@ export type Database = {
           unsubscribed_count: number
         }[]
       }
+      private_booking_settlement_rows: {
+        Args: { p_booking_id: string }
+        Returns: {
+          amount: number
+          method: string
+          paid_at: string
+        }[]
+      }
       process_pending_jobs: {
         Args: never
         Returns: {
@@ -20594,6 +20614,10 @@ export type Database = {
         Returns: Json
       }
       rebuild_customer_category_stats: { Args: never; Returns: number }
+      recalculate_invoice_settlement: {
+        Args: { p_invoice_id: string }
+        Returns: undefined
+      }
       recalculate_mileage_tax_year_v01: {
         Args: { p_trip_date: string }
         Returns: undefined
@@ -20633,6 +20657,26 @@ export type Database = {
         Args: { p_payment_data: Json }
         Returns: Json
       }
+      record_invoice_paypal_payment_atomic:
+        | {
+            Args: {
+              p_amount: number
+              p_capture_id: string
+              p_invoice_id: string
+              p_order_id?: string
+            }
+            Returns: Json
+          }
+        | {
+            Args: {
+              p_amount: number
+              p_capture_id: string
+              p_captured_at: string
+              p_invoice_id: string
+              p_order_id: string
+            }
+            Returns: Json
+          }
       record_table_cash_deposit_v05: {
         Args: {
           p_amount?: number

--- a/src/types/invoices.ts
+++ b/src/types/invoices.ts
@@ -18,7 +18,7 @@ export interface InvoiceVendor {
 
 export type InvoiceStatus = 'draft' | 'sent' | 'partially_paid' | 'paid' | 'overdue' | 'void' | 'written_off'
 export type QuoteStatus = 'draft' | 'sent' | 'accepted' | 'rejected' | 'expired'
-export type PaymentMethod = 'bank_transfer' | 'card' | 'cash' | 'cheque' | 'other'
+export type PaymentMethod = 'bank_transfer' | 'card' | 'cash' | 'cheque' | 'other' | 'paypal'
 export type RecurringFrequency = 'weekly' | 'monthly' | 'quarterly' | 'yearly'
 
 export interface Invoice {
@@ -98,7 +98,7 @@ interface InvoicePayment {
   created_at: string
   /** The private_booking_payments row this was copied from, when it was. */
   source_payment_id?: string | null
-  source_kind?: 'booking_payment' | 'booking_deposit' | null
+  source_kind?: 'booking_payment' | 'booking_deposit' | 'paypal' | null
 }
 
 export interface InvoiceWithDetails extends Invoice {

--- a/src/types/private-bookings.ts
+++ b/src/types/private-bookings.ts
@@ -294,14 +294,18 @@ export interface PrivateBookingPayment {
   id: string
   booking_id: string
   amount: number
-  method: PaymentMethod
+  method: PaymentMethod | 'bank_transfer' | 'cheque' | 'other'
   notes?: string
   recorded_by?: string
   created_at: string
+  source?: 'booking' | 'invoice'
+  invoice_id?: string
+  readonly?: boolean
 }
 
 // Extended types with relations
 export interface PrivateBookingWithDetails extends PrivateBooking {
+  applied_deposit_amount?: number
   items?: PrivateBookingItem[]
   customer?: {
     id: string
@@ -388,14 +392,19 @@ export type DepositPaymentEntry = {
   amount: number
   method: 'cash' | 'card' | 'invoice' | 'paypal'  // all methods valid for deposit
   date: string  // YYYY-MM-DD (London timezone)
+  appliedAmount?: number
+  readonly?: boolean
+  invoice_id?: string
 }
 
 export type BalancePaymentEntry = {
   id: string    // UUID from private_booking_payments.id
   type: 'balance'
   amount: number
-  method: 'cash' | 'card' | 'invoice'  // paypal never appears on balance; enforced by DB CHECK constraint
+  method: PrivateBookingPayment['method']
   date: string  // YYYY-MM-DD (London timezone)
+  readonly?: boolean
+  invoice_id?: string
 }
 
 export type PaymentHistoryEntry = DepositPaymentEntry | BalancePaymentEntry

--- a/supabase/migrations/20260905192946_private_booking_invoice_settlement.sql
+++ b/supabase/migrations/20260905192946_private_booking_invoice_settlement.sql
@@ -1,0 +1,721 @@
+-- Production target: tfcasgxopxegwrabvwat. Draft only until separately approved.
+-- Preserve both ledgers. Booking payments are mirrored one way onto invoices;
+-- invoice-origin payments contribute to the booking without being copied back.
+SET lock_timeout = '5s';
+
+ALTER TABLE public.invoice_payments
+  DROP CONSTRAINT invoice_payments_payment_method_check,
+  ADD CONSTRAINT invoice_payments_payment_method_check
+    CHECK (payment_method IN ('bank_transfer', 'cash', 'cheque', 'card', 'other', 'paypal')),
+  DROP CONSTRAINT invoice_payments_source_kind_check,
+  ADD CONSTRAINT invoice_payments_source_kind_check
+    CHECK (source_kind IN ('booking_payment', 'booking_deposit', 'paypal'));
+
+CREATE OR REPLACE FUNCTION public.private_booking_settlement_rows(p_booking_id uuid)
+RETURNS TABLE(amount numeric, paid_at timestamptz, method text)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT p.amount::numeric, p.created_at::timestamptz, p.method::text
+  FROM public.private_booking_payments p WHERE p.booking_id = p_booking_id
+  UNION ALL
+  SELECT p.amount::numeric,
+         (p.payment_date::timestamp AT TIME ZONE 'Europe/London')::timestamptz,
+         p.payment_method::text
+  FROM public.private_bookings b
+  JOIN public.invoice_payments p ON p.invoice_id = b.invoice_id
+  WHERE b.id = p_booking_id
+    AND (p.source_kind IS NULL OR p.source_kind NOT IN ('booking_payment', 'booking_deposit')
+         OR (p.source_kind = 'booking_deposit' AND b.invoice_deposit_treatment = 'deducted'));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_private_booking_settlement_total(p_booking_id uuid)
+RETURNS numeric LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  PERFORM public.assert_rpc_permission('private_bookings', 'view');
+  RETURN COALESCE((SELECT SUM(amount) FROM public.private_booking_settlement_rows(p_booking_id)), 0);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.calculate_private_booking_balance(p_booking_id uuid)
+RETURNS numeric LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  PERFORM public.assert_rpc_permission('private_bookings', 'view');
+  RETURN GREATEST(0, public.get_booking_gross_total(p_booking_id)
+    - COALESCE((SELECT SUM(amount) FROM public.private_booking_settlement_rows(p_booking_id)), 0));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.apply_balance_payment_status(p_booking_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_paid numeric;
+  v_total numeric;
+  v_date timestamptz;
+  v_method text;
+BEGIN
+  PERFORM 1 FROM public.private_bookings WHERE id = p_booking_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN; END IF;
+  v_total := public.get_booking_gross_total(p_booking_id);
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid FROM public.private_booking_settlement_rows(p_booking_id);
+  IF v_total > 0 AND v_paid >= v_total THEN
+    SELECT paid_at, method INTO v_date, v_method
+    FROM public.private_booking_settlement_rows(p_booking_id)
+    ORDER BY paid_at DESC NULLS LAST, method LIMIT 1;
+  END IF;
+  UPDATE public.private_bookings
+  SET final_payment_date = v_date, final_payment_method = v_method
+  WHERE id = p_booking_id
+    AND (final_payment_date IS DISTINCT FROM v_date OR final_payment_method IS DISTINCT FROM v_method);
+END;
+$$;
+
+-- All entry points take the booking lock before the invoice lock. Do not add
+-- invoice-to-booking writes to a caller that already locked the invoice first.
+CREATE OR REPLACE FUNCTION public.lock_invoice_settlement(p_invoice_id uuid)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_booking_id uuid;
+BEGIN
+  SELECT id INTO v_booking_id FROM public.private_bookings
+  WHERE invoice_id = p_invoice_id FOR UPDATE;
+  PERFORM 1 FROM public.invoices WHERE id = p_invoice_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'invoice_not_found'; END IF;
+  RETURN v_booking_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.recalculate_invoice_settlement(p_invoice_id uuid)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_booking_id uuid; v_paid numeric;
+BEGIN
+  v_booking_id := public.lock_invoice_settlement(p_invoice_id);
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid FROM public.invoice_payments WHERE invoice_id = p_invoice_id;
+  UPDATE public.invoices
+  SET paid_amount = v_paid,
+      status = CASE
+        WHEN status IN ('void', 'written_off') THEN status
+        WHEN total_amount > 0 AND v_paid >= total_amount THEN 'paid'
+        WHEN v_paid > 0 THEN 'partially_paid'
+        WHEN sent_at IS NULL THEN 'draft'
+        WHEN due_date < (now() AT TIME ZONE 'Europe/London')::date THEN 'overdue'
+        ELSE 'sent' END,
+      updated_at = now()
+  WHERE id = p_invoice_id;
+  IF v_booking_id IS NOT NULL THEN PERFORM public.apply_balance_payment_status(v_booking_id); END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.guard_invoice_payment_settlement()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_invoice public.invoices%ROWTYPE; v_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.invoice_id IS DISTINCT FROM OLD.invoice_id THEN
+    RAISE EXCEPTION 'payment_invoice_cannot_change';
+  END IF;
+  v_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.invoice_id ELSE NEW.invoice_id END;
+  PERFORM public.lock_invoice_settlement(v_id);
+  SELECT * INTO v_invoice FROM public.invoices WHERE id = v_id;
+  IF TG_OP IN ('UPDATE', 'DELETE') AND OLD.source_kind = 'paypal' THEN
+    IF TG_OP = 'DELETE' OR NEW.amount IS DISTINCT FROM OLD.amount
+      OR NEW.reference IS DISTINCT FROM OLD.reference OR NEW.source_kind IS DISTINCT FROM OLD.source_kind
+      OR NEW.payment_method IS DISTINCT FROM OLD.payment_method THEN
+      RAISE EXCEPTION 'PayPal captures cannot be changed or deleted; resolve a refund or credit';
+    END IF;
+  END IF;
+  IF TG_OP IN ('UPDATE', 'DELETE') AND OLD.source_kind = 'booking_payment' THEN
+    IF TG_OP = 'DELETE' AND pg_trigger_depth() < 2 THEN
+      RAISE EXCEPTION 'Edit or delete the original booking payment';
+    END IF;
+    IF TG_OP = 'UPDATE' AND (NEW.source_kind IS DISTINCT FROM OLD.source_kind
+      OR NEW.source_payment_id IS DISTINCT FROM OLD.source_payment_id) THEN
+      RAISE EXCEPTION 'Edit or delete the original booking payment';
+    END IF;
+  END IF;
+  IF TG_OP <> 'DELETE' AND NEW.source_kind = 'booking_payment' THEN
+    IF NOT EXISTS (SELECT 1 FROM public.private_booking_payments p
+      WHERE p.id = NEW.source_payment_id AND p.amount = NEW.amount
+        AND NOT EXISTS (SELECT 1 FROM public.private_bookings b WHERE b.invoice_id = NEW.invoice_id AND b.id <> p.booking_id)
+        AND (p.created_at AT TIME ZONE 'Europe/London')::date = NEW.payment_date
+        AND (CASE WHEN p.method IN ('cash','card') THEN p.method ELSE 'other' END) = NEW.payment_method
+        AND p.notes IS NOT DISTINCT FROM NEW.notes) THEN
+      RAISE EXCEPTION 'Edit or delete the original booking payment';
+    END IF;
+  END IF;
+  IF TG_OP IN ('UPDATE', 'DELETE') AND OLD.source_kind = 'booking_deposit'
+     AND EXISTS (SELECT 1 FROM public.private_bookings WHERE invoice_id = v_id AND invoice_deposit_treatment = 'deducted') THEN
+    RAISE EXCEPTION 'Applied deposit requires invoice credit resolution';
+  END IF;
+  IF TG_OP <> 'DELETE' THEN
+    IF v_invoice.deleted_at IS NOT NULL OR v_invoice.status IN ('void', 'written_off') THEN
+      RAISE EXCEPTION 'invoice_not_payable';
+    END IF;
+    IF NEW.amount IS NULL OR NEW.amount::text IN ('NaN', 'Infinity', '-Infinity') OR NEW.amount <= 0 OR NEW.amount <> round(NEW.amount, 2) THEN
+      RAISE EXCEPTION 'invalid_payment_amount';
+    END IF;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.after_invoice_payment_settlement()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  PERFORM public.recalculate_invoice_settlement(CASE WHEN TG_OP = 'DELETE' THEN OLD.invoice_id ELSE NEW.invoice_id END);
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER invoice_payment_settlement_guard BEFORE INSERT OR UPDATE OR DELETE ON public.invoice_payments
+FOR EACH ROW EXECUTE FUNCTION public.guard_invoice_payment_settlement();
+CREATE TRIGGER invoice_payment_settlement_changed AFTER INSERT OR UPDATE OR DELETE ON public.invoice_payments
+FOR EACH ROW EXECUTE FUNCTION public.after_invoice_payment_settlement();
+
+CREATE OR REPLACE FUNCTION public.guard_private_booking_payment_settlement()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_booking public.private_bookings%ROWTYPE; v_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.booking_id IS DISTINCT FROM OLD.booking_id THEN
+    RAISE EXCEPTION 'payment_booking_cannot_change';
+  END IF;
+  v_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.booking_id ELSE NEW.booking_id END;
+  SELECT * INTO v_booking FROM public.private_bookings WHERE id = v_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'booking_not_found'; END IF;
+  IF v_booking.invoice_id IS NOT NULL THEN
+    PERFORM public.lock_invoice_settlement(v_booking.invoice_id);
+    IF EXISTS (SELECT 1 FROM public.invoices WHERE id = v_booking.invoice_id
+               AND (deleted_at IS NOT NULL OR status IN ('void', 'written_off'))) THEN
+      RAISE EXCEPTION 'invoice_not_payable';
+    END IF;
+  END IF;
+  -- Delete the mirror before the foreign key can replace its source id with NULL.
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM public.invoice_payments WHERE source_kind = 'booking_payment' AND source_payment_id = OLD.id;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_private_booking_payment_settlement()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_invoice_id uuid; v_booking_id uuid;
+BEGIN
+  v_booking_id := CASE WHEN TG_OP = 'DELETE' THEN OLD.booking_id ELSE NEW.booking_id END;
+  SELECT invoice_id INTO v_invoice_id FROM public.private_bookings WHERE id = v_booking_id;
+  IF TG_OP <> 'DELETE' AND v_invoice_id IS NOT NULL THEN
+    INSERT INTO public.invoice_payments(invoice_id, payment_date, amount, payment_method, reference, notes, source_payment_id, source_kind)
+    VALUES(v_invoice_id, (NEW.created_at AT TIME ZONE 'Europe/London')::date, NEW.amount,
+      CASE WHEN NEW.method IN ('cash', 'card') THEN NEW.method ELSE 'other' END,
+      'Booking payment', NEW.notes, NEW.id, 'booking_payment')
+    ON CONFLICT (invoice_id, source_payment_id) WHERE source_payment_id IS NOT NULL
+    DO UPDATE SET amount = EXCLUDED.amount, payment_date = EXCLUDED.payment_date,
+      payment_method = EXCLUDED.payment_method, notes = EXCLUDED.notes;
+  END IF;
+  PERFORM public.apply_balance_payment_status(v_booking_id);
+  RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER private_booking_payment_settlement_guard BEFORE INSERT OR UPDATE OR DELETE ON public.private_booking_payments
+FOR EACH ROW EXECUTE FUNCTION public.guard_private_booking_payment_settlement();
+CREATE TRIGGER private_booking_payment_settlement_changed AFTER INSERT OR UPDATE OR DELETE ON public.private_booking_payments
+FOR EACH ROW EXECUTE FUNCTION public.sync_private_booking_payment_settlement();
+
+CREATE OR REPLACE FUNCTION public.after_private_booking_invoice_link()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF NEW.invoice_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.invoice_payments ip
+    LEFT JOIN public.private_booking_payments bp ON bp.id = ip.source_payment_id
+    WHERE ip.invoice_id = NEW.invoice_id AND ip.source_kind = 'booking_payment'
+      AND bp.booking_id IS DISTINCT FROM NEW.id
+  ) THEN RAISE EXCEPTION 'Invoice mirror belongs to another booking'; END IF;
+  PERFORM public.apply_balance_payment_status(NEW.id);
+  RETURN NULL;
+END;
+$$;
+CREATE TRIGGER private_booking_invoice_link_changed AFTER UPDATE OF invoice_id, invoice_deposit_treatment ON public.private_bookings
+FOR EACH ROW WHEN (OLD.invoice_id IS DISTINCT FROM NEW.invoice_id OR OLD.invoice_deposit_treatment IS DISTINCT FROM NEW.invoice_deposit_treatment)
+EXECUTE FUNCTION public.after_private_booking_invoice_link();
+
+-- Five explicit arguments avoid ambiguous default overload resolution in PostgREST.
+CREATE OR REPLACE FUNCTION public.record_invoice_paypal_payment_atomic(
+  p_invoice_id uuid, p_amount numeric, p_capture_id text, p_order_id text, p_captured_at timestamptz
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE
+  v_invoice public.invoices%ROWTYPE;
+  v_existing public.invoice_payments%ROWTYPE;
+  v_booking_id uuid;
+  v_inserted uuid;
+BEGIN
+  IF NULLIF(btrim(p_capture_id), '') IS NULL THEN RAISE EXCEPTION 'capture_id_required'; END IF;
+  IF p_amount IS NULL OR p_amount::text IN ('NaN', 'Infinity', '-Infinity') OR p_amount <= 0 OR p_amount <> round(p_amount, 2) THEN
+    RAISE EXCEPTION 'invalid_payment_amount';
+  END IF;
+  v_booking_id := public.lock_invoice_settlement(p_invoice_id);
+  SELECT * INTO v_invoice FROM public.invoices WHERE id = p_invoice_id;
+  IF v_invoice.deleted_at IS NOT NULL OR v_invoice.status IN ('void', 'written_off') THEN
+    RAISE EXCEPTION 'invoice_not_payable';
+  END IF;
+  INSERT INTO public.invoice_payments(invoice_id, payment_date, amount, payment_method, reference, notes, source_kind)
+  VALUES(p_invoice_id, (COALESCE(p_captured_at, now()) AT TIME ZONE 'Europe/London')::date,
+    p_amount, 'paypal', btrim(p_capture_id), 'Paid online by the customer via PayPal.', 'paypal')
+  ON CONFLICT (reference) WHERE source_kind = 'paypal' DO NOTHING RETURNING id INTO v_inserted;
+  IF v_inserted IS NULL THEN
+    SELECT * INTO v_existing FROM public.invoice_payments
+    WHERE source_kind = 'paypal' AND reference = btrim(p_capture_id);
+    IF v_existing.invoice_id IS DISTINCT FROM p_invoice_id OR v_existing.amount IS DISTINCT FROM p_amount THEN
+      RAISE EXCEPTION 'paypal_capture_conflict';
+    END IF;
+    PERFORM public.recalculate_invoice_settlement(p_invoice_id);
+  END IF;
+  UPDATE public.invoices
+  SET paypal_order_id = CASE WHEN status = 'paid' THEN NULL ELSE paypal_order_id END,
+      paypal_reconciliation_attempts = CASE WHEN status = 'paid' THEN 0 ELSE paypal_reconciliation_attempts END,
+      paypal_reconciliation_last_error = CASE WHEN status = 'paid' THEN NULL ELSE paypal_reconciliation_last_error END
+  WHERE id = p_invoice_id RETURNING * INTO v_invoice;
+  RETURN jsonb_build_object('recorded', v_inserted IS NOT NULL, 'already_recorded', v_inserted IS NULL,
+    'paid_amount', v_invoice.paid_amount, 'status', v_invoice.status,
+    'invoice_number', v_invoice.invoice_number, 'private_booking_id', v_booking_id,
+    'overpaid_amount', GREATEST(0, v_invoice.paid_amount - v_invoice.total_amount));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_invoice_paypal_payment_atomic(
+  p_invoice_id uuid, p_amount numeric, p_capture_id text, p_order_id text DEFAULT NULL
+)
+RETURNS jsonb LANGUAGE sql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+  SELECT public.record_invoice_paypal_payment_atomic(p_invoice_id, p_amount, p_capture_id, p_order_id, NULL::timestamptz);
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_invoice_payment_transaction(p_payment_data jsonb)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_invoice public.invoices%ROWTYPE; v_payment public.invoice_payments%ROWTYPE;
+  v_invoice_id uuid := (p_payment_data->>'invoice_id')::uuid;
+  v_amount numeric := (p_payment_data->>'amount')::numeric;
+  v_paid numeric;
+BEGIN
+  PERFORM public.assert_rpc_permission('invoices', 'edit');
+  PERFORM public.lock_invoice_settlement(v_invoice_id);
+  SELECT * INTO v_invoice FROM public.invoices WHERE id = v_invoice_id;
+  IF v_invoice.deleted_at IS NOT NULL OR v_invoice.status IN ('void', 'written_off') THEN
+    RAISE EXCEPTION 'invoice_not_payable';
+  END IF;
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid FROM public.invoice_payments WHERE invoice_id = v_invoice_id;
+  IF v_amount IS NULL OR v_amount::text IN ('NaN', 'Infinity', '-Infinity') OR v_amount <= 0 OR v_amount <> round(v_amount, 2) THEN RAISE EXCEPTION 'invalid_payment_amount'; END IF;
+  IF v_amount > v_invoice.total_amount - v_paid THEN RAISE EXCEPTION 'Payment amount exceeds outstanding balance'; END IF;
+  INSERT INTO public.invoice_payments(invoice_id, payment_date, amount, payment_method, reference, notes)
+  VALUES(v_invoice_id, (p_payment_data->>'payment_date')::date, v_amount,
+    p_payment_data->>'payment_method', p_payment_data->>'reference', p_payment_data->>'notes')
+  RETURNING * INTO v_payment;
+  RETURN to_jsonb(v_payment);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.record_balance_payment(p_booking_id uuid, p_amount numeric, p_method text, p_recorded_by uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_status text; v_remaining numeric; v_paid numeric;
+BEGIN
+  PERFORM public.assert_rpc_permission('private_bookings', 'manage_deposits');
+  SELECT status INTO v_status FROM public.private_bookings WHERE id = p_booking_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Booking not found: %', p_booking_id; END IF;
+  IF v_status IN ('cancelled', 'completed') THEN RAISE EXCEPTION 'Cannot record payment on a % booking', v_status; END IF;
+  IF p_amount IS NULL OR p_amount::text IN ('NaN', 'Infinity', '-Infinity') OR p_amount <= 0 OR p_amount <> round(p_amount, 2) THEN RAISE EXCEPTION 'invalid_payment_amount'; END IF;
+  v_remaining := public.calculate_private_booking_balance(p_booking_id);
+  IF p_amount > v_remaining THEN RAISE EXCEPTION 'Amount (%) exceeds remaining balance (%)', p_amount, v_remaining; END IF;
+  INSERT INTO public.private_booking_payments(booking_id, amount, method, recorded_by)
+  VALUES(p_booking_id, p_amount, p_method, p_recorded_by);
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid FROM public.private_booking_settlement_rows(p_booking_id);
+  v_remaining := public.calculate_private_booking_balance(p_booking_id);
+  RETURN jsonb_build_object('booking_id', p_booking_id, 'total_paid', v_paid,
+    'remaining_balance', v_remaining, 'is_fully_paid', v_remaining = 0);
+END;
+$$;
+
+-- No new permission surface. Read helpers respect the caller's existing RLS.
+REVOKE ALL ON FUNCTION public.private_booking_settlement_rows(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.private_booking_settlement_rows(uuid) TO service_role;
+REVOKE ALL ON FUNCTION public.get_private_booking_settlement_total(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_private_booking_settlement_total(uuid) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.calculate_private_booking_balance(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.calculate_private_booking_balance(uuid) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.apply_balance_payment_status(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_balance_payment_status(uuid) TO service_role;
+REVOKE ALL ON FUNCTION public.lock_invoice_settlement(uuid), public.recalculate_invoice_settlement(uuid),
+  public.guard_invoice_payment_settlement(), public.after_invoice_payment_settlement(),
+  public.guard_private_booking_payment_settlement(), public.sync_private_booking_payment_settlement(),
+  public.after_private_booking_invoice_link() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.lock_invoice_settlement(uuid), public.recalculate_invoice_settlement(uuid),
+  public.guard_invoice_payment_settlement(), public.after_invoice_payment_settlement(),
+  public.guard_private_booking_payment_settlement(), public.sync_private_booking_payment_settlement(),
+  public.after_private_booking_invoice_link() TO service_role;
+REVOKE ALL ON FUNCTION public.record_invoice_paypal_payment_atomic(uuid, numeric, text, text),
+  public.record_invoice_paypal_payment_atomic(uuid, numeric, text, text, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_invoice_paypal_payment_atomic(uuid, numeric, text, text),
+  public.record_invoice_paypal_payment_atomic(uuid, numeric, text, text, timestamptz) TO service_role;
+REVOKE ALL ON FUNCTION public.record_invoice_payment_transaction(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_invoice_payment_transaction(jsonb) TO authenticated, service_role;
+REVOKE ALL ON FUNCTION public.record_balance_payment(uuid, numeric, text, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_balance_payment(uuid, numeric, text, uuid) TO service_role;
+
+-- Keep the existing view's columns, order, grants and invoker RLS behaviour.
+CREATE OR REPLACE VIEW public.private_bookings_with_details WITH (security_invoker = on) AS
+ SELECT pb.id,
+    pb.customer_id,
+    pb.customer_name,
+    pb.contact_phone,
+    pb.contact_email,
+    pb.event_date,
+    pb.start_time,
+    pb.setup_time,
+    pb.end_time,
+    pb.end_time_next_day,
+    pb.guest_count,
+    pb.event_type,
+    pb.status,
+    pb.deposit_amount,
+    pb.deposit_paid_date,
+    pb.deposit_payment_method,
+    pb.total_amount,
+    pb.balance_due_date,
+    pb.final_payment_date,
+    pb.final_payment_method,
+    pb.calendar_event_id,
+    pb.contract_version,
+    pb.internal_notes,
+    pb.customer_requests,
+    pb.created_by,
+    pb.created_at,
+    pb.updated_at,
+    pb.setup_date,
+    pb.discount_type,
+    pb.discount_amount,
+    pb.discount_reason,
+    pb.customer_first_name,
+    pb.customer_last_name,
+    pb.customer_full_name,
+    pb.date_tbd,
+    c.mobile_number AS customer_mobile,
+    get_booking_discounted_total(pb.id) AS calculated_total,
+        CASE
+            WHEN pb.deposit_paid_date IS NOT NULL THEN 'Paid'::text
+            WHEN COALESCE(pb.deposit_amount, 0::numeric) <= 0::numeric THEN 'Not Required'::text
+            WHEN pb.status = 'confirmed'::text THEN 'Required'::text
+            ELSE 'Not Required'::text
+        END AS deposit_status,
+    pb.event_date - CURRENT_DATE AS days_until_event,
+    pb.contract_note,
+    pb.hold_expiry,
+    public.get_private_booking_settlement_total(pb.id) AS total_balance_paid,
+    calculate_private_booking_balance(pb.id) AS balance_remaining,
+        CASE
+            WHEN calculate_private_booking_balance(pb.id) <= 0::numeric THEN 'Fully Paid'::text
+            WHEN (public.get_private_booking_settlement_total(pb.id)) > 0::numeric THEN 'Partially Paid'::text
+            ELSE 'Unpaid'::text
+        END AS payment_status,
+    get_booking_vat_amount(pb.id) AS vat_amount,
+    get_booking_gross_total(pb.id) AS gross_total
+   FROM private_bookings pb
+     LEFT JOIN customers c ON pb.customer_id = c.id;
+REVOKE ALL ON public.private_bookings_with_details FROM anon;
+GRANT SELECT ON public.private_bookings_with_details TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.cancel_private_booking_invoice_atomic(p_booking_id uuid, p_reason text, p_actor_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_booking      public.private_bookings%ROWTYPE;
+  v_invoice      public.invoices%ROWTYPE;
+  v_real_payments integer;
+  v_reason       text := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_note         text;
+BEGIN
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'cancel_reason_required';
+  END IF;
+
+  -- 1. Lock the booking so a concurrent generate cannot race this cancel.
+  SELECT * INTO v_booking
+  FROM public.private_bookings
+  WHERE id = p_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'booking_not_found';
+  END IF;
+
+  IF v_booking.invoice_id IS NULL THEN
+    RAISE EXCEPTION 'booking_not_invoiced';
+  END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = v_booking.invoice_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_invoice.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'private_booking_invoice_missing_or_deleted';
+  END IF;
+
+  -- 2. Real money blocks the cancel. The mirrored deposit does not: it was
+  --    written by the invoicing RPC, not received against this invoice.
+  SELECT count(*) INTO v_real_payments
+  FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id
+    AND source_kind IS DISTINCT FROM 'booking_deposit';
+
+  IF v_real_payments > 0 THEN
+    RAISE EXCEPTION 'invoice_has_real_payments';
+  END IF;
+
+  IF v_invoice.paypal_order_id IS NOT NULL THEN
+    RAISE EXCEPTION 'Resolve the pending PayPal order before cancelling the invoice';
+  END IF;
+
+  UPDATE public.private_bookings
+  SET invoice_id = NULL, invoice_sent_at = NULL, invoice_deposit_treatment = NULL, updated_at = now()
+  WHERE id = p_booking_id;
+
+  -- 3. Drop the mirrored deposit so the void invoice does not keep reporting
+  --    money as paid against it. The deposit itself is untouched: it lives on
+  --    private_bookings.deposit_amount and is re-mirrored onto the next invoice.
+  DELETE FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id
+    AND source_kind = 'booking_deposit';
+
+  -- 4. Void the invoice, keeping the reason and who did it on the record.
+  --    The audit log holds the same facts; this puts them where anyone reading
+  --    the invoice itself will see them.
+  v_note := format('[VOIDED %s by %s] Reason: %s', now(), COALESCE(p_actor_id::text, 'unknown'), v_reason);
+
+  UPDATE public.invoices
+  SET status = 'void',
+      paid_amount = 0,
+      internal_notes = CASE
+        WHEN COALESCE(btrim(internal_notes), '') = '' THEN v_note
+        ELSE internal_notes || E'\n\n' || v_note
+      END,
+      updated_at = now()
+  WHERE id = v_invoice.id
+  RETURNING * INTO v_invoice;
+
+  -- 5. Release the booking. Clearing invoice_id is what re-opens the generate
+  --    flow, because the RPC's idempotent short circuit keys off exactly this.
+  UPDATE public.private_bookings
+  SET invoice_id = NULL,
+      invoice_sent_at = NULL,
+      invoice_deposit_treatment = NULL,
+      updated_at = now()
+  WHERE id = p_booking_id;
+
+  RETURN jsonb_build_object(
+    'unlinked', true,
+    'voided', true,
+    'invoice_number', v_invoice.invoice_number,
+    'released_amount', v_invoice.total_amount
+  );
+END;
+$function$
+;
+REVOKE ALL ON FUNCTION public.cancel_private_booking_invoice_atomic(uuid, text, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.cancel_private_booking_invoice_atomic(uuid, text, uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.reserve_refund_balance(p_source_type text, p_source_id uuid, p_original_amount numeric, p_amount numeric, p_refund_method text, p_reason text, p_initiated_by uuid, p_paypal_capture_id text DEFAULT NULL::text, p_paypal_request_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(refund_id uuid, remaining numeric)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_total_reserved NUMERIC(10,2);
+  v_remaining NUMERIC(10,2);
+  v_new_id UUID;
+BEGIN
+  IF p_source_type = 'private_booking' THEN
+    PERFORM 1 FROM public.private_bookings WHERE id = p_source_id FOR UPDATE;
+    IF EXISTS (SELECT 1 FROM public.private_bookings
+      WHERE id = p_source_id AND invoice_id IS NOT NULL AND invoice_deposit_treatment = 'deducted') THEN
+      RAISE EXCEPTION 'Applied deposit requires invoice credit resolution';
+    END IF;
+  END IF;
+
+  -- 1. Acquire advisory lock scoped to (source_type, source_id)
+  PERFORM pg_advisory_xact_lock(
+    hashtext(p_source_type || ':' || p_source_id::text)
+  );
+
+  -- 2. Calculate total already reserved (completed + pending)
+  SELECT COALESCE(SUM(amount), 0)
+  INTO v_total_reserved
+  FROM public.payment_refunds
+  WHERE source_type = p_source_type
+    AND source_id = p_source_id
+    AND status IN ('completed', 'pending');
+
+  v_remaining := p_original_amount - v_total_reserved;
+
+  -- 3. Validate the requested amount fits within the remaining balance
+  IF p_amount > v_remaining THEN
+    RAISE EXCEPTION 'Amount %.2f exceeds refundable balance %.2f', p_amount, v_remaining;
+  END IF;
+
+  -- 4. Insert the pending refund row
+  INSERT INTO public.payment_refunds (
+    source_type,
+    source_id,
+    paypal_capture_id,
+    paypal_request_id,
+    refund_method,
+    amount,
+    original_amount,
+    reason,
+    status,
+    initiated_by,
+    initiated_by_type
+  ) VALUES (
+    p_source_type,
+    p_source_id,
+    p_paypal_capture_id,
+    p_paypal_request_id,
+    p_refund_method,
+    p_amount,
+    p_original_amount,
+    p_reason,
+    'pending',
+    p_initiated_by,
+    'staff'
+  ) RETURNING id INTO v_new_id;
+
+  -- 5. Return the new row ID and the remaining balance AFTER this reservation
+  v_remaining := v_remaining - p_amount;
+  RETURN QUERY SELECT v_new_id::uuid, v_remaining::numeric;
+END;
+$function$
+;
+REVOKE ALL ON FUNCTION public.reserve_refund_balance(text, uuid, numeric, numeric, text, text, uuid, text, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reserve_refund_balance(text, uuid, numeric, numeric, text, text, uuid, text, uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.guard_private_booking_invoice_money()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF OLD.invoice_id IS NOT NULL THEN
+    IF TG_OP = 'UPDATE' AND (NEW.discount_type IS DISTINCT FROM OLD.discount_type
+      OR NEW.discount_amount IS DISTINCT FROM OLD.discount_amount
+      OR NEW.total_amount IS DISTINCT FROM OLD.total_amount) THEN
+      RAISE EXCEPTION 'Resolve the linked invoice before changing booking prices';
+    END IF;
+    IF TG_OP = 'DELETE' OR NEW.invoice_id IS DISTINCT FROM OLD.invoice_id THEN
+      IF EXISTS (SELECT 1 FROM public.invoice_payments WHERE invoice_id = OLD.invoice_id
+                 AND source_kind IS DISTINCT FROM 'booking_deposit') THEN
+        RAISE EXCEPTION 'invoice_has_real_payments';
+      END IF;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NEW.invoice_id IS NOT DISTINCT FROM OLD.invoice_id
+       AND OLD.invoice_deposit_treatment = 'deducted'
+       AND (NEW.deposit_amount IS DISTINCT FROM OLD.deposit_amount
+         OR NEW.deposit_paid_date IS DISTINCT FROM OLD.deposit_paid_date
+         OR NEW.deposit_waived IS DISTINCT FROM OLD.deposit_waived
+         OR NEW.invoice_deposit_treatment IS DISTINCT FROM OLD.invoice_deposit_treatment) THEN
+      RAISE EXCEPTION 'Applied deposit requires invoice credit resolution';
+    END IF;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+CREATE TRIGGER private_booking_invoice_money_guard BEFORE UPDATE OR DELETE ON public.private_bookings
+FOR EACH ROW EXECUTE FUNCTION public.guard_private_booking_invoice_money();
+
+CREATE OR REPLACE FUNCTION public.guard_linked_invoice_money()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND (NEW.total_amount IS DISTINCT FROM OLD.total_amount
+    OR NEW.subtotal_amount IS DISTINCT FROM OLD.subtotal_amount
+    OR NEW.discount_amount IS DISTINCT FROM OLD.discount_amount
+    OR NEW.invoice_discount_percentage IS DISTINCT FROM OLD.invoice_discount_percentage
+    OR NEW.vat_amount IS DISTINCT FROM OLD.vat_amount)
+    AND EXISTS (SELECT 1 FROM public.private_bookings WHERE invoice_id = OLD.id) THEN
+    RAISE EXCEPTION 'Resolve the linked invoice before changing booking prices';
+  END IF;
+  IF TG_OP = 'DELETE' OR (NEW.status IN ('void', 'written_off') AND NEW.status IS DISTINCT FROM OLD.status)
+     OR NEW.deleted_at IS DISTINCT FROM OLD.deleted_at THEN
+    IF EXISTS (SELECT 1 FROM public.private_bookings WHERE invoice_id = OLD.id) THEN
+      RAISE EXCEPTION 'Cancel the invoice from its private booking after resolving its payments';
+    END IF;
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+CREATE TRIGGER linked_invoice_money_guard BEFORE UPDATE OR DELETE ON public.invoices
+FOR EACH ROW EXECUTE FUNCTION public.guard_linked_invoice_money();
+REVOKE ALL ON FUNCTION public.guard_private_booking_invoice_money(), public.guard_linked_invoice_money() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.guard_private_booking_invoice_money(), public.guard_linked_invoice_money() TO service_role;
+
+CREATE OR REPLACE FUNCTION public.guard_linked_booking_item_prices()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+DECLARE v_booking_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.booking_id IS NOT DISTINCT FROM OLD.booking_id
+    AND NEW.quantity IS NOT DISTINCT FROM OLD.quantity
+    AND NEW.unit_price IS NOT DISTINCT FROM OLD.unit_price
+    AND NEW.discount_type IS NOT DISTINCT FROM OLD.discount_type
+    AND NEW.discount_value IS NOT DISTINCT FROM OLD.discount_value
+    AND NEW.vat_rate IS NOT DISTINCT FROM OLD.vat_rate THEN RETURN NEW; END IF;
+  FOR v_booking_id IN SELECT id FROM public.private_bookings
+    WHERE id IN (CASE WHEN TG_OP <> 'INSERT' THEN OLD.booking_id END,
+                 CASE WHEN TG_OP <> 'DELETE' THEN NEW.booking_id END)
+    ORDER BY id FOR UPDATE LOOP
+    IF EXISTS (SELECT 1 FROM public.private_bookings WHERE id = v_booking_id AND invoice_id IS NOT NULL) THEN
+      RAISE EXCEPTION 'Resolve the linked invoice before changing booking prices';
+    END IF;
+  END LOOP;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+CREATE TRIGGER linked_booking_item_prices_guard BEFORE INSERT OR UPDATE OR DELETE ON public.private_booking_items
+FOR EACH ROW EXECUTE FUNCTION public.guard_linked_booking_item_prices();
+
+CREATE OR REPLACE FUNCTION public.guard_linked_invoice_item_prices()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND NEW.invoice_id IS NOT DISTINCT FROM OLD.invoice_id
+    AND NEW.quantity IS NOT DISTINCT FROM OLD.quantity
+    AND NEW.unit_price IS NOT DISTINCT FROM OLD.unit_price
+    AND NEW.discount_percentage IS NOT DISTINCT FROM OLD.discount_percentage
+    AND NEW.vat_rate IS NOT DISTINCT FROM OLD.vat_rate THEN RETURN NEW; END IF;
+  IF EXISTS (SELECT 1 FROM public.private_bookings
+    WHERE invoice_id IN (CASE WHEN TG_OP <> 'INSERT' THEN OLD.invoice_id END,
+                         CASE WHEN TG_OP <> 'DELETE' THEN NEW.invoice_id END)) THEN
+    RAISE EXCEPTION 'Resolve the linked invoice before changing booking prices';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+CREATE TRIGGER linked_invoice_item_prices_guard BEFORE INSERT OR UPDATE OR DELETE ON public.invoice_line_items
+FOR EACH ROW EXECUTE FUNCTION public.guard_linked_invoice_item_prices();
+REVOKE ALL ON FUNCTION public.guard_linked_booking_item_prices(), public.guard_linked_invoice_item_prices() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.guard_linked_booking_item_prices(), public.guard_linked_invoice_item_prices() TO service_role;
+
+RESET lock_timeout;

--- a/supabase/migrations/20260905192951_reconcile_verified_private_booking_capture.sql
+++ b/supabase/migrations/20260905192951_reconcile_verified_private_booking_capture.sql
@@ -1,0 +1,37 @@
+-- Separately approved data repair. Provider evidence checked read-only on 2026-09-05.
+-- PayPal order 1NX08920NB808283W, completed GBP capture 62921439S0526370F.
+SET lock_timeout = '5s';
+DO $$
+DECLARE v_booking public.private_bookings%ROWTYPE; v_invoice public.invoices%ROWTYPE;
+  v_deposit numeric; v_existing public.invoice_payments%ROWTYPE;
+BEGIN
+  SELECT * INTO v_booking FROM public.private_bookings
+  WHERE id = 'c28527fe-a373-460d-85a8-e509b78d6eba' FOR UPDATE;
+  IF NOT FOUND OR v_booking.invoice_id IS DISTINCT FROM '8a590bb4-487b-4522-929b-b5c6c3f81071'::uuid
+     OR v_booking.invoice_deposit_treatment IS DISTINCT FROM 'deducted' THEN
+    RAISE EXCEPTION 'verified_capture_booking_link_changed';
+  END IF;
+  SELECT * INTO v_invoice FROM public.invoices WHERE id = v_booking.invoice_id FOR UPDATE;
+  IF NOT FOUND OR v_invoice.total_amount IS DISTINCT FROM 994.80::numeric
+     OR v_invoice.deleted_at IS NOT NULL OR v_invoice.status IN ('void', 'written_off') THEN
+    RAISE EXCEPTION 'verified_capture_invoice_changed';
+  END IF;
+  SELECT COALESCE(SUM(amount), 0) INTO v_deposit FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id AND source_kind = 'booking_deposit';
+  IF v_deposit <> 250 THEN RAISE EXCEPTION 'verified_capture_deposit_changed'; END IF;
+  SELECT * INTO v_existing FROM public.invoice_payments
+  WHERE source_kind = 'paypal' AND reference = '62921439S0526370F';
+  IF FOUND AND (v_existing.invoice_id IS DISTINCT FROM v_invoice.id OR v_existing.amount IS DISTINCT FROM 744.80::numeric) THEN
+    RAISE EXCEPTION 'verified_capture_conflict';
+  END IF;
+  PERFORM public.record_invoice_paypal_payment_atomic(v_invoice.id, 744.80, '62921439S0526370F',
+    '1NX08920NB808283W', '2026-09-04T13:38:30Z'::timestamptz);
+  -- An old application instance may have raced this repair using its capture-day
+  -- default. Only this provider-verified row is corrected; the amount is untouched.
+  UPDATE public.invoice_payments SET payment_date = '2026-09-04'::date
+  WHERE invoice_id = v_invoice.id AND source_kind = 'paypal' AND reference = '62921439S0526370F'
+    AND amount = 744.80 AND payment_date IS DISTINCT FROM '2026-09-04'::date;
+  PERFORM public.apply_balance_payment_status(v_booking.id);
+END;
+$$;
+RESET lock_timeout;

--- a/tests/api/invoicePayPalReconciliation.test.ts
+++ b/tests/api/invoicePayPalReconciliation.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({ alert: vi.fn(), auth: vi.fn(), get: vi.fn(), settle: vi.fn(), update: vi.fn(), limit: vi.fn() }))
+vi.mock('@/lib/cron/alerting', () => ({ reportCronFailure: mocks.alert }))
+vi.mock('server-only', () => ({}))
+vi.mock('@/lib/cron-auth', () => ({ authorizeCronRequest: mocks.auth }))
+vi.mock('@/lib/paypal', () => ({ getPayPalOrder: mocks.get, PayPalApiError: class extends Error {} }))
+vi.mock('@/lib/invoices/paypal-capture', () => ({ settleInvoicePayPalOrder: mocks.settle }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn() } }))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => ({ from: () => {
+  const select = { not: () => select, in: () => select, is: () => select, limit: mocks.limit }
+  return { select: () => select, update: mocks.update }
+} }) }))
+import { GET } from '@/app/api/cron/invoice-paypal-reconciliation/route'
+
+const invoice = {
+  id: 'INVOICE-1', invoice_number: 'INV-003WK', paypal_order_id: 'ORDER-1',
+  status: 'partially_paid', total_amount: 994.8, paid_amount: 250, paypal_reconciliation_attempts: 5,
+}
+const request = () => new NextRequest('https://management.orangejelly.co.uk/api/cron/invoice-paypal-reconciliation')
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.alert.mockResolvedValue(undefined)
+  mocks.auth.mockReturnValue({ authorized: true })
+  mocks.limit.mockResolvedValue({ data: [invoice], error: null })
+  mocks.get.mockResolvedValue({ status: 'COMPLETED' })
+  mocks.settle.mockResolvedValue({ success: true })
+  mocks.update.mockImplementation(() => {
+    const chain = { eq: () => chain, then: (resolve: (value: unknown) => void) => resolve({ error: null }) }
+    return chain
+  })
+})
+
+describe('invoice PayPal reconciliation', () => {
+  it('recovers a completed payment through the validated shared path', async () => {
+    const response = await GET(request())
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ settled: 1, failed: 0 })
+    expect(mocks.settle).toHaveBeenCalledWith(invoice, 'ORDER-1', 'reconciliation', { status: 'COMPLETED' })
+  })
+  it('alerts on captured excess while keeping the successful settlement', async () => {
+    mocks.settle.mockResolvedValue({ success: true, overpaidAmount: 10 })
+    const response = await GET(request())
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({ settled: 1, failed: 1 })
+    expect(mocks.alert).toHaveBeenCalledTimes(1)
+    expect(mocks.update).not.toHaveBeenCalled()
+    expect(mocks.settle).toHaveBeenCalledTimes(1)
+  })
+  it('preserves the order after more than five provider failures', async () => {
+    mocks.get.mockRejectedValue(new Error('PayPal timeout'))
+    const response = await GET(request())
+    expect(response.status).toBe(500)
+    expect(await response.json()).toMatchObject({ failed: 1, cleared: 0 })
+    expect(mocks.alert).toHaveBeenCalledTimes(1)
+    expect(mocks.update).toHaveBeenCalledWith(expect.objectContaining({ paypal_reconciliation_attempts: 6 }))
+    expect(mocks.update.mock.calls[0][0]).not.toHaveProperty('paypal_order_id')
+  })
+  it('preserves a completed order whose ledger write failed and reports failure', async () => {
+    mocks.settle.mockResolvedValue({ error: 'Payment could not be recorded' })
+    expect((await GET(request())).status).toBe(500)
+    expect(mocks.update.mock.calls[0][0]).not.toHaveProperty('paypal_order_id')
+  })
+  it('runs approved orders through the same amount and ownership checks', async () => {
+    mocks.get.mockResolvedValue({ status: 'APPROVED' })
+    mocks.settle.mockResolvedValue({ error: 'The amount due has changed' })
+    expect((await GET(request())).status).toBe(500)
+    expect(mocks.settle).toHaveBeenCalledTimes(1)
+  })
+  it('alerts when the initial database read fails', async () => {
+    mocks.limit.mockResolvedValue({ data: null, error: new Error('Database unavailable') })
+    expect((await GET(request())).status).toBe(500)
+    expect(mocks.alert).toHaveBeenCalledTimes(1)
+    expect(mocks.settle).not.toHaveBeenCalled()
+  })
+  it('requires cron authorisation before any processing or notification', async () => {
+    mocks.auth.mockReturnValue({ authorized: false })
+    expect((await GET(request())).status).toBe(401)
+    expect(mocks.limit).not.toHaveBeenCalled()
+    expect(mocks.alert).not.toHaveBeenCalled()
+  })
+  it('does not write or capture an order the customer has not approved', async () => {
+    mocks.get.mockResolvedValue({ status: 'CREATED' })
+    expect((await GET(request())).status).toBe(200)
+    expect(mocks.settle).not.toHaveBeenCalled()
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/invoicePayPalWebhook.test.ts
+++ b/tests/api/invoicePayPalWebhook.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  apply: vi.fn(), claim: vi.fn(), persist: vi.fn(), release: vi.fn(), verify: vi.fn(), insert: vi.fn(),
+}))
+vi.mock('server-only', () => ({}))
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: () => ({ from: () => ({ insert: mocks.insert }) }) }))
+vi.mock('@/lib/paypal', () => ({ verifyPayPalWebhook: mocks.verify, resolveWebhookIdForUrl: vi.fn() }))
+vi.mock('@/lib/logger', () => ({ logger: { error: vi.fn(), info: vi.fn() } }))
+vi.mock('@/lib/invoices/paypal-capture', () => ({
+  applyInvoicePayPalCapture: mocks.apply,
+  positivePennies: (value: string) => /^\d+(\.\d{1,2})?$/.test(value) && Number(value) > 0 ? Math.round(Number(value) * 100) : null,
+}))
+vi.mock('@/lib/api/idempotency', () => ({
+  claimIdempotencyKey: mocks.claim, computeIdempotencyRequestHash: () => 'HASH',
+  persistIdempotencyResponse: mocks.persist, releaseIdempotencyClaim: mocks.release,
+}))
+import { POST } from '@/app/api/webhooks/paypal/invoices/route'
+
+function request(overrides: Record<string, unknown> = {}) {
+  return new NextRequest('https://management.orangejelly.co.uk/api/webhooks/paypal/invoices', {
+    method: 'POST', body: JSON.stringify({
+      id: 'EVENT-1', event_type: 'PAYMENT.CAPTURE.COMPLETED', resource: {
+        id: 'CAPTURE-1', status: 'COMPLETED', custom_id: 'inv-pay-8a590bb4-487b-4522-929b-b5c6c3f81071',
+        amount: { value: '744.80', currency_code: 'GBP' }, create_time: '2026-09-04T13:38:30Z',
+        supplementary_data: { related_ids: { order_id: 'ORDER-1' } }, ...overrides,
+      },
+    }),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.PAYPAL_INVOICES_WEBHOOK_ID = 'WEBHOOK-1'
+  mocks.verify.mockResolvedValue(true)
+  mocks.claim.mockResolvedValue({ state: 'claimed' })
+  mocks.apply.mockResolvedValue({ success: true })
+  mocks.persist.mockResolvedValue(undefined)
+  mocks.release.mockResolvedValue(undefined)
+  mocks.insert.mockResolvedValue({ error: null })
+})
+
+describe('invoice PayPal webhook', () => {
+  it('leaves a failed recording retryable instead of acknowledging lost money', async () => {
+    mocks.apply.mockResolvedValue({ error: 'Payment write failed' })
+    const response = await POST(request())
+    expect(response.status).toBe(500)
+    expect(mocks.persist).not.toHaveBeenCalled()
+    expect(mocks.release).toHaveBeenCalledTimes(1)
+  })
+  it('records the exact capture, order and provider timestamp', async () => {
+    expect((await POST(request())).status).toBe(200)
+    expect(mocks.apply).toHaveBeenCalledWith(expect.objectContaining({
+      amount: 744.8, captureId: 'CAPTURE-1', orderId: 'ORDER-1', capturedAt: '2026-09-04T13:38:30Z',
+    }))
+    expect(mocks.persist).toHaveBeenCalledTimes(1)
+    expect(mocks.release).not.toHaveBeenCalled()
+  })
+  it('acknowledges only completed duplicates', async () => {
+    mocks.claim.mockResolvedValue({ state: 'replay', response: { received: true } })
+    expect((await POST(request())).status).toBe(200)
+    expect(mocks.apply).not.toHaveBeenCalled()
+  })
+  it.each(['in_progress', 'conflict'])('keeps %s deliveries retryable', async state => {
+    mocks.claim.mockResolvedValue({ state })
+    expect((await POST(request())).status).toBe(503)
+    expect(mocks.apply).not.toHaveBeenCalled()
+  })
+  it.each([
+    { status: 'PENDING' }, { amount: { value: '744.80' } }, { amount: { value: '744.801', currency_code: 'GBP' } },
+  ])('rejects an unconfirmed or malformed capture', async resource => {
+    expect((await POST(request(resource))).status).toBe(500)
+    expect(mocks.apply).not.toHaveBeenCalled()
+    expect(mocks.release).toHaveBeenCalledTimes(1)
+  })
+  it('rejects an invalid signature before claiming or recording', async () => {
+    mocks.verify.mockResolvedValue(false)
+    expect((await POST(request())).status).toBe(401)
+    expect(mocks.apply).not.toHaveBeenCalled()
+    expect(mocks.claim).not.toHaveBeenCalled()
+  })
+})

--- a/tests/fixtures/private-booking-settlement/live-extra-columns.json
+++ b/tests/fixtures/private-booking-settlement/live-extra-columns.json
@@ -1,0 +1,298 @@
+[
+  {
+    "table_name": "payment_refunds",
+    "column_name": "id",
+    "data_type": "uuid",
+    "column_default": "gen_random_uuid()",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "source_type",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "source_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "paypal_capture_id",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "paypal_refund_id",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "paypal_request_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "paypal_status",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "paypal_status_details",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "refund_method",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "amount",
+    "data_type": "numeric",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "original_amount",
+    "data_type": "numeric",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "reason",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "status",
+    "data_type": "text",
+    "column_default": "'pending'::text",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "initiated_by",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "initiated_by_type",
+    "data_type": "text",
+    "column_default": "'staff'::text",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "notification_status",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "completed_at",
+    "data_type": "timestamp with time zone",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "failed_at",
+    "data_type": "timestamp with time zone",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "failure_message",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "payment_refunds",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "column_default": "now()",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "id",
+    "data_type": "uuid",
+    "column_default": "gen_random_uuid()",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "booking_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "item_type",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "space_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "package_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "vendor_id",
+    "data_type": "uuid",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "description",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "quantity",
+    "data_type": "numeric",
+    "column_default": "1",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "unit_price",
+    "data_type": "numeric",
+    "column_default": null,
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "discount_type",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "discount_value",
+    "data_type": "numeric",
+    "column_default": "0",
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "discount_reason",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "notes",
+    "data_type": "text",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "created_at",
+    "data_type": "timestamp with time zone",
+    "column_default": "timezone('utc'::text, now())",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "display_order",
+    "data_type": "integer",
+    "column_default": "0",
+    "is_nullable": "NO",
+    "generation_expression": null
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "line_total",
+    "data_type": "numeric",
+    "column_default": null,
+    "is_nullable": "YES",
+    "generation_expression": "GREATEST((0)::numeric,\nCASE\n    WHEN (discount_type = 'percent'::text) THEN ((quantity * unit_price) * ((1)::numeric - (COALESCE(discount_value, (0)::numeric) / (100)::numeric)))\n    WHEN (discount_type = 'fixed'::text) THEN ((quantity * unit_price) - COALESCE(discount_value, (0)::numeric))\n    ELSE (quantity * unit_price)\nEND)"
+  },
+  {
+    "table_name": "private_booking_items",
+    "column_name": "vat_rate",
+    "data_type": "numeric",
+    "column_default": "20",
+    "is_nullable": "NO",
+    "generation_expression": null
+  }
+]

--- a/tests/fixtures/private-booking-settlement/live-functions-before.sql
+++ b/tests/fixtures/private-booking-settlement/live-functions-before.sql
@@ -1,0 +1,931 @@
+-- Non-PII function definitions read from tfcasgxopxegwrabvwat on 2026-09-05.
+CREATE OR REPLACE FUNCTION public.assert_rpc_permission(p_module text, p_action text)
+ RETURNS void
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+declare
+  v_role text;
+  v_uid  uuid;
+begin
+  v_role := coalesce(nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role', '');
+
+  -- Trusted server-side path: service_role key (cron, admin client).
+  if v_role = 'service_role' then
+    return;
+  end if;
+
+  v_uid := auth.uid();
+
+  if v_uid is null or not public.user_has_permission(v_uid, p_module, p_action) then
+    raise exception 'permission_denied: %.%', p_module, p_action
+      using errcode = '42501';
+  end if;
+end;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_booking_discounted_total(p_booking_id uuid)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_items_total NUMERIC;
+  v_discount_type TEXT;
+  v_discount_amount NUMERIC;
+BEGIN
+  SELECT COALESCE(SUM(line_total), 0) INTO v_items_total
+  FROM public.private_booking_items
+  WHERE booking_id = p_booking_id;
+
+  SELECT discount_type, COALESCE(discount_amount, 0)
+  INTO v_discount_type, v_discount_amount
+  FROM public.private_bookings
+  WHERE id = p_booking_id;
+
+  IF v_discount_type = 'percent' AND v_discount_amount > 0 THEN
+    RETURN GREATEST(0, v_items_total * (1 - v_discount_amount / 100));
+  ELSIF v_discount_type = 'fixed' AND v_discount_amount > 0 THEN
+    RETURN GREATEST(0, v_items_total - v_discount_amount);
+  END IF;
+
+  RETURN v_items_total;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_booking_gross_total(p_booking_id uuid)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+BEGIN
+  RETURN ROUND(public.get_booking_discounted_total(p_booking_id), 2)
+       + public.get_booking_vat_amount(p_booking_id);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_booking_vat_amount(p_booking_id uuid)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ STABLE
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_items_total NUMERIC;
+  v_vat_raw NUMERIC;
+  v_discount_type TEXT;
+  v_discount_amount NUMERIC;
+  v_factor NUMERIC := 1;
+BEGIN
+  SELECT COALESCE(SUM(line_total), 0), COALESCE(SUM(line_total * COALESCE(vat_rate, 20) / 100), 0)
+  INTO v_items_total, v_vat_raw
+  FROM public.private_booking_items
+  WHERE booking_id = p_booking_id;
+
+  IF v_items_total <= 0 THEN
+    RETURN 0;
+  END IF;
+
+  SELECT discount_type, COALESCE(discount_amount, 0)
+  INTO v_discount_type, v_discount_amount
+  FROM public.private_bookings
+  WHERE id = p_booking_id;
+
+  IF v_discount_type = 'percent' AND v_discount_amount > 0 THEN
+    v_factor := GREATEST(0, 1 - v_discount_amount / 100);
+  ELSIF v_discount_type = 'fixed' AND v_discount_amount > 0 THEN
+    v_factor := GREATEST(0, v_items_total - v_discount_amount) / v_items_total;
+  END IF;
+
+  RETURN ROUND(v_vat_raw * v_factor, 2);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.reserve_refund_balance(p_source_type text, p_source_id uuid, p_original_amount numeric, p_amount numeric, p_refund_method text, p_reason text, p_initiated_by uuid, p_paypal_capture_id text DEFAULT NULL::text, p_paypal_request_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(refund_id uuid, remaining numeric)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_total_reserved NUMERIC(10,2);
+  v_remaining NUMERIC(10,2);
+  v_new_id UUID;
+BEGIN
+  -- 1. Acquire advisory lock scoped to (source_type, source_id)
+  PERFORM pg_advisory_xact_lock(
+    hashtext(p_source_type || ':' || p_source_id::text)
+  );
+
+  -- 2. Calculate total already reserved (completed + pending)
+  SELECT COALESCE(SUM(amount), 0)
+  INTO v_total_reserved
+  FROM public.payment_refunds
+  WHERE source_type = p_source_type
+    AND source_id = p_source_id
+    AND status IN ('completed', 'pending');
+
+  v_remaining := p_original_amount - v_total_reserved;
+
+  -- 3. Validate the requested amount fits within the remaining balance
+  IF p_amount > v_remaining THEN
+    RAISE EXCEPTION 'Amount %.2f exceeds refundable balance %.2f', p_amount, v_remaining;
+  END IF;
+
+  -- 4. Insert the pending refund row
+  INSERT INTO public.payment_refunds (
+    source_type,
+    source_id,
+    paypal_capture_id,
+    paypal_request_id,
+    refund_method,
+    amount,
+    original_amount,
+    reason,
+    status,
+    initiated_by,
+    initiated_by_type
+  ) VALUES (
+    p_source_type,
+    p_source_id,
+    p_paypal_capture_id,
+    p_paypal_request_id,
+    p_refund_method,
+    p_amount,
+    p_original_amount,
+    p_reason,
+    'pending',
+    p_initiated_by,
+    'staff'
+  ) RETURNING id INTO v_new_id;
+
+  -- 5. Return the new row ID and the remaining balance AFTER this reservation
+  v_remaining := v_remaining - p_amount;
+  RETURN QUERY SELECT v_new_id, v_remaining;
+END;
+$function$
+;
+
+
+CREATE OR REPLACE FUNCTION public.apply_balance_payment_status(p_booking_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_total        numeric;
+  v_paid         numeric;
+  v_remaining    numeric;
+  v_last_method  text;
+BEGIN
+  v_total := public.get_booking_gross_total(p_booking_id);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid
+  FROM public.private_booking_payments WHERE booking_id = p_booking_id;
+
+  v_remaining := GREATEST(0, v_total - v_paid);
+
+  IF v_remaining = 0 AND v_total > 0 THEN
+    SELECT method INTO v_last_method
+    FROM public.private_booking_payments
+    WHERE booking_id = p_booking_id
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1;
+
+    UPDATE public.private_bookings
+    SET final_payment_date   = now(),
+        final_payment_method = v_last_method
+    WHERE id = p_booking_id
+      AND final_payment_date IS NULL;
+
+  ELSIF v_remaining > 0 THEN
+    UPDATE public.private_bookings
+    SET final_payment_date   = NULL,
+        final_payment_method = NULL
+    WHERE id = p_booking_id
+      AND final_payment_date IS NOT NULL;
+  END IF;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.calculate_private_booking_balance(p_booking_id uuid)
+ RETURNS numeric
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_total NUMERIC;
+  v_payments_sum NUMERIC;
+BEGIN
+  v_total := public.get_booking_gross_total(p_booking_id);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_payments_sum
+  FROM public.private_booking_payments
+  WHERE booking_id = p_booking_id;
+
+  RETURN GREATEST(0, v_total - v_payments_sum);
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.cancel_private_booking_invoice_atomic(p_booking_id uuid, p_reason text, p_actor_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_booking      public.private_bookings%ROWTYPE;
+  v_invoice      public.invoices%ROWTYPE;
+  v_real_payments integer;
+  v_reason       text := NULLIF(btrim(COALESCE(p_reason, '')), '');
+  v_note         text;
+BEGIN
+  IF v_reason IS NULL THEN
+    RAISE EXCEPTION 'cancel_reason_required';
+  END IF;
+
+  -- 1. Lock the booking so a concurrent generate cannot race this cancel.
+  SELECT * INTO v_booking
+  FROM public.private_bookings
+  WHERE id = p_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'booking_not_found';
+  END IF;
+
+  IF v_booking.invoice_id IS NULL THEN
+    RAISE EXCEPTION 'booking_not_invoiced';
+  END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = v_booking.invoice_id
+  FOR UPDATE;
+
+  -- A deleted invoice still leaves the booking linked and stuck. Release the
+  -- booking rather than refusing, then stop: there is nothing left to void.
+  IF NOT FOUND OR v_invoice.deleted_at IS NOT NULL THEN
+    UPDATE public.private_bookings
+    SET invoice_id = NULL,
+        invoice_sent_at = NULL,
+        invoice_deposit_treatment = NULL,
+        updated_at = now()
+    WHERE id = p_booking_id;
+
+    RETURN jsonb_build_object(
+      'unlinked', true,
+      'voided', false,
+      'invoice_number', NULL,
+      'released_amount', 0
+    );
+  END IF;
+
+  -- 2. Real money blocks the cancel. The mirrored deposit does not: it was
+  --    written by the invoicing RPC, not received against this invoice.
+  SELECT count(*) INTO v_real_payments
+  FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id
+    AND source_kind IS DISTINCT FROM 'booking_deposit';
+
+  IF v_real_payments > 0 THEN
+    RAISE EXCEPTION 'invoice_has_real_payments';
+  END IF;
+
+  -- 3. Drop the mirrored deposit so the void invoice does not keep reporting
+  --    money as paid against it. The deposit itself is untouched: it lives on
+  --    private_bookings.deposit_amount and is re-mirrored onto the next invoice.
+  DELETE FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id
+    AND source_kind = 'booking_deposit';
+
+  -- 4. Void the invoice, keeping the reason and who did it on the record.
+  --    The audit log holds the same facts; this puts them where anyone reading
+  --    the invoice itself will see them.
+  v_note := format('[VOIDED %s by %s] Reason: %s', now(), COALESCE(p_actor_id::text, 'unknown'), v_reason);
+
+  UPDATE public.invoices
+  SET status = 'void',
+      paid_amount = 0,
+      internal_notes = CASE
+        WHEN COALESCE(btrim(internal_notes), '') = '' THEN v_note
+        ELSE internal_notes || E'\n\n' || v_note
+      END,
+      updated_at = now()
+  WHERE id = v_invoice.id
+  RETURNING * INTO v_invoice;
+
+  -- 5. Release the booking. Clearing invoice_id is what re-opens the generate
+  --    flow, because the RPC's idempotent short circuit keys off exactly this.
+  UPDATE public.private_bookings
+  SET invoice_id = NULL,
+      invoice_sent_at = NULL,
+      invoice_deposit_treatment = NULL,
+      updated_at = now()
+  WHERE id = p_booking_id;
+
+  RETURN jsonb_build_object(
+    'unlinked', true,
+    'voided', true,
+    'invoice_number', v_invoice.invoice_number,
+    'released_amount', v_invoice.total_amount
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_private_booking_invoice_atomic(p_booking_id uuid, p_invoice_date date, p_due_date date, p_reference text, p_deposit_treatment text, p_line_items jsonb, p_totals jsonb, p_actor_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_booking          public.private_bookings;
+  v_invoice          public.invoices;
+  v_existing         public.invoices;
+  v_items_total      numeric;
+  v_gross_total      numeric;
+  v_claimed_total    numeric;
+  v_deposit          numeric := 0;
+  v_paid             numeric := 0;
+  v_status           text;
+  v_line_count       integer;
+  v_sequence         integer;
+  v_number           integer;
+  v_remainder        integer;
+  v_encoded          text := '';
+  v_invoice_number   text;
+BEGIN
+  PERFORM public.assert_rpc_permission('invoices', 'create');
+
+  IF p_deposit_treatment NOT IN ('held_separately', 'deducted') THEN
+    RAISE EXCEPTION 'invalid_deposit_treatment';
+  END IF;
+
+  -- 1. Lock the source row first. This, not any index, is the double-click guard.
+  SELECT * INTO v_booking
+  FROM public.private_bookings
+  WHERE id = p_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'booking_not_found';
+  END IF;
+
+  -- 2. Idempotent short circuit. A second call returns the first invoice.
+  IF v_booking.invoice_id IS NOT NULL THEN
+    SELECT * INTO v_existing
+    FROM public.invoices
+    WHERE id = v_booking.invoice_id;
+
+    IF NOT FOUND OR v_existing.deleted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'private_booking_invoice_missing_or_deleted';
+    END IF;
+
+    RETURN jsonb_build_object('created', false, 'invoice', to_jsonb(v_existing));
+  END IF;
+
+  -- 3. Recheck eligibility under the lock.
+  -- `status` is the authoritative field, not `cancelled_at`.
+  --
+  -- `cancelled_at` is stamped when a booking is cancelled and, until the
+  -- companion fix in this migration set, was never cleared when one was
+  -- reinstated. Three live confirmed bookings therefore carried a cancellation
+  -- date from months earlier and could not be invoiced, even though the status
+  -- said confirmed and the customer was owed an invoice.
+  --
+  -- Order matters: test for 'cancelled' first so a genuinely cancelled booking
+  -- still gets its specific message rather than the generic "not confirmed".
+  IF v_booking.status = 'cancelled' THEN
+    RAISE EXCEPTION 'booking_cancelled';
+  END IF;
+
+  IF v_booking.status <> 'confirmed' THEN
+    RAISE EXCEPTION 'booking_not_confirmed';
+  END IF;
+
+  IF v_booking.date_tbd THEN
+    RAISE EXCEPTION 'booking_date_tbd';
+  END IF;
+
+  SELECT COALESCE(SUM(line_total), 0) INTO v_items_total
+  FROM public.private_booking_items
+  WHERE booking_id = p_booking_id;
+
+  IF v_items_total <= 0 THEN
+    RAISE EXCEPTION 'booking_has_no_priced_items';
+  END IF;
+
+  v_line_count := COALESCE(jsonb_array_length(p_line_items), 0);
+  IF v_line_count = 0 THEN
+    RAISE EXCEPTION 'booking_has_no_priced_items';
+  END IF;
+
+  -- 4. The arithmetic guard. The customer already holds this figure on their
+  --    contract and by SMS, so the invoice must match it to the penny.
+  v_gross_total   := public.get_booking_gross_total(p_booking_id);
+  v_claimed_total := (p_totals->>'total_amount')::numeric;
+
+  IF v_claimed_total IS DISTINCT FROM v_gross_total THEN
+    RAISE EXCEPTION 'invoice_total_reconciliation_failed: mapper produced %, booking gross is %',
+      v_claimed_total, v_gross_total;
+  END IF;
+
+  -- 5. Invoice number. Same series and encoding as every other invoice.
+  SELECT next_sequence INTO v_sequence
+  FROM public.get_and_increment_invoice_series('INV')
+  LIMIT 1;
+
+  v_number := v_sequence + 5000;
+
+  IF v_number = 0 THEN
+    v_encoded := '0';
+  END IF;
+
+  WHILE v_number > 0 LOOP
+    v_remainder := v_number % 36;
+    v_encoded := substr('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ', v_remainder + 1, 1) || v_encoded;
+    v_number := floor(v_number / 36);
+  END LOOP;
+
+  v_invoice_number := 'INV-' || lpad(v_encoded, 5, '0');
+
+  -- 6. The invoice header. Status is corrected at step 10 once payments land.
+  INSERT INTO public.invoices (
+    invoice_number,
+    vendor_id,
+    invoice_date,
+    due_date,
+    reference,
+    invoice_discount_percentage,
+    subtotal_amount,
+    discount_amount,
+    vat_amount,
+    total_amount,
+    notes,
+    internal_notes,
+    status
+  )
+  VALUES (
+    v_invoice_number,
+    (p_totals->>'vendor_id')::uuid,
+    p_invoice_date,
+    p_due_date,
+    NULLIF(btrim(COALESCE(p_reference, '')), ''),
+    COALESCE((p_totals->>'invoice_discount_percentage')::numeric, 0),
+    (p_totals->>'subtotal_amount')::numeric,
+    COALESCE((p_totals->>'discount_amount')::numeric, 0),
+    (p_totals->>'vat_amount')::numeric,
+    v_gross_total,
+    p_totals->>'notes',
+    p_totals->>'internal_notes',
+    'draft'
+  )
+  RETURNING * INTO v_invoice;
+
+  -- 7. Line items. The four money columns are GENERATED ALWAYS in this schema
+  --    and must never be named here.
+  INSERT INTO public.invoice_line_items (
+    invoice_id,
+    catalog_item_id,
+    description,
+    quantity,
+    unit_price,
+    discount_percentage,
+    vat_rate,
+    display_order
+  )
+  SELECT
+    v_invoice.id,
+    NULLIF(item->>'catalog_item_id', '')::uuid,
+    item->>'description',
+    (item->>'quantity')::numeric,
+    (item->>'unit_price')::numeric,
+    COALESCE((item->>'discount_percentage')::numeric, 0),
+    COALESCE((item->>'vat_rate')::numeric, 20),
+    COALESCE((item->>'display_order')::integer, ordinality::integer)
+  FROM jsonb_array_elements(p_line_items) WITH ORDINALITY AS t(item, ordinality);
+
+  -- 8. Copy every balance payment already recorded on the booking.
+  --    Method mapping matters: private_booking_payments allows
+  --    cash|card|invoice, invoice_payments allows
+  --    bank_transfer|cash|cheque|card|other. 'invoice' would violate the
+  --    invoice-side CHECK, and would do so AFTER the number was burnt.
+  INSERT INTO public.invoice_payments (
+    invoice_id,
+    payment_date,
+    amount,
+    payment_method,
+    reference,
+    notes,
+    source_payment_id,
+    source_kind
+  )
+  SELECT
+    v_invoice.id,
+    (p.created_at AT TIME ZONE 'Europe/London')::date,
+    p.amount,
+    CASE p.method
+      WHEN 'cash' THEN 'cash'
+      WHEN 'card' THEN 'card'
+      ELSE 'other'
+    END,
+    'Booking payment',
+    p.notes,
+    p.id,
+    'booking_payment'
+  FROM public.private_booking_payments p
+  WHERE p.booking_id = p_booking_id
+  ON CONFLICT (invoice_id, source_payment_id) WHERE source_payment_id IS NOT NULL
+  DO NOTHING;
+
+  -- 9. The deposit, only when the operator chose to apply it.
+  --    Written as a PAYMENT, never as a discount: the supply is still the full
+  --    amount, so a discount would understate the VAT.
+  IF p_deposit_treatment = 'deducted'
+     AND v_booking.deposit_paid_date IS NOT NULL
+     AND COALESCE(v_booking.deposit_waived, false) = false
+     AND COALESCE(v_booking.deposit_amount, 0) > 0 THEN
+
+    v_deposit := v_booking.deposit_amount;
+
+    INSERT INTO public.invoice_payments (
+      invoice_id,
+      payment_date,
+      amount,
+      payment_method,
+      reference,
+      notes,
+      source_kind
+    )
+    VALUES (
+      v_invoice.id,
+      (v_booking.deposit_paid_date AT TIME ZONE 'Europe/London')::date,
+      v_deposit,
+      CASE COALESCE(v_booking.deposit_payment_method, '')
+        WHEN 'cash' THEN 'cash'
+        WHEN 'card' THEN 'card'
+        ELSE 'other'
+      END,
+      'Booking and damage deposit',
+      'Deposit applied to this invoice at the operator''s instruction.',
+      'booking_deposit'
+    )
+    ON CONFLICT (invoice_id) WHERE source_kind = 'booking_deposit'
+    DO NOTHING;
+  END IF;
+
+  -- 10. Derive paid_amount from the rows, never by incrementing.
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid
+  FROM public.invoice_payments
+  WHERE invoice_id = v_invoice.id;
+
+  IF v_paid > v_gross_total THEN
+    RAISE EXCEPTION 'booking_payments_exceed_invoice_total: paid % exceeds total %',
+      v_paid, v_gross_total;
+  END IF;
+
+  v_status := CASE
+    WHEN v_gross_total > 0 AND v_paid >= v_gross_total THEN 'paid'
+    WHEN v_paid > 0 THEN 'partially_paid'
+    ELSE 'draft'
+  END;
+
+  UPDATE public.invoices
+  SET paid_amount = v_paid,
+      status = v_status,
+      updated_at = now()
+  WHERE id = v_invoice.id
+  RETURNING * INTO v_invoice;
+
+  -- 11. Claim the booking. The conditional WHERE is what makes two concurrent
+  --     callers resolve to one invoice even if both got past step 2.
+  UPDATE public.private_bookings
+  SET invoice_id = v_invoice.id,
+      invoice_deposit_treatment = p_deposit_treatment,
+      updated_at = now()
+  WHERE id = p_booking_id
+    AND invoice_id IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Booking invoice could not be finalized';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'created', true,
+    'invoice', to_jsonb(v_invoice),
+    'deposit_applied', v_deposit,
+    'deposit_treatment', p_deposit_treatment
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.record_balance_payment(p_booking_id uuid, p_amount numeric, p_method text, p_recorded_by uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_booking RECORD;
+  v_gross_total NUMERIC;
+  v_payments_total NUMERIC;
+  v_remaining NUMERIC;
+BEGIN
+  IF NOT public.user_has_permission(auth.uid(), 'private_bookings', 'manage_deposits') THEN
+    RAISE EXCEPTION 'Permission denied: manage_deposits required';
+  END IF;
+
+  SELECT id, status, event_date, start_time, end_time, customer_first_name, customer_last_name,
+         customer_name, contact_phone, customer_id, calendar_event_id, guest_count, event_type,
+         deposit_paid_date, deposit_amount, total_amount
+  INTO v_booking
+  FROM public.private_bookings
+  WHERE id = p_booking_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Booking not found: %', p_booking_id;
+  END IF;
+
+  IF v_booking.status IN ('cancelled', 'completed') THEN
+    RAISE EXCEPTION 'Cannot record payment on a % booking', v_booking.status;
+  END IF;
+
+  v_gross_total := public.get_booking_gross_total(p_booking_id);
+
+  SELECT COALESCE(SUM(amount), 0) INTO v_payments_total
+  FROM public.private_booking_payments
+  WHERE booking_id = p_booking_id;
+
+  v_remaining := GREATEST(0, v_gross_total - v_payments_total);
+  IF p_amount > v_remaining + 0.005 THEN
+    RAISE EXCEPTION 'Amount (%) exceeds remaining balance (%)', p_amount, v_remaining;
+  END IF;
+
+  INSERT INTO public.private_booking_payments (booking_id, amount, method, recorded_by)
+  VALUES (p_booking_id, p_amount, p_method, p_recorded_by);
+
+  v_payments_total := v_payments_total + p_amount;
+  v_remaining := GREATEST(0, v_gross_total - v_payments_total);
+
+  IF v_remaining <= 0 THEN
+    UPDATE public.private_bookings
+    SET final_payment_date = NOW(),
+        final_payment_method = p_method,
+        updated_at = NOW()
+    WHERE id = p_booking_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'booking_id', p_booking_id,
+    'total_paid', v_payments_total,
+    'remaining_balance', v_remaining,
+    'is_fully_paid', v_remaining <= 0
+  );
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.record_invoice_payment_transaction(p_payment_data jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_catalog'
+AS $function$
+DECLARE
+  v_payment_id UUID;
+  v_invoice_id UUID;
+  v_amount DECIMAL;
+  v_current_paid DECIMAL;
+  v_total DECIMAL;
+  v_new_paid DECIMAL;
+  v_new_status text; -- Changed from invoice_status to text
+  v_payment_record JSONB;
+BEGIN
+  PERFORM public.assert_rpc_permission('invoices', 'edit');
+
+  v_invoice_id := (p_payment_data->>'invoice_id')::UUID;
+  v_amount := (p_payment_data->>'amount')::DECIMAL;
+
+  -- 1. Get current invoice details
+  SELECT paid_amount, total_amount, status
+  INTO v_current_paid, v_total, v_new_status
+  FROM invoices
+  WHERE id = v_invoice_id
+  FOR UPDATE; -- Lock the row
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Invoice not found';
+  END IF;
+
+  IF v_amount > (v_total - v_current_paid) THEN
+    RAISE EXCEPTION 'Payment amount exceeds outstanding balance';
+  END IF;
+
+  -- 2. Insert Payment
+  INSERT INTO invoice_payments (
+    invoice_id,
+    payment_date,
+    amount,
+    payment_method,
+    reference,
+    notes
+  ) VALUES (
+    v_invoice_id,
+    (p_payment_data->>'payment_date')::DATE,
+    v_amount,
+    p_payment_data->>'payment_method',
+    p_payment_data->>'reference',
+    p_payment_data->>'notes'
+  )
+  RETURNING id INTO v_payment_id;
+
+  -- 3. Update Invoice Status
+  v_new_paid := v_current_paid + v_amount;
+
+  IF v_new_paid >= v_total THEN
+    v_new_status := 'paid';
+  ELSIF v_new_paid > 0 AND v_new_status NOT IN ('void', 'written_off') THEN
+    v_new_status := 'partially_paid';
+  END IF;
+
+  UPDATE invoices
+  SET
+    paid_amount = v_new_paid,
+    status = v_new_status,
+    updated_at = NOW()
+  WHERE id = v_invoice_id;
+
+  -- 4. Return Payment Record
+  SELECT to_jsonb(ip) INTO v_payment_record
+  FROM invoice_payments ip
+  WHERE ip.id = v_payment_id;
+
+  RETURN v_payment_record;
+
+EXCEPTION WHEN OTHERS THEN
+  RAISE;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.record_invoice_paypal_payment_atomic(p_invoice_id uuid, p_amount numeric, p_capture_id text, p_order_id text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_invoice public.invoices%ROWTYPE;
+  v_inserted uuid;
+  v_paid numeric;
+  v_status text;
+BEGIN
+  IF p_capture_id IS NULL OR btrim(p_capture_id) = '' THEN
+    RAISE EXCEPTION 'capture_id_required';
+  END IF;
+
+  IF p_amount IS NULL OR p_amount <= 0 THEN
+    RAISE EXCEPTION 'invalid_payment_amount';
+  END IF;
+
+  SELECT * INTO v_invoice
+  FROM public.invoices
+  WHERE id = p_invoice_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_invoice.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'invoice_not_found';
+  END IF;
+
+  -- Money must never land on an invoice that has been withdrawn. If PayPal
+  -- has already taken it, that is a refund, and a human has to make that call.
+  IF v_invoice.status IN ('void', 'written_off') THEN
+    RAISE EXCEPTION 'invoice_not_payable';
+  END IF;
+
+  -- The idempotent step. A capture already recorded returns quietly, so the
+  -- webhook, the portal return and the cron can all race safely.
+  INSERT INTO public.invoice_payments (
+    invoice_id, payment_date, amount, payment_method, reference, notes, source_kind
+  )
+  VALUES (
+    p_invoice_id,
+    CURRENT_DATE,
+    p_amount,
+    'paypal',
+    btrim(p_capture_id),
+    'Paid online by the customer via PayPal.',
+    'paypal'
+  )
+  ON CONFLICT (reference) WHERE source_kind = 'paypal'
+  DO NOTHING
+  RETURNING id INTO v_inserted;
+
+  -- Derive from the rows, never by incrementing, so a double call cannot drift.
+  SELECT COALESCE(SUM(amount), 0) INTO v_paid
+  FROM public.invoice_payments
+  WHERE invoice_id = p_invoice_id;
+
+  v_status := CASE
+    WHEN COALESCE(v_invoice.total_amount, 0) > 0 AND v_paid >= v_invoice.total_amount THEN 'paid'
+    WHEN v_paid > 0 THEN 'partially_paid'
+    ELSE v_invoice.status
+  END;
+
+  UPDATE public.invoices
+  SET paid_amount = v_paid,
+      status = v_status,
+      -- Retire the order once settled so nothing keeps polling it.
+      paypal_order_id = CASE WHEN v_status = 'paid' THEN NULL ELSE paypal_order_id END,
+      paypal_reconciliation_attempts = CASE WHEN v_status = 'paid' THEN 0 ELSE paypal_reconciliation_attempts END,
+      paypal_reconciliation_last_error = CASE WHEN v_status = 'paid' THEN NULL ELSE paypal_reconciliation_last_error END,
+      updated_at = now()
+  WHERE id = p_invoice_id;
+
+  RETURN jsonb_build_object(
+    'recorded', v_inserted IS NOT NULL,
+    'already_recorded', v_inserted IS NULL,
+    'paid_amount', v_paid,
+    'status', v_status,
+    'invoice_number', v_invoice.invoice_number
+  );
+END;
+$function$
+;
+
+CREATE VIEW public.private_bookings_with_details WITH (security_invoker = on) AS
+ SELECT pb.id,
+    pb.customer_id,
+    pb.customer_name,
+    pb.contact_phone,
+    pb.contact_email,
+    pb.event_date,
+    pb.start_time,
+    pb.setup_time,
+    pb.end_time,
+    pb.end_time_next_day,
+    pb.guest_count,
+    pb.event_type,
+    pb.status,
+    pb.deposit_amount,
+    pb.deposit_paid_date,
+    pb.deposit_payment_method,
+    pb.total_amount,
+    pb.balance_due_date,
+    pb.final_payment_date,
+    pb.final_payment_method,
+    pb.calendar_event_id,
+    pb.contract_version,
+    pb.internal_notes,
+    pb.customer_requests,
+    pb.created_by,
+    pb.created_at,
+    pb.updated_at,
+    pb.setup_date,
+    pb.discount_type,
+    pb.discount_amount,
+    pb.discount_reason,
+    pb.customer_first_name,
+    pb.customer_last_name,
+    pb.customer_full_name,
+    pb.date_tbd,
+    c.mobile_number AS customer_mobile,
+    get_booking_discounted_total(pb.id) AS calculated_total,
+        CASE
+            WHEN pb.deposit_paid_date IS NOT NULL THEN 'Paid'::text
+            WHEN COALESCE(pb.deposit_amount, 0::numeric) <= 0::numeric THEN 'Not Required'::text
+            WHEN pb.status = 'confirmed'::text THEN 'Required'::text
+            ELSE 'Not Required'::text
+        END AS deposit_status,
+    pb.event_date - CURRENT_DATE AS days_until_event,
+    pb.contract_note,
+    pb.hold_expiry,
+    ( SELECT COALESCE(sum(pbp.amount), 0::numeric) AS "coalesce"
+           FROM private_booking_payments pbp
+          WHERE pbp.booking_id = pb.id) AS total_balance_paid,
+    calculate_private_booking_balance(pb.id) AS balance_remaining,
+        CASE
+            WHEN calculate_private_booking_balance(pb.id) <= 0::numeric THEN 'Fully Paid'::text
+            WHEN (( SELECT COALESCE(sum(pbp.amount), 0::numeric) AS "coalesce"
+               FROM private_booking_payments pbp
+              WHERE pbp.booking_id = pb.id)) > 0::numeric THEN 'Partially Paid'::text
+            ELSE 'Unpaid'::text
+        END AS payment_status,
+    get_booking_vat_amount(pb.id) AS vat_amount,
+    get_booking_gross_total(pb.id) AS gross_total
+   FROM private_bookings pb
+     LEFT JOIN customers c ON pb.customer_id = c.id;

--- a/tests/fixtures/private-booking-settlement/live-schema-before.json
+++ b/tests/fixtures/private-booking-settlement/live-schema-before.json
@@ -1,0 +1,1232 @@
+{
+  "sizes": [
+    {
+      "bytes": 262144,
+      "relname": "invoices",
+      "n_live_tup": 60
+    },
+    {
+      "bytes": 81920,
+      "relname": "invoice_payments",
+      "n_live_tup": 50
+    },
+    {
+      "bytes": 245760,
+      "relname": "private_bookings",
+      "n_live_tup": 43
+    },
+    {
+      "bytes": 32768,
+      "relname": "private_booking_payments",
+      "n_live_tup": 8
+    }
+  ],
+  "views": [
+    {
+      "view_name": "customer_communications",
+      "table_name": "private_bookings"
+    },
+    {
+      "view_name": "private_booking_sms_reminders",
+      "table_name": "private_bookings"
+    },
+    {
+      "view_name": "private_booking_summary",
+      "table_name": "private_bookings"
+    },
+    {
+      "view_name": "private_bookings_with_details",
+      "table_name": "private_booking_payments"
+    },
+    {
+      "view_name": "private_bookings_with_details",
+      "table_name": "private_bookings"
+    }
+  ],
+  "columns": [
+    {
+      "data_type": "uuid",
+      "table_name": "invoice_payments",
+      "column_name": "id",
+      "is_nullable": "NO",
+      "column_default": "gen_random_uuid()"
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "invoice_payments",
+      "column_name": "invoice_id",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "date",
+      "table_name": "invoice_payments",
+      "column_name": "payment_date",
+      "is_nullable": "NO",
+      "column_default": "CURRENT_DATE"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoice_payments",
+      "column_name": "amount",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "character varying",
+      "table_name": "invoice_payments",
+      "column_name": "payment_method",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "character varying",
+      "table_name": "invoice_payments",
+      "column_name": "reference",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoice_payments",
+      "column_name": "notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "invoice_payments",
+      "column_name": "created_at",
+      "is_nullable": "YES",
+      "column_default": "now()"
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "invoice_payments",
+      "column_name": "source_payment_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoice_payments",
+      "column_name": "source_kind",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "invoices",
+      "column_name": "id",
+      "is_nullable": "NO",
+      "column_default": "gen_random_uuid()"
+    },
+    {
+      "data_type": "character varying",
+      "table_name": "invoices",
+      "column_name": "invoice_number",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "invoices",
+      "column_name": "vendor_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "date",
+      "table_name": "invoices",
+      "column_name": "invoice_date",
+      "is_nullable": "NO",
+      "column_default": "CURRENT_DATE"
+    },
+    {
+      "data_type": "date",
+      "table_name": "invoices",
+      "column_name": "due_date",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "character varying",
+      "table_name": "invoices",
+      "column_name": "reference",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "character varying",
+      "table_name": "invoices",
+      "column_name": "status",
+      "is_nullable": "YES",
+      "column_default": "'draft'::character varying"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "invoice_discount_percentage",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "subtotal_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "discount_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "vat_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "total_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "invoices",
+      "column_name": "paid_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "internal_notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "invoices",
+      "column_name": "created_at",
+      "is_nullable": "YES",
+      "column_default": "now()"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "invoices",
+      "column_name": "updated_at",
+      "is_nullable": "YES",
+      "column_default": "now()"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "invoices",
+      "column_name": "deleted_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "invoices",
+      "column_name": "deleted_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "invoices",
+      "column_name": "is_fixed_price",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "invoices",
+      "column_name": "sent_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "sent_to",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "payment_state",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "paypal_order_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "integer",
+      "table_name": "invoices",
+      "column_name": "paypal_reconciliation_attempts",
+      "is_nullable": "NO",
+      "column_default": "0"
+    },
+    {
+      "data_type": "text",
+      "table_name": "invoices",
+      "column_name": "paypal_reconciliation_last_error",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_booking_payments",
+      "column_name": "id",
+      "is_nullable": "NO",
+      "column_default": "gen_random_uuid()"
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_booking_payments",
+      "column_name": "booking_id",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_booking_payments",
+      "column_name": "amount",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_booking_payments",
+      "column_name": "method",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_booking_payments",
+      "column_name": "notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_booking_payments",
+      "column_name": "recorded_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_booking_payments",
+      "column_name": "created_at",
+      "is_nullable": "NO",
+      "column_default": "now()"
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "id",
+      "is_nullable": "NO",
+      "column_default": "gen_random_uuid()"
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "customer_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "customer_name",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "contact_phone",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "contact_email",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "date",
+      "table_name": "private_bookings",
+      "column_name": "event_date",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "time without time zone",
+      "table_name": "private_bookings",
+      "column_name": "start_time",
+      "is_nullable": "NO",
+      "column_default": null
+    },
+    {
+      "data_type": "time without time zone",
+      "table_name": "private_bookings",
+      "column_name": "setup_time",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "time without time zone",
+      "table_name": "private_bookings",
+      "column_name": "end_time",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "integer",
+      "table_name": "private_bookings",
+      "column_name": "guest_count",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "event_type",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "status",
+      "is_nullable": "YES",
+      "column_default": "'draft'::text"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_bookings",
+      "column_name": "deposit_amount",
+      "is_nullable": "YES",
+      "column_default": "250.00"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "deposit_paid_date",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "deposit_payment_method",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_bookings",
+      "column_name": "total_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "date",
+      "table_name": "private_bookings",
+      "column_name": "balance_due_date",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "final_payment_date",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "final_payment_method",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "calendar_event_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "integer",
+      "table_name": "private_bookings",
+      "column_name": "contract_version",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "internal_notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "customer_requests",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "created_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "created_at",
+      "is_nullable": "NO",
+      "column_default": "timezone('utc'::text, now())"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "updated_at",
+      "is_nullable": "NO",
+      "column_default": "timezone('utc'::text, now())"
+    },
+    {
+      "data_type": "date",
+      "table_name": "private_bookings",
+      "column_name": "setup_date",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "discount_type",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_bookings",
+      "column_name": "discount_amount",
+      "is_nullable": "YES",
+      "column_default": "0"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "discount_reason",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "customer_first_name",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "customer_last_name",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "customer_full_name",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "source",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "special_requirements",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "accessibility_needs",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "cancellation_reason",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "cancelled_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "end_time_next_day",
+      "is_nullable": "YES",
+      "column_default": "false"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "hold_expiry",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "contract_note",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "paypal_deposit_order_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "paypal_deposit_capture_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "review_processed_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "review_clicked_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "post_event_outcome",
+      "is_nullable": "YES",
+      "column_default": "'pending'::text"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "post_event_outcome_decided_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "outcome_email_sent_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "review_sms_sent_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "deposit_refund_status",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "date_tbd",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "integer",
+      "table_name": "private_bookings",
+      "column_name": "paypal_reconciliation_attempts",
+      "is_nullable": "NO",
+      "column_default": "0"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "paypal_reconciliation_last_error",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "has_open_dispute",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "deposit_waived",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "deposit_waived_reason",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "contract_sent_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "contract_sent_to",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "contract_accepted_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "contract_acceptance_method",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "final_details_status",
+      "is_nullable": "NO",
+      "column_default": "'not_requested'::text"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "supplier_status",
+      "is_nullable": "NO",
+      "column_default": "'not_applicable'::text"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "waiver_status",
+      "is_nullable": "NO",
+      "column_default": "'not_required'::text"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "risk_status",
+      "is_nullable": "NO",
+      "column_default": "'normal'::text"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "event_sheet_status",
+      "is_nullable": "NO",
+      "column_default": "'not_generated'::text"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "post_event_status",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "layout",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "integer",
+      "table_name": "private_bookings",
+      "column_name": "guest_count_adults",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "integer",
+      "table_name": "private_bookings",
+      "column_name": "guest_count_under_18",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "bar_tab_required",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_bookings",
+      "column_name": "bar_tab_limit",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "numeric",
+      "table_name": "private_bookings",
+      "column_name": "bar_tab_prepaid_amount",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "bar_tab_preauth_reference",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "bar_tab_approved_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "outside_food",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "high_power_equipment",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "high_power_equipment_approved_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "decorations_plan",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "boolean",
+      "table_name": "private_bookings",
+      "column_name": "dogs_expected",
+      "is_nullable": "NO",
+      "column_default": "false"
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "special_risk_notes",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "communication_preference",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "time without time zone",
+      "table_name": "private_bookings",
+      "column_name": "cleardown_time",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "cancellation_channel",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "cancellation_received_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "cancellation_evidence_document_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "cancelled_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "locked_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "locked_reason",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "locked_by",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "uuid",
+      "table_name": "private_bookings",
+      "column_name": "invoice_id",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "timestamp with time zone",
+      "table_name": "private_bookings",
+      "column_name": "invoice_sent_at",
+      "is_nullable": "YES",
+      "column_default": null
+    },
+    {
+      "data_type": "text",
+      "table_name": "private_bookings",
+      "column_name": "invoice_deposit_treatment",
+      "is_nullable": "YES",
+      "column_default": null
+    }
+  ],
+  "triggers": [
+    {
+      "def": "CREATE TRIGGER trg_oj_invoice_paid AFTER UPDATE OF status ON public.invoices FOR EACH ROW EXECUTE FUNCTION oj_mark_entries_paid_on_invoice_paid()",
+      "tab": "invoices"
+    },
+    {
+      "def": "CREATE TRIGGER update_invoices_updated_at BEFORE UPDATE ON public.invoices FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()",
+      "tab": "invoices"
+    },
+    {
+      "def": "CREATE TRIGGER audit_balance_due_date_change AFTER UPDATE ON public.private_bookings FOR EACH ROW WHEN ((old.balance_due_date IS DISTINCT FROM new.balance_due_date)) EXECUTE FUNCTION audit_balance_due_date_change()",
+      "tab": "private_bookings"
+    },
+    {
+      "def": "CREATE TRIGGER private_bookings_delete_gate BEFORE DELETE ON public.private_bookings FOR EACH ROW EXECUTE FUNCTION prevent_hard_delete_when_sms_sent()",
+      "tab": "private_bookings"
+    },
+    {
+      "def": "CREATE TRIGGER set_balance_due_date BEFORE INSERT OR UPDATE OF event_date ON public.private_bookings FOR EACH ROW EXECUTE FUNCTION calculate_balance_due_date()",
+      "tab": "private_bookings"
+    },
+    {
+      "def": "CREATE TRIGGER sync_customer_name_trigger BEFORE INSERT OR UPDATE OF customer_id ON public.private_bookings FOR EACH ROW EXECUTE FUNCTION sync_customer_name_from_customers()",
+      "tab": "private_bookings"
+    },
+    {
+      "def": "CREATE TRIGGER update_private_bookings_updated_at BEFORE UPDATE ON public.private_bookings FOR EACH ROW EXECUTE FUNCTION update_updated_at_column()",
+      "tab": "private_bookings"
+    }
+  ],
+  "constraints": [
+    {
+      "def": "UNIQUE (invoice_number)",
+      "tab": "invoices",
+      "conname": "invoices_invoice_number_key"
+    },
+    {
+      "def": "PRIMARY KEY (id)",
+      "tab": "invoices",
+      "conname": "invoices_pkey"
+    },
+    {
+      "def": "CHECK (((sent_to IS NULL) OR (sent_at IS NOT NULL)))",
+      "tab": "invoices",
+      "conname": "invoices_sent_to_requires_sent_at"
+    },
+    {
+      "def": "CHECK (((status)::text = ANY (ARRAY[('draft'::character varying)::text, ('sent'::character varying)::text, ('paid'::character varying)::text, ('partially_paid'::character varying)::text, ('overdue'::character varying)::text, ('void'::character varying)::text, ('written_off'::character varying)::text])))",
+      "tab": "invoices",
+      "conname": "invoices_status_check"
+    },
+    {
+      "def": "FOREIGN KEY (vendor_id) REFERENCES invoice_vendors(id) ON DELETE RESTRICT",
+      "tab": "invoices",
+      "conname": "invoices_vendor_id_fkey"
+    },
+    {
+      "def": "FOREIGN KEY (invoice_id) REFERENCES invoices(id) ON DELETE CASCADE",
+      "tab": "invoice_payments",
+      "conname": "invoice_payments_invoice_id_fkey"
+    },
+    {
+      "def": "CHECK (((payment_method)::text = ANY (ARRAY[('bank_transfer'::character varying)::text, ('cash'::character varying)::text, ('cheque'::character varying)::text, ('card'::character varying)::text, ('other'::character varying)::text])))",
+      "tab": "invoice_payments",
+      "conname": "invoice_payments_payment_method_check"
+    },
+    {
+      "def": "PRIMARY KEY (id)",
+      "tab": "invoice_payments",
+      "conname": "invoice_payments_pkey"
+    },
+    {
+      "def": "CHECK ((source_kind = ANY (ARRAY['booking_payment'::text, 'booking_deposit'::text])))",
+      "tab": "invoice_payments",
+      "conname": "invoice_payments_source_kind_check"
+    },
+    {
+      "def": "FOREIGN KEY (source_payment_id) REFERENCES private_booking_payments(id) ON DELETE SET NULL",
+      "tab": "invoice_payments",
+      "conname": "invoice_payments_source_payment_id_fkey"
+    },
+    {
+      "def": "CHECK (((end_time IS NULL) OR (end_time > start_time) OR (end_time_next_day = true)))",
+      "tab": "private_bookings",
+      "conname": "chk_booking_times"
+    },
+    {
+      "def": "CHECK (((contact_email IS NULL) OR (contact_email ~* '^[A-Za-z0-9._%-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$'::text)))",
+      "tab": "private_bookings",
+      "conname": "chk_email_format"
+    },
+    {
+      "def": "CHECK (((contact_phone IS NULL) OR (contact_phone ~ '^\\+[1-9][0-9]{7,14}$'::text) OR (contact_phone ~ '^00[1-9][0-9]{7,14}$'::text) OR (contact_phone ~ '^0[0-9]{6,14}$'::text) OR (contact_phone ~ '^[1-9][0-9]{7,14}$'::text)))",
+      "tab": "private_bookings",
+      "conname": "chk_phone_format"
+    },
+    {
+      "def": "CHECK (((setup_time IS NULL) OR (setup_date < event_date) OR ((setup_date = event_date) AND (setup_time <= start_time)) OR ((setup_date IS NULL) AND (setup_time <= start_time))))",
+      "tab": "private_bookings",
+      "conname": "chk_setup_before_start"
+    },
+    {
+      "def": "CHECK (((cancellation_channel IS NULL) OR (cancellation_channel = ANY (ARRAY['email'::text, 'whatsapp'::text, 'text'::text, 'phone'::text, 'in_person'::text, 'other'::text]))))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_cancellation_channel_check"
+    },
+    {
+      "def": "FOREIGN KEY (cancellation_evidence_document_id) REFERENCES private_booking_documents(id)",
+      "tab": "private_bookings",
+      "conname": "private_bookings_cancellation_evidence_document_id_fkey"
+    },
+    {
+      "def": "FOREIGN KEY (created_by) REFERENCES auth.users(id)",
+      "tab": "private_bookings",
+      "conname": "private_bookings_created_by_fkey"
+    },
+    {
+      "def": "FOREIGN KEY (customer_id) REFERENCES customers(id) ON DELETE RESTRICT",
+      "tab": "private_bookings",
+      "conname": "private_bookings_customer_id_fkey"
+    },
+    {
+      "def": "CHECK ((deposit_refund_status = ANY (ARRAY['partially_refunded'::text, 'refunded'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_deposit_refund_status_check"
+    },
+    {
+      "def": "CHECK ((discount_type = ANY (ARRAY['percent'::text, 'fixed'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_discount_type_check"
+    },
+    {
+      "def": "CHECK ((event_sheet_status = ANY (ARRAY['not_generated'::text, 'generated'::text, 'sent_to_staff'::text, 'locked'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_event_sheet_status_check"
+    },
+    {
+      "def": "CHECK ((final_details_status = ANY (ARRAY['not_requested'::text, 'requested'::text, 'complete'::text, 'incomplete'::text, 'overdue'::text, 'manager_reviewed'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_final_details_status_check"
+    },
+    {
+      "def": "CHECK ((invoice_deposit_treatment = ANY (ARRAY['held_separately'::text, 'deducted'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_invoice_deposit_treatment_check"
+    },
+    {
+      "def": "FOREIGN KEY (invoice_id) REFERENCES invoices(id)",
+      "tab": "private_bookings",
+      "conname": "private_bookings_invoice_id_fkey"
+    },
+    {
+      "def": "CHECK (((layout IS NULL) OR (layout = ANY (ARRAY['seated'::text, 'standing'::text, 'mixed'::text]))))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_layout_check"
+    },
+    {
+      "def": "PRIMARY KEY (id)",
+      "tab": "private_bookings",
+      "conname": "private_bookings_pkey"
+    },
+    {
+      "def": "CHECK ((post_event_outcome = ANY (ARRAY['pending'::text, 'went_well'::text, 'issues'::text, 'skip'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_post_event_outcome_check"
+    },
+    {
+      "def": "CHECK (((post_event_status IS NULL) OR (post_event_status = ANY (ARRAY['awaiting_inspection'::text, 'inspection_complete'::text, 'deduction_discussion'::text, 'refund_processed'::text, 'complete'::text]))))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_post_event_status_check"
+    },
+    {
+      "def": "CHECK ((risk_status = ANY (ARRAY['low'::text, 'normal'::text, 'high'::text, 'gm_approval_required'::text, 'approved'::text, 'rejected'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_risk_status_check"
+    },
+    {
+      "def": "CHECK ((status = ANY (ARRAY['draft'::text, 'confirmed'::text, 'completed'::text, 'cancelled'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_status_check"
+    },
+    {
+      "def": "CHECK ((supplier_status = ANY (ARRAY['not_applicable'::text, 'requested'::text, 'incomplete'::text, 'approved'::text, 'rejected'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_supplier_status_check"
+    },
+    {
+      "def": "CHECK ((waiver_status = ANY (ARRAY['not_required'::text, 'required'::text, 'sent'::text, 'signed'::text, 'overdue'::text])))",
+      "tab": "private_bookings",
+      "conname": "private_bookings_waiver_status_check"
+    },
+    {
+      "def": "CHECK ((amount > (0)::numeric))",
+      "tab": "private_booking_payments",
+      "conname": "private_booking_payments_amount_check"
+    },
+    {
+      "def": "FOREIGN KEY (booking_id) REFERENCES private_bookings(id) ON DELETE CASCADE",
+      "tab": "private_booking_payments",
+      "conname": "private_booking_payments_booking_id_fkey"
+    },
+    {
+      "def": "CHECK ((method = ANY (ARRAY['cash'::text, 'card'::text, 'invoice'::text])))",
+      "tab": "private_booking_payments",
+      "conname": "private_booking_payments_method_check"
+    },
+    {
+      "def": "PRIMARY KEY (id)",
+      "tab": "private_booking_payments",
+      "conname": "private_booking_payments_pkey"
+    },
+    {
+      "def": "FOREIGN KEY (recorded_by) REFERENCES auth.users(id)",
+      "tab": "private_booking_payments",
+      "conname": "private_booking_payments_recorded_by_fkey"
+    }
+  ],
+  "latest_migrations": [
+    {
+      "name": "event_booking_dining_requests",
+      "version": "20260905124510"
+    },
+    {
+      "name": "christmas_course_snapshot",
+      "version": "20260905124506"
+    },
+    {
+      "name": "restrict_profiles_read_to_authenticated",
+      "version": "20260905052727"
+    },
+    {
+      "name": "short_link_legacy_reports",
+      "version": "20260903220000"
+    },
+    {
+      "name": "invoice_paypal_payment_foundations",
+      "version": "20260903160000"
+    }
+  ]
+}

--- a/tests/fixtures/private-booking-settlement/regression-after.sql
+++ b/tests/fixtures/private-booking-settlement/regression-after.sql
@@ -1,0 +1,125 @@
+SET timezone = 'UTC';
+SELECT fixture_assert(calculate_private_booking_balance('c28527fe-a373-460d-85a8-e509b78d6eba')=744.80,'applied deposit deducted once');
+SELECT fixture_assert(calculate_private_booking_balance('00000000-0000-0000-0000-000000000020')=120,'held deposit stays separate');
+SELECT fixture_throws($q$UPDATE invoice_payments SET amount=200 WHERE source_kind='booking_deposit'$q$,'invoice credit resolution');
+SELECT fixture_throws($q$DELETE FROM invoice_payments WHERE source_kind='booking_deposit'$q$,'invoice credit resolution');
+SELECT fixture_throws($q$UPDATE private_bookings SET deposit_amount=200 WHERE id='c28527fe-a373-460d-85a8-e509b78d6eba'$q$,'invoice credit resolution');
+SELECT fixture_throws($q$SELECT * FROM reserve_refund_balance('private_booking','c28527fe-a373-460d-85a8-e509b78d6eba',250,50,'paypal','Fixture',NULL)$q$,'invoice credit resolution');
+SELECT fixture_assert((SELECT count(*)=0 FROM payment_refunds),'rejected refund created no reservation');
+
+-- Payments after invoicing must synchronise and must never be counted twice.
+SELECT record_balance_payment('c28527fe-a373-460d-85a8-e509b78d6eba',100,'cash');
+SELECT fixture_assert((SELECT paid_amount=350 FROM invoices WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'),'booking insertion mirrored');
+SELECT fixture_assert(calculate_private_booking_balance('c28527fe-a373-460d-85a8-e509b78d6eba')=644.80,'mirror not double counted');
+SELECT fixture_throws($q$UPDATE invoice_payments SET amount=101 WHERE source_kind='booking_payment'$q$,'original booking payment');
+SELECT fixture_throws($q$DELETE FROM invoice_payments WHERE source_kind='booking_payment'$q$,'original booking payment');
+UPDATE private_booking_payments SET amount=150 WHERE booking_id='c28527fe-a373-460d-85a8-e509b78d6eba';
+SELECT fixture_assert((SELECT paid_amount=400 FROM invoices WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'),'booking edit mirrored');
+DELETE FROM private_booking_payments WHERE booking_id='c28527fe-a373-460d-85a8-e509b78d6eba';
+SELECT fixture_assert((SELECT paid_amount=250 FROM invoices WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'),'booking deletion removes mirror before source foreign key');
+
+-- Simulate the old four-argument application racing the dated recovery.
+SELECT record_invoice_paypal_payment_atomic('8a590bb4-487b-4522-929b-b5c6c3f81071',744.80,'62921439S0526370F','1NX08920NB808283W');
+SELECT fixture_assert((SELECT status='paid' AND paid_amount=994.80 FROM invoices WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'),'PayPal completes invoice');
+SELECT fixture_assert((SELECT final_payment_date IS NOT NULL FROM private_bookings WHERE id='c28527fe-a373-460d-85a8-e509b78d6eba'),'PayPal completes booking');
+SELECT fixture_assert((SELECT balance_remaining=0 AND total_balance_paid=994.80 AND payment_status='Fully Paid' FROM private_bookings_with_details WHERE id='c28527fe-a373-460d-85a8-e509b78d6eba'),'view uses same payment ledger');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('8a590bb4-487b-4522-929b-b5c6c3f81071',744.81,'62921439S0526370F',NULL)$q$,'paypal_capture_conflict');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000011',744.80,'62921439S0526370F',NULL)$q$,'paypal_capture_conflict');
+SELECT fixture_throws($q$SELECT record_balance_payment('c28527fe-a373-460d-85a8-e509b78d6eba',1,'cash')$q$,'exceeds remaining balance');
+SELECT fixture_throws($q$UPDATE invoices SET status='void' WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'$q$,'Cancel the invoice');
+SELECT fixture_throws($q$SELECT cancel_private_booking_invoice_atomic('c28527fe-a373-460d-85a8-e509b78d6eba','Fixture',NULL)$q$,'invoice_has_real_payments');
+SELECT fixture_throws($q$UPDATE private_bookings SET invoice_id=NULL WHERE id='c28527fe-a373-460d-85a8-e509b78d6eba'$q$,'invoice_has_real_payments');
+
+-- Provider identities and amounts are immutable, so replays cannot credit twice.
+SELECT fixture_throws($q$UPDATE invoice_payments SET amount=700 WHERE reference='62921439S0526370F'$q$,'PayPal captures cannot be changed');
+SELECT fixture_throws($q$UPDATE invoice_payments SET reference='CHANGED' WHERE reference='62921439S0526370F'$q$,'PayPal captures cannot be changed');
+SELECT fixture_throws($q$DELETE FROM invoice_payments WHERE reference='62921439S0526370F'$q$,'PayPal captures cannot be changed');
+-- Manual payment corrections reopen both summaries.
+SELECT record_invoice_payment_transaction('{"invoice_id":"00000000-0000-0000-0000-000000000010","amount":120,"payment_method":"cash","payment_date":"2026-09-04","reference":"MANUAL-EDIT"}');
+SELECT fixture_assert((SELECT final_payment_date IS NOT NULL FROM private_bookings WHERE id='00000000-0000-0000-0000-000000000020'),'manual payment completes booking');
+UPDATE invoice_payments SET amount=110 WHERE reference='MANUAL-EDIT';
+SELECT fixture_assert((SELECT final_payment_date IS NULL FROM private_bookings WHERE id='00000000-0000-0000-0000-000000000020'),'reducing manual payment reopens booking');
+SELECT fixture_assert((SELECT status='partially_paid' AND paid_amount=110 FROM invoices WHERE id='00000000-0000-0000-0000-000000000010'),'reducing manual payment reopens invoice');
+DELETE FROM invoice_payments WHERE reference='MANUAL-EDIT';
+
+-- Provider dates are London dates even when PostgreSQL runs in UTC.
+SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000011',10,'LONDON-DATE',NULL,'2026-09-04T23:30:00Z');
+SELECT fixture_assert((SELECT payment_date='2026-09-05' FROM invoice_payments WHERE reference='LONDON-DATE'),'London capture date');
+UPDATE invoice_payments SET payment_date='2026-09-04' WHERE reference='LONDON-DATE';
+INSERT INTO invoices(id,invoice_number,due_date,total_amount,status,sent_at)
+VALUES('00000000-0000-0000-0000-000000000013','FIXTURE-DELETE','2026-09-09',120,'sent',now());
+SELECT record_invoice_payment_transaction('{"invoice_id":"00000000-0000-0000-0000-000000000013","amount":10,"payment_method":"cash","payment_date":"2026-09-04","reference":"DELETE-MANUAL"}');
+DELETE FROM invoice_payments WHERE reference='DELETE-MANUAL';
+SELECT fixture_assert((SELECT paid_amount=0 AND status='sent' FROM invoices WHERE id='00000000-0000-0000-0000-000000000013'),'deletion resets invoice');
+UPDATE invoices SET status='void' WHERE id='00000000-0000-0000-0000-000000000011';
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000011',10,'VOID',NULL)$q$,'invoice_not_payable');
+SELECT fixture_throws($q$SELECT record_invoice_payment_transaction('{"invoice_id":"00000000-0000-0000-0000-000000000011","amount":10,"payment_method":"cash","payment_date":"2026-09-04"}')$q$,'invoice_not_payable');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010',0,'ZERO',NULL)$q$,'invalid_payment_amount');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010',1.001,'ROUNDING',NULL)$q$,'invalid_payment_amount');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010','NaN'::numeric,'NAN',NULL)$q$,'invalid_payment_amount');
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010','Infinity'::numeric,'INF',NULL)$q$,'invalid_payment_amount');
+INSERT INTO invoices(id,invoice_number,due_date,total_amount,status)
+VALUES('00000000-0000-0000-0000-000000000012','FIXTURE-OVERPAY','2026-09-09',120,'sent');
+SELECT fixture_assert((record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000012',130,'OVERPAY',NULL)->>'overpaid_amount')::numeric=10,'actual excess capture retained and flagged');
+SELECT fixture_assert((SELECT paid_amount=130 FROM invoices WHERE id='00000000-0000-0000-0000-000000000012'),'overpayment is never clipped');
+
+-- Reuse actual permission helper with an invoice-only staff fixture. Internal
+-- booking recalculation must not require this person to have booking.view.
+GRANT USAGE ON SCHEMA public,auth TO authenticated,service_role,anon;
+GRANT EXECUTE ON FUNCTION public.fixture_throws(text,text), public.fixture_assert(boolean,text) TO authenticated,service_role,anon;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
+SET ROLE authenticated;
+SET request.jwt.claims='{"role":"authenticated"}';
+SET fixture.user_id='00000000-0000-0000-0000-000000000099';
+SET fixture.permission='invoices.edit';
+SELECT record_invoice_payment_transaction('{"invoice_id":"00000000-0000-0000-0000-000000000010","amount":5,"payment_method":"cash","payment_date":"2026-09-04"}');
+SELECT fixture_throws($q$SELECT calculate_private_booking_balance('00000000-0000-0000-0000-000000000020')$q$,'permission_denied');
+SET fixture.permission='private_bookings.view';
+SELECT fixture_assert(calculate_private_booking_balance('00000000-0000-0000-0000-000000000020')=115,'booking-only staff can see invoice-origin money');
+SELECT fixture_throws($q$SELECT * FROM private_booking_settlement_rows('00000000-0000-0000-0000-000000000020')$q$,'permission denied');
+RESET ROLE;
+SET request.jwt.claims='{"role":"service_role"}';
+DELETE FROM invoice_payments WHERE invoice_id='00000000-0000-0000-0000-000000000010';
+
+-- The real invoice creation function must still copy earlier booking payments,
+-- accept a deposit credit and permit cancellation when no real payment exists.
+INSERT INTO private_bookings(id,customer_name,event_date,start_time,status,deposit_amount,deposit_paid_date)
+VALUES('00000000-0000-0000-0000-000000000030','Fixture cancellation','2026-09-10','19:00','confirmed',20,'2026-09-01'),
+('00000000-0000-0000-0000-000000000031','Fixture earlier payment','2026-09-10','19:00','confirmed',0,NULL);
+INSERT INTO private_booking_items(booking_id,item_type,description,unit_price)
+VALUES('00000000-0000-0000-0000-000000000030','other','Fixture event',100),
+('00000000-0000-0000-0000-000000000031','other','Fixture event',100);
+SELECT record_balance_payment('00000000-0000-0000-0000-000000000031',30,'cash');
+SELECT fixture_throws($q$INSERT INTO invoice_payments(invoice_id,payment_date,amount,payment_method,source_payment_id,source_kind)
+SELECT '00000000-0000-0000-0000-000000000010',(created_at AT TIME ZONE 'Europe/London')::date,amount,'cash',id,'booking_payment'
+FROM private_booking_payments WHERE booking_id='00000000-0000-0000-0000-000000000031'$q$,'original booking payment');
+SELECT create_private_booking_invoice_atomic('00000000-0000-0000-0000-000000000030','2026-09-01','2026-09-09',NULL,'deducted',
+ '[{"description":"Fixture event","quantity":1,"unit_price":100,"vat_rate":20}]','{"subtotal_amount":100,"vat_amount":20,"total_amount":120}',NULL);
+SELECT create_private_booking_invoice_atomic('00000000-0000-0000-0000-000000000031','2026-09-01','2026-09-09',NULL,'held_separately',
+ '[{"description":"Fixture event","quantity":1,"unit_price":100,"vat_rate":20}]','{"subtotal_amount":100,"vat_amount":20,"total_amount":120}',NULL);
+SELECT fixture_assert((SELECT i.paid_amount=30 FROM private_bookings b JOIN invoices i ON i.id=b.invoice_id WHERE b.id='00000000-0000-0000-0000-000000000031'),'pre-invoice payment copied once');
+SELECT fixture_assert(calculate_private_booking_balance('00000000-0000-0000-0000-000000000031')=90,'pre-invoice payment not doubled');
+SELECT fixture_throws($q$UPDATE private_booking_items SET unit_price=101 WHERE booking_id='00000000-0000-0000-0000-000000000031'$q$,'Resolve the linked invoice');
+SELECT fixture_throws($q$DELETE FROM private_booking_items WHERE booking_id='00000000-0000-0000-0000-000000000031'$q$,'Resolve the linked invoice');
+SELECT fixture_throws($q$INSERT INTO private_booking_items(booking_id,item_type,description,unit_price) VALUES('00000000-0000-0000-0000-000000000031','other','Fixture extra',1)$q$,'Resolve the linked invoice');
+SELECT fixture_throws($q$UPDATE private_bookings SET discount_type='fixed',discount_amount=1 WHERE id='00000000-0000-0000-0000-000000000031'$q$,'Resolve the linked invoice');
+SELECT fixture_throws($q$UPDATE invoices SET total_amount=121 WHERE id=(SELECT invoice_id FROM private_bookings WHERE id='00000000-0000-0000-0000-000000000031')$q$,'Resolve the linked invoice');
+SELECT fixture_throws($q$UPDATE invoice_line_items SET unit_price=101 WHERE invoice_id=(SELECT invoice_id FROM private_bookings WHERE id='00000000-0000-0000-0000-000000000031')$q$,'Resolve the linked invoice');
+SELECT fixture_assert((SELECT i.total_amount=120 AND get_booking_gross_total(b.id)=120 FROM private_bookings b JOIN invoices i ON i.id=b.invoice_id WHERE b.id='00000000-0000-0000-0000-000000000031'),'price guards preserve both totals');
+UPDATE private_booking_items SET notes='Fixture operational note' WHERE booking_id='00000000-0000-0000-0000-000000000031';
+SELECT cancel_private_booking_invoice_atomic('00000000-0000-0000-0000-000000000030','Fixture cancellation',NULL);
+SELECT fixture_assert((SELECT invoice_id IS NULL FROM private_bookings WHERE id='00000000-0000-0000-0000-000000000030'),'deposit-only cancellation unlinks');
+SELECT fixture_assert(calculate_private_booking_balance('00000000-0000-0000-0000-000000000030')=120,'cancelled deposit credit no longer reduces event price');
+
+SELECT fixture_assert(NOT has_function_privilege('anon','public.record_invoice_paypal_payment_atomic(uuid,numeric,text,text,timestamptz)','EXECUTE'),'anon cannot record capture');
+SELECT fixture_assert(NOT has_function_privilege('authenticated','public.record_invoice_paypal_payment_atomic(uuid,numeric,text,text,timestamptz)','EXECUTE'),'authenticated cannot call trusted capture RPC');
+SELECT fixture_assert(has_function_privilege('service_role','public.record_invoice_paypal_payment_atomic(uuid,numeric,text,text,timestamptz)','EXECUTE'),'service role can record capture');
+SET ROLE anon;
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('00000000-0000-0000-0000-000000000010',1,'ANON',NULL)$q$,'permission denied');
+SELECT fixture_throws($q$SELECT calculate_private_booking_balance('00000000-0000-0000-0000-000000000020')$q$,'permission denied');
+RESET ROLE;
+SET request.jwt.claims='{}';
+SET fixture.user_id='';
+SELECT fixture_throws($q$SELECT get_private_booking_settlement_total('c28527fe-a373-460d-85a8-e509b78d6eba')$q$,'permission_denied');
+SET request.jwt.claims='{"role":"service_role"}';
+SELECT 'PASS settlement ledger, mirrors, invalid states, dates, permissions and retries';

--- a/tests/fixtures/private-booking-settlement/regression-before.sql
+++ b/tests/fixtures/private-booking-settlement/regression-before.sql
@@ -1,0 +1,29 @@
+CREATE FUNCTION public.fixture_assert(ok boolean, label text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN IF ok IS DISTINCT FROM true THEN RAISE EXCEPTION 'ASSERT: %', label; END IF; END;
+$$;
+CREATE FUNCTION public.fixture_throws(statement text, expected text) RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  BEGIN EXECUTE statement;
+  EXCEPTION WHEN OTHERS THEN
+    IF position(expected IN SQLERRM) > 0 THEN RETURN; END IF;
+    RAISE EXCEPTION 'Expected %, got %', expected, SQLERRM;
+  END;
+  RAISE EXCEPTION 'Expected failure: %', expected;
+END;
+$$;
+
+INSERT INTO invoices(id,invoice_number,due_date,total_amount,status,sent_at,paypal_order_id)
+VALUES('8a590bb4-487b-4522-929b-b5c6c3f81071','FIXTURE-REPAIR','2026-09-09',994.80,'partially_paid',now(),'1NX08920NB808283W'),
+('00000000-0000-0000-0000-000000000010','FIXTURE-CONCURRENT','2026-09-09',120,'sent',now(),NULL),
+('00000000-0000-0000-0000-000000000011','FIXTURE-SECOND','2026-09-09',120,'sent',now(),NULL);
+INSERT INTO private_bookings(customer_name,id,event_date,start_time,guest_count,status,invoice_id,invoice_deposit_treatment,deposit_amount,deposit_paid_date)
+VALUES('Fixture booking','c28527fe-a373-460d-85a8-e509b78d6eba','2026-09-10','19:00',24,'confirmed','8a590bb4-487b-4522-929b-b5c6c3f81071','deducted',250,'2026-08-28'),
+('Fixture booking','00000000-0000-0000-0000-000000000020','2026-09-10','19:00',10,'confirmed','00000000-0000-0000-0000-000000000010','held_separately',250,'2026-08-28');
+INSERT INTO private_booking_items(booking_id,item_type,description,unit_price)
+VALUES('c28527fe-a373-460d-85a8-e509b78d6eba','other','Fixture event',829),
+('00000000-0000-0000-0000-000000000020','other','Fixture event',100);
+INSERT INTO invoice_payments(invoice_id,payment_date,amount,payment_method,source_kind)
+VALUES('8a590bb4-487b-4522-929b-b5c6c3f81071','2026-08-28',250,'other','booking_deposit');
+UPDATE invoices SET paid_amount=250 WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071';
+SELECT fixture_throws($q$SELECT record_invoice_paypal_payment_atomic('8a590bb4-487b-4522-929b-b5c6c3f81071',744.80,'BEFORE-FAIL',NULL)$q$, 'invoice_payments_payment_method_check');
+SELECT fixture_assert(calculate_private_booking_balance('c28527fe-a373-460d-85a8-e509b78d6eba')=994.80,'old balance ignores deposit credit');

--- a/tests/fixtures/private-booking-settlement/regression-repair.sql
+++ b/tests/fixtures/private-booking-settlement/regression-repair.sql
@@ -1,0 +1,5 @@
+SELECT fixture_assert((SELECT count(*)=1 FROM invoice_payments WHERE reference='62921439S0526370F'),'recovery idempotent');
+SELECT fixture_assert((SELECT payment_date='2026-09-04' AND amount=744.80 FROM invoice_payments WHERE reference='62921439S0526370F'),'recovery corrects old-client capture date');
+SELECT fixture_assert((SELECT paid_amount=994.80 AND status='paid' FROM invoices WHERE id='8a590bb4-487b-4522-929b-b5c6c3f81071'),'recovery settled invoice');
+SELECT fixture_assert((SELECT final_payment_date AT TIME ZONE 'Europe/London'='2026-09-04'::timestamp AND final_payment_method='paypal' FROM private_bookings WHERE id='c28527fe-a373-460d-85a8-e509b78d6eba'),'recovery booking date and method');
+SELECT 'PASS verified-capture recovery and repeated recovery';

--- a/tests/services/privateBookingsFinancial.test.ts
+++ b/tests/services/privateBookingsFinancial.test.ts
@@ -45,13 +45,13 @@ function mockSupabase(opts: {
     error: opts.bookingError ?? (opts.booking ? null : { message: 'not found' }),
   })
   const bookingEq = vi.fn().mockReturnValue({ single: bookingSingle })
-  const bookingSelect = vi.fn().mockReturnValue({ eq: bookingEq })
+  const bookingSelect = vi.fn().mockReturnValue({ eq: bookingEq, in: vi.fn(async (_key: string, ids: string[]) => ({ data: opts.booking ? ids.map(id => ({ id, invoice_id: null })) : [], error: opts.bookingError ?? null })) })
 
   const paymentsEq = vi.fn().mockResolvedValue({
     data: opts.payments ?? [],
     error: opts.paymentsError ?? null,
   })
-  const paymentsSelect = vi.fn().mockReturnValue({ eq: paymentsEq })
+  const paymentsSelect = vi.fn().mockReturnValue({ eq: paymentsEq, in: vi.fn(async (_key: string, ids: string[]) => ({ data: (opts.payments ?? []).map((payment, index) => ({ ...payment, id: String(index), booking_id: ids[0], method: 'cash', created_at: '2026-01-10' })), error: opts.paymentsError ?? null })) })
 
   mockedCreateAdminClient.mockReturnValue({
     from: vi.fn((table: string) => {
@@ -145,21 +145,13 @@ describe('getPrivateBookingPaidTotals', () => {
     expect(totals.has_open_dispute).toBe(false)
   })
 
-  it('returns safe zeros when booking cannot be loaded', async () => {
+  it('fails closed when booking cannot be loaded', async () => {
     mockSupabase({
       booking: null,
       bookingError: { message: 'not found' },
     })
 
-    const totals = await getPrivateBookingPaidTotals('missing-booking')
-
-    expect(totals).toEqual({
-      deposit_paid: 0,
-      balance_payments_total: 0,
-      total_paid: 0,
-      has_open_dispute: false,
-      event_date: null,
-    })
+    await expect(getPrivateBookingPaidTotals('missing-booking')).rejects.toThrow('Could not load booking payment totals')
   })
 })
 

--- a/tests/services/privateBookingsScheduledSms.test.ts
+++ b/tests/services/privateBookingsScheduledSms.test.ts
@@ -28,6 +28,7 @@ function mockSupabase(opts: {
   bookingError?: { message: string } | null
   idempRows?: IdempRow[]
   paymentRows?: Array<{ amount: number }>
+  invoicePayments?: Array<Record<string, unknown>>
 }): void {
   const bookingSingle = vi.fn().mockResolvedValue({
     data: opts.booking ?? null,
@@ -35,7 +36,7 @@ function mockSupabase(opts: {
       opts.bookingError ?? (opts.booking ? null : { message: 'not found' }),
   })
   const bookingEq = vi.fn().mockReturnValue({ single: bookingSingle })
-  const bookingSelect = vi.fn().mockReturnValue({ eq: bookingEq })
+  const bookingSelect = vi.fn().mockReturnValue({ eq: bookingEq, in: vi.fn(async (_key: string, ids: string[]) => ({ data: ids.map(id => ({ id, invoice_id: opts.booking?.invoice_id ?? null, invoice_deposit_treatment: opts.booking?.invoice_deposit_treatment ?? null })), error: null })) })
 
   const idempEq = vi.fn().mockResolvedValue({
     data: opts.idempRows ?? [],
@@ -46,7 +47,7 @@ function mockSupabase(opts: {
     data: opts.paymentRows ?? [],
     error: null,
   })
-  const paymentsSelect = vi.fn().mockReturnValue({ eq: paymentsEq })
+  const paymentsSelect = vi.fn().mockReturnValue({ eq: paymentsEq, in: vi.fn(async (_key: string, ids: string[]) => ({ data: (opts.paymentRows ?? (opts.booking?.final_payment_date ? [{ amount: Number(opts.booking.gross_total ?? opts.booking.calculated_total ?? opts.booking.total_amount ?? 0) }] : [])).map((payment, index) => ({ ...payment, id: String(index), booking_id: ids[0], method: 'cash', created_at: '2026-01-10' })), error: null })) })
 
   // getGoogleReviewLink (review-request preview) reads system_settings and
   // falls back to the feedback funnel URL when the row is absent.
@@ -59,6 +60,8 @@ function mockSupabase(opts: {
       if (table === 'private_bookings' || table === 'private_bookings_with_details') {
         return { select: bookingSelect }
       }
+      if (table === 'invoices') return { select: () => ({ in: async () => ({ data: [{ id: opts.booking?.invoice_id, status: 'paid', deleted_at: null }], error: null }) }) }
+      if (table === 'invoice_payments') return { select: () => ({ in: async () => ({ data: opts.invoicePayments ?? [], error: null }) }) }
       if (table === 'private_booking_send_idempotency')
         return { select: idempSelect }
       if (table === 'private_booking_payments') return { select: paymentsSelect }
@@ -333,4 +336,18 @@ describe('getBookingScheduledSms', () => {
     )
     expect(balance).toBeUndefined()
   })
+})
+
+
+it('suppresses a balance reminder when the linked invoice is settled before its booking stamp refreshes', async () => {
+  process.env.PRIVATE_BOOKING_UPCOMING_EVENT_SMS_ENABLED = 'true'
+  mockSupabase({
+    booking: confirmedBooking({ invoice_id: 'invoice', invoice_deposit_treatment: 'deducted', final_payment_date: null }),
+    invoicePayments: [
+      { id: 'deposit', invoice_id: 'invoice', amount: 250, source_kind: 'booking_deposit' },
+      { id: 'paypal', invoice_id: 'invoice', amount: 950, source_kind: 'paypal', payment_method: 'paypal', payment_date: '2026-05-01' },
+    ],
+  })
+  const result = await getBookingScheduledSms(BOOKING_ID, NOW)
+  expect(result.some(reminder => reminder.trigger_type.startsWith('balance_reminder_'))).toBe(false)
 })


### PR DESCRIPTION
## What changed

Private-booking invoice payments could be captured by PayPal while the database rejected them, leaving the invoice unsettled and the booking balance wrong. This change validates and recovers completed captures, keeps invoice and booking totals consistent, and shows applied deposits and invoice payments once in payment history.

Payment retries preserve the original order, failed webhook writes remain retryable, and simultaneous entries use consistent locks. Financial guards protect applied deposits, linked prices and recorded capture identities. Refund controls, reminders and future contracts use the same payment totals. Existing sent documents are unchanged.

## Testing done

- Full integration suite: 733 files passed, 6,325 tests passed, two skipped.
- Lint and cold type checking passed.
- Isolated PostgreSQL: rollback, replay/conflict, permissions, recovery and concurrent settlement passed.
- Production post-migration reads: expected settlement totals, all nine anonymous-surface checks and all changed catalogue objects verified.
- Final cold Node 20 production build and full coverage run passed: 6,325 tests; lines 53.42%, branches 43.01%, functions 60.97%, all above required floors. GitHub checks are verified before merge.

## Complexity score

L. One payment-settlement concern spans provider handling, financial SQL and booking presentation.

## Breaking changes

The schema migration must precede the application deployment. It is already applied. The former four-argument payment routine remains compatible. The internal capture writer is no longer exposed as a server action.

## Migration risk

High, explicitly approved and applied through the Supabase migration tool. Approved draft 20260905180000 was applied as version 20260905192946; repair draft 20260905180100 was applied as 20260905192951. Repository filenames now match those actual history versions; the approved SQL and checksums are unchanged. Five-second lock timeout; transactional rollback was tested. After commit, preserve capture evidence and use an approved forward fix rather than delete real money records.

The paired website only consumes booking APIs and required no change. No additional payment, refund or customer message was sent. Unrelated local work is excluded.
