### PR TITLE
fix: keep event checklist responsive during saves

### DIFF
--- a/src/components/features/events/EventChecklistCard.tsx
+++ b/src/components/features/events/EventChecklistCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { Card } from '@/ds'
 import { Badge } from '@/ds'
@@ -23,7 +23,8 @@ export function EventChecklistCard({ eventId, eventName, className }: EventCheck
   const [items, setItems] = useState<EventChecklistItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [pendingTaskKey, setPendingTaskKey] = useState<string | null>(null)
+  const pendingTasks = useRef(new Set<string>())
+  const [pendingTaskKeys, setPendingTaskKeys] = useState<Set<string>>(new Set())
   const todayIso = getTodayIsoDate()
 
   const loadChecklist = useCallback(async () => {
@@ -51,38 +52,43 @@ export function EventChecklistCard({ eventId, eventName, className }: EventCheck
   }, [loadChecklist])
 
   const handleToggle = useCallback(async (item: EventChecklistItem) => {
+    const pendingKey = `${eventId}:${item.key}`
+    if (pendingTasks.current.has(pendingKey)) return
+    pendingTasks.current.add(pendingKey)
+    setPendingTaskKeys(new Set(pendingTasks.current))
+
     const nextState = !item.completed
-    setPendingTaskKey(item.key)
-
-    let previousItems: EventChecklistItem[] | null = null
-    if (nextState) {
-      previousItems = items
-      const optimisticItems = items.map((existing) => {
-        if (existing.key !== item.key) return existing
-        const updated: EventChecklistItem = {
-          ...existing,
-          completed: true,
-          completedAt: new Date().toISOString(),
-          status: 'completed',
-        }
-        return updated
-      })
-      setItems(optimisticItems)
+    const today = getTodayIsoDate()
+    const updated: EventChecklistItem = {
+      ...item,
+      completed: nextState,
+      completedAt: nextState ? new Date().toISOString() : null,
+      status: nextState ? 'completed' : item.dueDate < today ? 'overdue' : item.dueDate === today ? 'due_today' : 'upcoming',
     }
+    const replaceItem = (replacement: EventChecklistItem) => {
+      setItems(current => current.map(existing =>
+        existing.eventId === eventId && existing.key === item.key ? replacement : existing
+      ))
+    }
+    replaceItem(updated)
 
-    const result = await toggleEventChecklistTask(eventId, item.key, nextState)
-    if (!result.success) {
-      toast.error(result.error || 'Failed to update task')
-      if (previousItems) {
-        setItems(previousItems)
+    try {
+      const result = await toggleEventChecklistTask(eventId, item.key, nextState)
+      if (!result.success) {
+        // Restore only this task so other saves in progress keep their state.
+        replaceItem(item)
+        toast.error(result.error || 'Failed to update task')
+      } else {
+        toast.success(nextState ? 'Task marked complete' : 'Task reopened')
       }
-    } else {
-      toast.success(nextState ? 'Task marked complete' : 'Task reopened')
-      await loadChecklist()
+    } catch {
+      replaceItem(item)
+      toast.error('Failed to update task')
+    } finally {
+      pendingTasks.current.delete(pendingKey)
+      setPendingTaskKeys(new Set(pendingTasks.current))
     }
-
-    setPendingTaskKey(null)
-  }, [eventId, items, loadChecklist])
+  }, [eventId])
 
   const { completedCount, overdueCount, dueTodayCount, nextTask } = useMemo(() => {
     if (!items || items.length === 0) {
@@ -189,7 +195,7 @@ export function EventChecklistCard({ eventId, eventName, className }: EventCheck
                 />
               ) : (
                 outstandingItems.map((item) => {
-                  const isPending = pendingTaskKey === item.key
+                  const isPending = pendingTaskKeys.has(`${eventId}:${item.key}`)
                   const dueColor = item.status === 'overdue'
                     ? 'text-red-600'
                     : item.status === 'due_today'
@@ -250,7 +256,7 @@ export function EventChecklistCard({ eventId, eventName, className }: EventCheck
                         size="xs"
                         variant="secondary"
                         onClick={() => handleToggle(item)}
-                        disabled={pendingTaskKey === item.key}
+                        disabled={pendingTaskKeys.has(`${eventId}:${item.key}`)}
                       >
                         Reopen
                       </Button>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,15 @@
+# Event checklist rapid completion, 6 September 2026
+
+- [x] Confirm the active event detail card reloads after each completion.
+- [x] Update only the changed task, with independent pending and rollback state.
+- [x] Verify overlapping saves, failures and reopening in six component tests and browser fixtures.
+- [x] Complete build gate: lint, typecheck, 734 test files (6,331 passed) and production build passed.
+- [ ] Merge, deploy and verify the production release.
+
+Browser evidence: five ticks produced four saved tasks and one isolated rollback; checklist reads stayed at one while other tasks remained usable.
+
+No database migration. Assumption: completing prep tasks refers to the event detail checklist. Other checklist views already update local state without explicitly reloading the checklist.
+
 # Friday manager report, 5 September 2026
 
 Detailed plan: [Friday manager report](./plan-2026-09-05-friday-manager-report.md).

--- a/tests/components/EventChecklistCard.test.tsx
+++ b/tests/components/EventChecklistCard.test.tsx
@@ -1,0 +1,172 @@
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EventChecklistItem } from '@/lib/event-checklist'
+import { getEventChecklist, toggleEventChecklistTask } from '@/app/actions/event-checklist'
+import { EventChecklistCard } from '@/components/features/events/EventChecklistCard'
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
+
+vi.mock('@/app/actions/event-checklist', () => ({
+  getEventChecklist: vi.fn(),
+  toggleEventChecklistTask: vi.fn(),
+}))
+
+vi.mock('@/ds', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/ds')>(),
+  toast,
+}))
+
+vi.mock('@/lib/dateUtils', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/lib/dateUtils')>(),
+  getTodayIsoDate: () => '2026-09-06',
+}))
+
+type ToggleResult = Awaited<ReturnType<typeof toggleEventChecklistTask>>
+
+function deferred() {
+  let resolve!: (value: ToggleResult) => void
+  let reject!: (reason: Error) => void
+  const promise = new Promise<ToggleResult>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function task(key: string, overrides: Partial<EventChecklistItem> = {}): EventChecklistItem {
+  return {
+    key,
+    label: key,
+    eventId: 'event-1',
+    offsetDays: -3,
+    channel: 'Admin',
+    required: true,
+    order: 0,
+    dueDate: '2026-09-06',
+    dueDateFormatted: '6 September 2026',
+    completed: false,
+    completedAt: null,
+    status: 'due_today',
+    ...overrides,
+  }
+}
+
+function completeCheckbox(label: string) {
+  return screen.getByRole('checkbox', { name: `Mark ${label} as complete` })
+}
+
+function reopenButton(label: string) {
+  const row = screen.getByText(label).closest('.justify-between')
+  if (!row) throw new Error(`No completed row for ${label}`)
+  return within(row as HTMLElement).getByRole('button', { name: 'Reopen' })
+}
+
+async function renderChecklist(items = [task('First task'), task('Second task', { order: 1 })]) {
+  vi.mocked(getEventChecklist).mockResolvedValue({ success: true, items })
+  render(<EventChecklistCard eventId="event-1" eventName="Quiz" />)
+  await screen.findByText(items[0].label)
+}
+
+describe('EventChecklistCard updates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(cleanup)
+
+  it('allows overlapping completions and keeps the checklist visible without refetching', async () => {
+    const first = deferred()
+    const second = deferred()
+    vi.mocked(toggleEventChecklistTask)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    await renderChecklist()
+
+    fireEvent.click(completeCheckbox('First task'))
+    expect(reopenButton('First task')).toBeDisabled()
+    expect(completeCheckbox('Second task')).toBeEnabled()
+    fireEvent.click(completeCheckbox('Second task'))
+    expect(reopenButton('First task')).toBeDisabled()
+    expect(reopenButton('Second task')).toBeDisabled()
+    expect(toggleEventChecklistTask).toHaveBeenNthCalledWith(1, 'event-1', 'First task', true)
+    expect(toggleEventChecklistTask).toHaveBeenNthCalledWith(2, 'event-1', 'Second task', true)
+
+    await act(async () => second.resolve({ success: true }))
+    expect(reopenButton('Second task')).toBeEnabled()
+    expect(reopenButton('First task')).toBeDisabled()
+    expect(screen.getByText('Outstanding Tasks')).toBeVisible()
+    await act(async () => first.resolve({ success: true }))
+
+    expect(reopenButton('First task')).toBeEnabled()
+    expect(screen.getByText('All caught up')).toBeVisible()
+    expect(getEventChecklist).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores only the failed task when another completion has succeeded', async () => {
+    const first = deferred()
+    const second = deferred()
+    vi.mocked(toggleEventChecklistTask)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+    await renderChecklist()
+
+    fireEvent.click(completeCheckbox('First task'))
+    fireEvent.click(completeCheckbox('Second task'))
+    await act(async () => second.resolve({ success: true }))
+    await act(async () => first.resolve({ success: false, error: 'Unable to save first task' }))
+
+    expect(completeCheckbox('First task')).toBeEnabled()
+    expect(completeCheckbox('First task')).not.toBeChecked()
+    expect(reopenButton('Second task')).toBeEnabled()
+    expect(toast.error).toHaveBeenCalledWith('Unable to save first task')
+    expect(getEventChecklist).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores a rejected update and lets the user retry', async () => {
+    const rejected = deferred()
+    vi.mocked(toggleEventChecklistTask)
+      .mockReturnValueOnce(rejected.promise)
+      .mockResolvedValueOnce({ success: true })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await renderChecklist()
+      fireEvent.click(completeCheckbox('First task'))
+      await act(async () => rejected.reject(new Error('Network interrupted')))
+
+      expect(toast.error).toHaveBeenCalled()
+      expect(completeCheckbox('First task')).toBeEnabled()
+      await act(async () => fireEvent.click(completeCheckbox('First task')))
+      expect(reopenButton('First task')).toBeEnabled()
+      expect(toggleEventChecklistTask).toHaveBeenCalledTimes(2)
+      expect(getEventChecklist).toHaveBeenCalledTimes(1)
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it.each([
+    ['2026-09-05', '1 day overdue (5 September 2026)', '5 September 2026'],
+    ['2026-09-06', 'Due today', '6 September 2026'],
+    ['2026-09-07', 'Due in 1 day (7 September 2026)', '7 September 2026'],
+  ])('reopens a task due on %s with its local due status', async (dueDate, dueDescription, dueDateFormatted) => {
+    const pending = deferred()
+    vi.mocked(toggleEventChecklistTask).mockReturnValueOnce(pending.promise)
+    await renderChecklist([task('Completed task', {
+      dueDate,
+      dueDateFormatted,
+      completed: true,
+      completedAt: '2026-09-05T12:00:00.000Z',
+      status: 'completed',
+    })])
+
+    fireEvent.click(reopenButton('Completed task'))
+    expect(completeCheckbox('Completed task')).toBeDisabled()
+    expect(screen.getByText(dueDescription)).toBeVisible()
+    await act(async () => pending.resolve({ success: true }))
+
+    expect(completeCheckbox('Completed task')).toBeEnabled()
+    expect(completeCheckbox('Completed task')).not.toBeChecked()
+    expect(toggleEventChecklistTask).toHaveBeenCalledWith('event-1', 'Completed task', false)
+    expect(getEventChecklist).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What changed
The event detail checklist now updates each task immediately without replacing the section with a loading spinner after every save. Staff can tick subsequent tasks while earlier saves complete. A failed save restores only its own task, and reopening updates immediately too.

## Testing done
Lint, typecheck, all 734 test files (6,331 passed, 2 existing skips), and production build passed. Six component regressions cover overlapping saves, isolated rollback, retry and reopened due states. Browser fixture using the real component confirmed five rapid ticks, four saves and one isolated rollback with only one checklist read. Live event detail page inspected read-only.

## Scope
Only EventChecklistCard, its regression test and task notes changed. Other checklist views already update local state; server permissions, persistence and cache invalidation are unchanged. Assumption: the reported reload is the event detail checklist. No migration.

## Complexity score
S

## Breaking changes
None

## Migration risk
None
