### PR TITLE
Artwork branding: logo shadow, BOOK NOW strip, smaller default QR, snap to centre

### DIFF
--- a/src/app/(authenticated)/events/_components/ArtworkBrandingModal.test.tsx
+++ b/src/app/(authenticated)/events/_components/ArtworkBrandingModal.test.tsx
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import {
   LOGO_DEFAULT_WIDTH_FRAC,
+  QR_DEFAULT_WIDTH_FRAC,
+  QR_STRIP_LABEL,
   logoRect,
   logoRectFree,
+  qrBlockRect,
+  qrCodeRectWithinCanvas,
   qrMinWidthFrac,
   qrMinWidthPx,
+  qrStripRect,
 } from '@/lib/events/artwork/geometry'
 import { EVENT_IMAGE_VARIANTS, type EventImageVariant } from '@/lib/events/imageVariants'
 
@@ -19,6 +24,49 @@ vi.mock('react-hot-toast', () => ({
 vi.mock('qrcode', () => {
   const toDataURL = vi.fn().mockResolvedValue('data:image/png;base64,QUJD')
   return { default: { toDataURL }, toDataURL }
+})
+
+/**
+ * dnd-kit is swapped for a fake that renders its children and hands the drag
+ * callbacks back to the test.
+ *
+ * Its `PointerSensor` needs real `PointerEvent`s and a laid-out document, and
+ * jsdom has neither, so driving the library here would test jsdom rather than
+ * this component. What is worth asserting is what the modal does with a drag:
+ * snap the axis, show the guide, and commit the position exactly once on drop.
+ */
+const dnd = vi.hoisted(() => ({
+  onDragMove: null as ((event: unknown) => void) | null,
+  onDragEnd: null as ((event: unknown) => void) | null,
+}))
+
+vi.mock('@dnd-kit/core', async () => {
+  const React = await import('react')
+  return {
+    DndContext: ({
+      children,
+      onDragMove,
+      onDragEnd,
+    }: {
+      children: React.ReactNode
+      onDragMove: (event: unknown) => void
+      onDragEnd: (event: unknown) => void
+    }) => {
+      dnd.onDragMove = onDragMove
+      dnd.onDragEnd = onDragEnd
+      return React.createElement(React.Fragment, null, children)
+    },
+    PointerSensor: class PointerSensorStub {},
+    useSensor: () => ({}),
+    useSensors: (...sensors: unknown[]) => sensors,
+    useDraggable: () => ({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: null,
+      isDragging: false,
+    }),
+  }
 })
 
 // Lightweight stand-ins for the design system so the test does not pull in the
@@ -99,6 +147,43 @@ function rectString(rect: { x: number; y: number; width: number; height: number 
   return `${rect.x},${rect.y},${rect.width},${rect.height}`
 }
 
+/** The preview the drag maths is done against. Any size works: the handler
+ *  converts pixels to fractions of it, so only the ratio matters. */
+const PREVIEW_W = 600
+const PREVIEW_H = 848
+
+function stubPreviewSize(): void {
+  const preview = screen.getByTestId('artwork-preview')
+  vi.spyOn(preview, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: PREVIEW_W,
+    bottom: PREVIEW_H,
+    width: PREVIEW_W,
+    height: PREVIEW_H,
+    toJSON: () => ({}),
+  } as DOMRect)
+}
+
+/** One drag, as fractions of the preview: a move and then a drop, which is the
+ *  order dnd-kit fires them in. */
+function drag(target: 'logo' | 'qr', dxFrac: number, dyFrac: number): void {
+  const event = {
+    active: { id: target },
+    delta: { x: dxFrac * PREVIEW_W, y: dyFrac * PREVIEW_H },
+  }
+  act(() => {
+    dnd.onDragMove?.(event)
+    dnd.onDragEnd?.(event)
+  })
+}
+
+function qrXPercent(): string {
+  return (screen.getByLabelText('QR X (%)') as HTMLInputElement).value
+}
+
 function renderModal(
   overrides: Partial<React.ComponentProps<typeof ArtworkBrandingModal>> = {}
 ) {
@@ -162,6 +247,10 @@ describe('ArtworkBrandingModal, logo placement', () => {
     renderModal()
 
     await user.click(screen.getByRole('radio', { name: 'Free' }))
+    // Away from the middle on purpose: the default free placement sits on the
+    // centre, which is a snap target, and this test is about the step size
+    // rather than about snapping. The snap behaviour has its own tests.
+    fireEvent.change(screen.getByLabelText('Logo X (%)'), { target: { value: '30' } })
     const overlay = screen.getByTestId('logo-overlay')
     const xField = screen.getByLabelText('Logo X (%)') as HTMLInputElement
 
@@ -248,10 +337,25 @@ describe('ArtworkBrandingModal, QR code', () => {
 
     fireEvent.change(slider, { target: { value: '5' } })
 
-    const [, , width] = (screen.getByTestId('qr-overlay').getAttribute('data-rect') ?? '')
+    // data-code-rect, not data-rect: the footprint that is dragged and outlined
+    // is the code plus its BOOK NOW strip, and the 40mm minimum is about the
+    // scannable square alone.
+    const [, , width] = (screen.getByTestId('qr-overlay').getAttribute('data-code-rect') ?? '')
       .split(',')
       .map(Number)
     expect(width).toBeGreaterThanOrEqual(qrMinWidthPx(POSTER_W))
+  })
+
+  it('starts a new QR at the shared default width', () => {
+    renderModal()
+
+    expect((screen.getByLabelText('QR size') as HTMLInputElement).value).toBe(
+      String(Math.round(QR_DEFAULT_WIDTH_FRAC * 100))
+    )
+    expect(screen.getByTestId('qr-overlay')).toHaveAttribute(
+      'data-code-rect',
+      rectString(qrCodeRectWithinCanvas(POSTER_W, POSTER_H, 0.5, 0.8, QR_DEFAULT_WIDTH_FRAC))
+    )
   })
 
   it('keeps every reachable QR width inside the bounds the route accepts', async () => {
@@ -298,6 +402,131 @@ describe('ArtworkBrandingModal, QR code', () => {
   })
 })
 
+describe('ArtworkBrandingModal, snapping to the centre', () => {
+  it('snaps a drag that lands near the centre onto it exactly, and shows the guide', () => {
+    renderModal()
+    stubPreviewSize()
+
+    // 40% across, set exactly, so the drag starts well clear of the centre.
+    fireEvent.change(screen.getByLabelText('QR X (%)'), { target: { value: '40' } })
+    expect(screen.queryByTestId('snap-guide-x')).toBeNull()
+
+    // Nine percent to the right lands on 49%, inside the two percent threshold.
+    drag('qr', 0.09, 0)
+
+    expect(qrXPercent()).toBe('50')
+    expect(screen.getByTestId('snap-guide-x')).toBeInTheDocument()
+    expect(screen.getByTestId('qr-overlay')).toHaveAttribute(
+      'data-code-rect',
+      rectString(qrCodeRectWithinCanvas(POSTER_W, POSTER_H, 0.5, 0.8, QR_DEFAULT_WIDTH_FRAC))
+    )
+    // The vertical position was never near the centre, so only one guide shows.
+    expect(screen.queryByTestId('snap-guide-y')).toBeNull()
+  })
+
+  it('lets the snap go once the drag carries on past the threshold', () => {
+    renderModal()
+    stubPreviewSize()
+
+    fireEvent.change(screen.getByLabelText('QR X (%)'), { target: { value: '40' } })
+    drag('qr', 0.09, 0)
+    expect(qrXPercent()).toBe('50')
+
+    drag('qr', 0.05, 0)
+
+    // 54, not 55: the pointer had really reached 49% when the snap showed 50%,
+    // so another five percent of travel lands on 54%. The snap moves what is
+    // stored and drawn, never where the next move is measured from, which is
+    // what stops it becoming a trap around the centre.
+    expect(qrXPercent()).toBe('54')
+    expect(screen.queryByTestId('snap-guide-x')).toBeNull()
+  })
+
+  it('snaps an arrow-key nudge the same way, so a keyboard gets the same help', () => {
+    renderModal()
+
+    fireEvent.change(screen.getByLabelText('QR X (%)'), { target: { value: '48' } })
+    expect(screen.queryByTestId('snap-guide-x')).toBeNull()
+
+    // One press is a single percent, which would land on 49 without snapping.
+    fireEvent.keyDown(screen.getByTestId('qr-overlay'), { key: 'ArrowRight' })
+
+    expect(qrXPercent()).toBe('50')
+    expect(screen.getByTestId('snap-guide-x')).toBeInTheDocument()
+  })
+
+  it('never snaps a typed position, because the field is the exact-entry route', () => {
+    renderModal()
+
+    fireEvent.change(screen.getByLabelText('QR X (%)'), { target: { value: '49' } })
+
+    expect(qrXPercent()).toBe('49')
+    expect(screen.queryByTestId('snap-guide-x')).toBeNull()
+    expect(screen.getByTestId('qr-overlay')).toHaveAttribute(
+      'data-code-rect',
+      rectString(qrCodeRectWithinCanvas(POSTER_W, POSTER_H, 0.49, 0.8, QR_DEFAULT_WIDTH_FRAC))
+    )
+  })
+
+  it('snaps the logo as well when it is placed freely', () => {
+    renderModal()
+    stubPreviewSize()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Free' }))
+    fireEvent.change(screen.getByLabelText('Logo X (%)'), { target: { value: '40' } })
+
+    drag('logo', 0.09, 0)
+
+    expect((screen.getByLabelText('Logo X (%)') as HTMLInputElement).value).toBe('50')
+    expect(screen.getByTestId('snap-guide-x')).toBeInTheDocument()
+  })
+})
+
+describe('ArtworkBrandingModal, what the preview shows', () => {
+  it('gives the preview logo the shadow the compositor will print', async () => {
+    const user = userEvent.setup()
+    renderModal()
+
+    // The shadow is always the opposite of the mark, which is what makes a
+    // white logo readable on pale artwork and a black one on dark artwork.
+    expect(screen.getByTestId('logo-preview-image').getAttribute('style')).toContain('rgba(0, 0, 0')
+
+    await user.click(screen.getByRole('radio', { name: 'Black logo' }))
+
+    expect(screen.getByTestId('logo-preview-image').getAttribute('style')).toContain(
+      'rgba(255, 255, 255'
+    )
+  })
+
+  it('draws the BOOK NOW strip beside the poster code', () => {
+    renderModal()
+
+    const strip = screen.getByTestId('qr-strip')
+    expect(strip).toHaveTextContent(QR_STRIP_LABEL)
+
+    // Laid out from the geometry module, so the strip sits where the compositor
+    // will actually print it rather than wherever a percentage guessed here
+    // happens to land.
+    const code = qrCodeRectWithinCanvas(POSTER_W, POSTER_H, 0.5, 0.8, QR_DEFAULT_WIDTH_FRAC)
+    const block = qrBlockRect(code)
+    const stripRect = qrStripRect(code)
+    expect(strip.style.left).toBe(`${((stripRect.x - block.x) / block.width) * 100}%`)
+    expect(strip.style.width).toBe(`${(stripRect.width / block.width) * 100}%`)
+
+    // The whole block is the drag footprint; the stored width still means the
+    // code, which is what the 40mm print minimum is measured against.
+    const overlay = screen.getByTestId('qr-overlay')
+    expect(overlay).toHaveAttribute('data-rect', rectString(block))
+    expect(overlay).toHaveAttribute('data-code-rect', rectString(code))
+  })
+
+  it('draws no strip on a variant that carries no QR code', () => {
+    renderModal({ variant: 'square', imageUrl: 'https://storage.test/square.png' })
+
+    expect(screen.queryByTestId('qr-strip')).toBeNull()
+  })
+})
+
 describe('ArtworkBrandingModal, saving', () => {
   it('posts exactly the documented body shape', async () => {
     const user = userEvent.setup()
@@ -318,7 +547,13 @@ describe('ArtworkBrandingModal, saving', () => {
       placement: { mode: 'corner', corner: 'bottom_right', widthFrac: LOGO_DEFAULT_WIDTH_FRAC },
       colour: 'white',
     })
-    expect(body.qr).toEqual({ centreXFrac: 0.5, centreYFrac: 0.8, widthFrac: 0.22 })
+    // Exactly three keys: the BOOK NOW strip is a rendering concern the server
+    // derives from the code, so nothing about it may appear in the payload.
+    expect(body.qr).toEqual({
+      centreXFrac: 0.5,
+      centreYFrac: 0.8,
+      widthFrac: QR_DEFAULT_WIDTH_FRAC,
+    })
     expect(body.action).toBeUndefined()
 
     await waitFor(() =>

--- a/src/app/(authenticated)/events/_components/ArtworkBrandingModal.tsx
+++ b/src/app/(authenticated)/events/_components/ArtworkBrandingModal.tsx
@@ -4,7 +4,7 @@
  * Places the venue logo, and on the A4 poster a booking QR code, onto artwork
  * that has already been uploaded for an event.
  *
- * Four decisions here that later edits must not undo:
+ * Five decisions here that later edits must not undo:
  *
  * 1. GEOMETRY IS NEVER RECOMPUTED. Every rectangle on screen comes from
  *    `src/lib/events/artwork/geometry.ts`, which the server compositor also
@@ -29,6 +29,12 @@
  *    route re-runs it server side and refuses the composite regardless. Do not
  *    remove the server check on the grounds that the button is disabled.
  *
+ * 5. SNAPPING IS A DRAG AND KEYBOARD AID, NOT A CONSTRAINT. `snapFrac` pulls a
+ *    move onto the exact centre when it lands close, draws a guide line while
+ *    it holds, and lets go the moment the move passes the threshold. The
+ *    numeric fields deliberately bypass it: they are the exact-entry escape
+ *    hatch, and silently turning a typed 49% into 50% would be a bug.
+ *
  * The surface is a full-screen dialog rather than a route or the DS Modal.
  * Navigating away from the event drawer would discard unsaved event edits, and
  * the DS Modal caps at 800px while an A4 preview 600px wide is about 848px
@@ -43,6 +49,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragMoveEvent,
 } from '@dnd-kit/core'
 import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
@@ -55,11 +62,18 @@ import {
   LOGO_DEFAULT_WIDTH_FRAC,
   LOGO_MAX_WIDTH_FRAC,
   LOGO_MIN_WIDTH_FRAC,
+  QR_DEFAULT_WIDTH_FRAC,
   QR_MIN_MM,
+  QR_STRIP_LABEL,
+  cssDropShadow,
   logoRectFree,
+  logoShadowSpec,
+  qrBlockRect,
+  qrCodeRectWithinCanvas,
   qrMinWidthFrac,
-  qrRect,
+  qrStripRect,
   resolveLogoRect,
+  snapFrac,
   validateQrPlacement,
   type Corner,
   type LogoPlacement,
@@ -78,7 +92,34 @@ type LogoMode = 'none' | 'corner' | 'free'
 const DEFAULT_CORNER: Corner = 'bottom_right'
 const DEFAULT_FREE_CENTRE = { x: 0.5, y: 0.85 }
 const DEFAULT_QR_CENTRE = { x: 0.5, y: 0.8 }
-const DEFAULT_QR_WIDTH_FRAC = 0.22
+
+/**
+ * Which axes are currently held on a snap target, and where.
+ *
+ * `x` and `y` carry the target fraction so the guide can be drawn exactly where
+ * the snap landed rather than assuming it was the centre.
+ */
+interface SnapAxes {
+  x: number | null
+  y: number | null
+}
+
+/** One shared "nothing is snapped" value, so clearing the guide twice does not
+ *  hand React a new object and force a pointless re-render. */
+const NO_SNAP: SnapAxes = { x: null, y: null }
+
+/**
+ * The preview width in CSS pixels assumed until the element has been measured.
+ *
+ * Only the drop shadow uses it, and only for a frame: a `ResizeObserver` takes
+ * over as soon as there is a layout. It matters because the shadow is computed
+ * from the DISPLAYED logo, so an unmeasured preview must not fall back to the
+ * full-resolution canvas and paint a shadow ten times too heavy.
+ */
+const NOMINAL_PREVIEW_WIDTH_PX = 600
+
+/** How much of the strip's displayed width the label glyphs take. */
+const QR_STRIP_FONT_FRAC = 0.6
 
 /**
  * The QR size controls work in whole percent, and these are their bounds.
@@ -162,6 +203,17 @@ function centreOf(rect: Rect, imageW: number, imageH: number): { x: number; y: n
   return { x: (rect.x + rect.width / 2) / imageW, y: (rect.y + rect.height / 2) / imageH }
 }
 
+/** A length as a CSS percentage of the box it is being placed inside. */
+function percentOf(length: number, total: number): string {
+  return `${(length / total) * 100}%`
+}
+
+/** Do two snap states describe the same thing? Used to hold object identity so
+ *  a pointer move that changes nothing does not re-render the editor. */
+function sameSnap(a: SnapAxes, b: SnapAxes): boolean {
+  return a.x === b.x && a.y === b.y
+}
+
 export function ArtworkBrandingModal({
   open,
   onClose,
@@ -200,28 +252,70 @@ export function ArtworkBrandingModal({
   const [corner, setCorner] = useState<Corner>(
     savedPlacement?.mode === 'corner' ? savedPlacement.corner : DEFAULT_CORNER
   )
-  const [logoCentre, setLogoCentre] = useState(
+  const initialLogoCentre =
     savedPlacement?.mode === 'free'
       ? { x: savedPlacement.centreXFrac, y: savedPlacement.centreYFrac }
       : DEFAULT_FREE_CENTRE
-  )
+  const [logoCentre, setLogoCentre] = useState(initialLogoCentre)
   const [logoWidthFrac, setLogoWidthFrac] = useState(
     savedPlacement?.widthFrac ?? LOGO_DEFAULT_WIDTH_FRAC
   )
   const [colour, setColour] = useState<LogoColour>(savedLogo?.colour ?? 'white')
 
   const [qrOn, setQrOn] = useState(isPoster && (branding ? savedQr !== null : true))
-  const [qrCentre, setQrCentre] = useState(
-    savedQr ? { x: savedQr.centreXFrac, y: savedQr.centreYFrac } : DEFAULT_QR_CENTRE
-  )
-  const [qrWidthFrac, setQrWidthFrac] = useState(savedQr?.widthFrac ?? DEFAULT_QR_WIDTH_FRAC)
+  const initialQrCentre = savedQr
+    ? { x: savedQr.centreXFrac, y: savedQr.centreYFrac }
+    : DEFAULT_QR_CENTRE
+  const [qrCentre, setQrCentre] = useState(initialQrCentre)
+  const [qrWidthFrac, setQrWidthFrac] = useState(savedQr?.widthFrac ?? QR_DEFAULT_WIDTH_FRAC)
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
 
   const [busy, setBusy] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
   const [confirmRevert, setConfirmRevert] = useState(false)
 
+  /**
+   * The guide belongs to whatever is being moved right now, which is why there
+   * is one of these and not one per overlay: moving the QR replaces the logo's
+   * guide, exactly as a manager expects when their attention has moved on.
+   */
+  const [snapGuide, setSnapGuide] = useState<SnapAxes>(NO_SNAP)
+
+  /**
+   * Where each item really is, before snapping rounded it off.
+   *
+   * Without this a snap becomes a trap: from dead centre, every 1% arrow press
+   * would land back inside the 2% threshold and be pulled straight back, so the
+   * logo could never be nudged off the middle at all. Moves accumulate against
+   * the true position and the snapped value is only what gets stored and drawn,
+   * which is how a second press escapes.
+   */
+  const rawCentreRef = useRef<Record<'logo' | 'qr', { x: number; y: number }>>({
+    logo: initialLogoCentre,
+    qr: initialQrCentre,
+  })
+
   const previewRef = useRef<HTMLDivElement | null>(null)
+  const [previewWidthPx, setPreviewWidthPx] = useState(NOMINAL_PREVIEW_WIDTH_PX)
+
+  /**
+   * Measure the preview so the drop shadow can be drawn at the size it is being
+   * looked at. The observer is optional: without one the nominal width above
+   * still gives a shadow of roughly the right weight, which beats none at all.
+   */
+  useEffect(() => {
+    const node = previewRef.current
+    if (!node) return
+    const measure = (): void => {
+      const width = node.getBoundingClientRect().width
+      if (width > 0) setPreviewWidthPx(width)
+    }
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [open])
 
   const sensors = useSensors(
     // A short distance threshold so a tap that was meant as a tap is still a tap.
@@ -244,21 +338,84 @@ export function ArtworkBrandingModal({
     [placement, imageW, imageH]
   )
 
-  const qrBox = useMemo(
+  /**
+   * The scannable square. `qr_width_frac` and the stored centre both describe
+   * THIS rect and nothing else, which is what keeps the 40mm print minimum and
+   * the database CHECK meaning what they say. `qrCodeRectWithinCanvas` shifts it
+   * back when the BOOK NOW strip beside it would otherwise hang off the edge.
+   */
+  const qrCodeBox = useMemo(
     () =>
-      isPoster && qrOn ? qrRect(imageW, imageH, qrCentre.x, qrCentre.y, qrWidthFrac) : null,
+      isPoster && qrOn
+        ? qrCodeRectWithinCanvas(imageW, imageH, qrCentre.x, qrCentre.y, qrWidthFrac)
+        : null,
     [isPoster, qrOn, imageW, imageH, qrCentre, qrWidthFrac]
   )
 
+  /** The strip, and the code plus strip: what actually lands on the artwork, and
+   *  therefore what is dragged and outlined. */
+  const qrStripBox = useMemo(() => (qrCodeBox ? qrStripRect(qrCodeBox) : null), [qrCodeBox])
+  const qrBlockBox = useMemo(() => (qrCodeBox ? qrBlockRect(qrCodeBox) : null), [qrCodeBox])
+
+  /** The label has to fit the strip at the size it is being looked at, so this
+   *  comes off the displayed width rather than the poster's pixels. */
+  const qrStripFontPx = qrStripBox
+    ? Math.max(5, Math.round((qrStripBox.width / imageW) * previewWidthPx * QR_STRIP_FONT_FRAC))
+    : 0
+
   const qrCheck = useMemo(
     () =>
-      qrBox
-        ? validateQrPlacement(imageW, imageH, qrBox, logoBox)
+      qrCodeBox
+        ? // The CODE goes in, not the block: the validator grows it into the
+          // block itself, and handing it a block would measure a block of a
+          // block and reject placements the compositor is happy with.
+          validateQrPlacement(imageW, imageH, qrCodeBox, logoBox)
         : ({ ok: true } as const),
-    [qrBox, imageW, imageH, logoBox]
+    [qrCodeBox, imageW, imageH, logoBox]
   )
 
-  const qrMillimetres = qrBox ? (qrBox.width * A4_WIDTH_MM) / imageW : 0
+  // Still the code, deliberately: the printed-size readout is about the thing a
+  // phone has to scan, and the strip is not part of that measurement.
+  const qrMillimetres = qrCodeBox ? (qrCodeBox.width * A4_WIDTH_MM) / imageW : 0
+
+  /**
+   * The composited logo carries a shadow in the opposite colour, so the preview
+   * has to as well or someone positions the mark against a picture that is not
+   * the file they get.
+   *
+   * The spec is computed from the DISPLAYED logo, not the full-resolution one.
+   * `logoShadowSpec` returns pixels as a fraction of the logo width, and on the
+   * 2480px poster that is an 87px blur: correct on the file, and absurd over a
+   * preview a quarter of the size. Scaling the rect first keeps the shadow the
+   * same relative weight on screen as it is on the artwork.
+   */
+  const logoShadowFilter = useMemo(() => {
+    if (!logoBox) return undefined
+    const scale = previewWidthPx / imageW
+    return cssDropShadow(
+      logoShadowSpec(
+        {
+          x: logoBox.x * scale,
+          y: logoBox.y * scale,
+          width: logoBox.width * scale,
+          height: logoBox.height * scale,
+        },
+        colour
+      )
+    )
+  }, [logoBox, previewWidthPx, imageW, colour])
+
+  /**
+   * Said once, when an axis catches, and cleared when it lets go. `snapGuide`
+   * only changes identity on a real transition, so a drag across the centre
+   * announces once instead of on every pointer move.
+   */
+  const snapMessage = useMemo(() => {
+    const axes: string[] = []
+    if (snapGuide.x !== null) axes.push('horizontal centre')
+    if (snapGuide.y !== null) axes.push('vertical centre')
+    return axes.length === 0 ? '' : `Snapped to the ${axes.join(' and ')}.`
+  }, [snapGuide])
 
   /**
    * Where the printed code will point. Derived from the event id, not the slug,
@@ -290,60 +447,141 @@ export function ArtworkBrandingModal({
     }
   }, [open, isPoster, qrOn, posterShortUrl])
 
-  const nudgeLogo = useCallback(
-    (dx: number, dy: number) => {
-      setLogoCentre((current) => {
-        // Settle against the geometry module's own clamped result first, so
-        // pressing left at the margin ten times does not bank ten presses that
-        // have to be undone before the logo moves right again.
-        const settled = centreOf(
-          logoRectFree(imageW, imageH, current.x, current.y, logoWidthFrac),
-          imageW,
-          imageH
-        )
-        return { x: clampFraction(settled.x + dx), y: clampFraction(settled.y + dy) }
-      })
+  /**
+   * Where a move lands, and which axes the snap caught.
+   *
+   * The current position is settled against the geometry module's own clamped
+   * rect first, so pressing left at the margin ten times does not bank ten
+   * presses that have to be undone before the item moves right again. Both the
+   * pointer drag and the arrow keys arrive here, which is exactly why keyboard
+   * users get the same snapping help as a mouse.
+   */
+  const resolveMove = useCallback(
+    (
+      target: 'logo' | 'qr',
+      dx: number,
+      dy: number
+    ): {
+      centre: { x: number; y: number }
+      raw: { x: number; y: number }
+      snap: SnapAxes
+    } => {
+      const current = rawCentreRef.current[target]
+      const settled = centreOf(
+        target === 'logo'
+          ? logoRectFree(imageW, imageH, current.x, current.y, logoWidthFrac)
+          : qrCodeRectWithinCanvas(imageW, imageH, current.x, current.y, qrWidthFrac),
+        imageW,
+        imageH
+      )
+      const raw = { x: clampFraction(settled.x + dx), y: clampFraction(settled.y + dy) }
+      const x = snapFrac(raw.x)
+      const y = snapFrac(raw.y)
+      return { centre: { x: x.value, y: y.value }, raw, snap: { x: x.snappedTo, y: y.snappedTo } }
     },
-    [imageW, imageH, logoWidthFrac]
+    [imageW, imageH, logoWidthFrac, qrWidthFrac]
   )
 
-  const nudgeQr = useCallback(
-    (dx: number, dy: number) => {
-      setQrCentre((current) => {
-        const settled = centreOf(
-          qrRect(imageW, imageH, current.x, current.y, qrWidthFrac),
-          imageW,
-          imageH
-        )
-        return { x: clampFraction(settled.x + dx), y: clampFraction(settled.y + dy) }
-      })
+  /** Hold the object identity when nothing changed, so a pointer move that is
+   *  still inside the same snap does not re-render the editor. */
+  const showSnap = useCallback((snap: SnapAxes): void => {
+    setSnapGuide((current) => (sameSnap(current, snap) ? current : snap))
+  }, [])
+
+  const nudge = useCallback(
+    (target: 'logo' | 'qr', dx: number, dy: number): void => {
+      const { centre, raw, snap } = resolveMove(target, dx, dy)
+      // Only a committed move updates the true position. A drag in progress
+      // must not, or the guide flickering past the centre would drag the
+      // starting point along with it.
+      rawCentreRef.current[target] = raw
+      if (target === 'logo') setLogoCentre(centre)
+      else setQrCentre(centre)
+      showSnap(snap)
     },
-    [imageW, imageH, qrWidthFrac]
+    [resolveMove, showSnap]
+  )
+
+  /**
+   * Set one axis to exactly what was typed, with no snapping at all.
+   *
+   * Deliberate, and the reason the true position is written here too: a typed
+   * 49% has to stay 49% and has to be where the next arrow press starts from.
+   */
+  const setExactCentre = useCallback(
+    (target: 'logo' | 'qr', axis: 'x' | 'y', value: number): void => {
+      const next = clampFraction(value)
+      rawCentreRef.current[target] = { ...rawCentreRef.current[target], [axis]: next }
+      const apply = target === 'logo' ? setLogoCentre : setQrCentre
+      apply((current) => ({ ...current, [axis]: next }))
+      setSnapGuide(NO_SNAP)
+    },
+    []
+  )
+
+  const nudgeLogo = useCallback((dx: number, dy: number): void => nudge('logo', dx, dy), [nudge])
+  const nudgeQr = useCallback((dx: number, dy: number): void => nudge('qr', dx, dy), [nudge])
+
+  const dragMove = useCallback(
+    (
+      event: DragEndEvent | DragMoveEvent
+    ): { target: 'logo' | 'qr'; dx: number; dy: number } | null => {
+      const id = event.active.id
+      if (id !== 'logo' && id !== 'qr') return null
+      const box = previewRef.current?.getBoundingClientRect()
+      // No measurable preview means no reliable conversion from pixels to
+      // fractions, so the drag is dropped rather than guessed at.
+      if (!box || box.width === 0 || box.height === 0) return null
+      return { target: id, dx: event.delta.x / box.width, dy: event.delta.y / box.height }
+    },
+    []
+  )
+
+  /**
+   * The guide follows the pointer, so the snap is visible before the button is
+   * released. Only the guide: the position itself is still committed once, on
+   * drop, exactly as decision 2 above requires.
+   */
+  const handleDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      const move = dragMove(event)
+      if (!move) return
+      showSnap(resolveMove(move.target, move.dx, move.dy).snap)
+    },
+    [dragMove, resolveMove, showSnap]
   )
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
-      const box = previewRef.current?.getBoundingClientRect()
-      // No measurable preview means no reliable conversion from pixels to
-      // fractions, so the drag is dropped rather than guessed at.
-      if (!box || box.width === 0 || box.height === 0) return
-      const dx = event.delta.x / box.width
-      const dy = event.delta.y / box.height
-      if (event.active.id === 'logo') nudgeLogo(dx, dy)
-      if (event.active.id === 'qr') nudgeQr(dx, dy)
+      const move = dragMove(event)
+      if (!move) return
+      nudge(move.target, move.dx, move.dy)
     },
-    [nudgeLogo, nudgeQr]
+    [dragMove, nudge]
   )
+
+  /**
+   * A cancelled drag (Escape, or a lost pointer) fires this instead of drag end,
+   * so the guide the pointer left behind has to go: nothing moved, and a line
+   * still sitting there would claim a snap that was never committed.
+   */
+  const handleDragCancel = useCallback((): void => {
+    setSnapGuide(NO_SNAP)
+  }, [])
 
   function resetLogoPlacement(): void {
     setCorner(DEFAULT_CORNER)
     setLogoCentre(DEFAULT_FREE_CENTRE)
+    rawCentreRef.current.logo = DEFAULT_FREE_CENTRE
     setLogoWidthFrac(LOGO_DEFAULT_WIDTH_FRAC)
+    setSnapGuide(NO_SNAP)
   }
 
   function resetQrPlacement(): void {
     setQrCentre(DEFAULT_QR_CENTRE)
-    setQrWidthFrac(DEFAULT_QR_WIDTH_FRAC)
+    rawCentreRef.current.qr = DEFAULT_QR_CENTRE
+    setQrWidthFrac(QR_DEFAULT_WIDTH_FRAC)
+    setSnapGuide(NO_SNAP)
   }
 
   async function post(body: Record<string, unknown>, successMessage: string): Promise<void> {
@@ -435,7 +673,12 @@ export function ArtworkBrandingModal({
           </div>
 
           <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-            <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+            <DndContext
+              sensors={sensors}
+              onDragMove={handleDragMove}
+              onDragEnd={handleDragEnd}
+              onDragCancel={handleDragCancel}
+            >
               <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-surface-2 p-4">
                 <div
                   ref={previewRef}
@@ -464,39 +707,99 @@ export function ArtworkBrandingModal({
                       <img
                         src={`/guest/anchor-logo-${colour}.png`}
                         alt=""
+                        data-testid="logo-preview-image"
                         className="pointer-events-none h-full w-full object-contain"
                         draggable={false}
+                        style={{ filter: logoShadowFilter }}
                       />
                     </PlacementOverlay>
                   )}
 
-                  {qrBox && (
+                  {qrBlockBox && qrCodeBox && qrStripBox && (
                     <PlacementOverlay
                       id="qr"
                       testId="qr-overlay"
                       label="QR code position"
-                      rect={qrBox}
+                      // The BLOCK is dragged and outlined, because the block is
+                      // what lands on the artwork. `codeRect` carries the code
+                      // on its own, which is what the stored width still means.
+                      rect={qrBlockBox}
+                      codeRect={qrCodeBox}
                       imageW={imageW}
                       imageH={imageH}
                       draggable
                       invalid={!qrCheck.ok}
                       onNudge={nudgeQr}
                     >
-                      {qrDataUrl && (
-                        <img
-                          src={qrDataUrl}
-                          alt=""
-                          className="pointer-events-none h-full w-full object-contain"
-                          draggable={false}
-                        />
-                      )}
-                      {/* The caption sits ON the code deliberately. It labels the
-                          preview as a guide and makes it unscannable, so nobody
-                          points a phone at a screen and books from a draft. */}
-                      <span className="pointer-events-none absolute inset-x-0 bottom-0 bg-text/75 px-1 py-0.5 text-center text-[10px] font-medium leading-tight text-surface">
-                        Guide only
+                      <span
+                        data-testid="qr-strip"
+                        className="pointer-events-none absolute top-0 flex items-center justify-center overflow-hidden font-semibold leading-none"
+                        style={{
+                          left: percentOf(qrStripBox.x - qrBlockBox.x, qrBlockBox.width),
+                          width: percentOf(qrStripBox.width, qrBlockBox.width),
+                          height: '100%',
+                          // Deliberately literal black and white rather than
+                          // design tokens: this is a picture of what the
+                          // compositor prints, and printing it in the app's
+                          // theme colours would make the preview a lie.
+                          backgroundColor: '#000000',
+                          color: '#ffffff',
+                          // vertical-rl plus a half turn reads bottom to top,
+                          // which is the convention for a spine label.
+                          writingMode: 'vertical-rl',
+                          transform: 'rotate(180deg)',
+                          fontSize: `${qrStripFontPx}px`,
+                          letterSpacing: '0.08em',
+                        }}
+                      >
+                        {QR_STRIP_LABEL}
+                      </span>
+
+                      <span
+                        className="pointer-events-none absolute top-0"
+                        style={{
+                          left: percentOf(qrCodeBox.x - qrBlockBox.x, qrBlockBox.width),
+                          width: percentOf(qrCodeBox.width, qrBlockBox.width),
+                          height: '100%',
+                        }}
+                      >
+                        {qrDataUrl && (
+                          <img
+                            src={qrDataUrl}
+                            alt=""
+                            className="pointer-events-none h-full w-full object-contain"
+                            draggable={false}
+                          />
+                        )}
+                        {/* The caption sits ON the code deliberately. It labels
+                            the preview as a guide and makes it unscannable, so
+                            nobody points a phone at a screen and books from a
+                            draft. */}
+                        <span className="pointer-events-none absolute inset-x-0 bottom-0 bg-text/75 px-1 py-0.5 text-center text-[10px] font-medium leading-tight text-surface">
+                          Guide only
+                        </span>
                       </span>
                     </PlacementOverlay>
+                  )}
+
+                  {/* The guides sit above the overlays so a snapped edge is
+                      still visible against the artwork, and are decorative:
+                      the polite region below says the same thing in words. */}
+                  {snapGuide.x !== null && (
+                    <div
+                      data-testid="snap-guide-x"
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-y-0 w-0.5 -translate-x-1/2 bg-primary ring-1 ring-surface/70"
+                      style={{ left: `${snapGuide.x * 100}%` }}
+                    />
+                  )}
+                  {snapGuide.y !== null && (
+                    <div
+                      data-testid="snap-guide-y"
+                      aria-hidden="true"
+                      className="pointer-events-none absolute inset-x-0 h-0.5 -translate-y-1/2 bg-primary ring-1 ring-surface/70"
+                      style={{ top: `${snapGuide.y * 100}%` }}
+                    />
                   )}
                 </div>
               </div>
@@ -550,6 +853,11 @@ export function ArtworkBrandingModal({
                       onChange={(next) => setLogoWidthFrac(next / 100)}
                     />
 
+                    {/* Typed positions are NOT snapped, on purpose. These fields
+                        are the exact-entry escape hatch from the snapping the
+                        drag and arrow keys apply, and quietly turning a typed
+                        49% into 50% would make the number on screen a lie.
+                        Setting one clears the guide for the same reason. */}
                     <div className="grid grid-cols-3 gap-2">
                       <NumberField
                         id={`${fieldId}-logo-x`}
@@ -559,9 +867,7 @@ export function ArtworkBrandingModal({
                         max={100}
                         value={toPercent(logoCentre.x)}
                         disabled={logoMode !== 'free'}
-                        onChange={(next) =>
-                          setLogoCentre((current) => ({ ...current, x: clampFraction(next / 100) }))
-                        }
+                        onChange={(next) => setExactCentre('logo', 'x', next / 100)}
                       />
                       <NumberField
                         id={`${fieldId}-logo-y`}
@@ -571,9 +877,7 @@ export function ArtworkBrandingModal({
                         max={100}
                         value={toPercent(logoCentre.y)}
                         disabled={logoMode !== 'free'}
-                        onChange={(next) =>
-                          setLogoCentre((current) => ({ ...current, y: clampFraction(next / 100) }))
-                        }
+                        onChange={(next) => setExactCentre('logo', 'y', next / 100)}
                       />
                       <NumberField
                         id={`${fieldId}-logo-width`}
@@ -627,6 +931,7 @@ export function ArtworkBrandingModal({
                         onChange={(next) => setQrWidthFrac(clampQrWidthPercent(next) / 100)}
                       />
 
+                      {/* Exact entry, so these are not snapped either. */}
                       <div className="grid grid-cols-3 gap-2">
                         <NumberField
                           id={`${fieldId}-qr-x`}
@@ -635,9 +940,7 @@ export function ArtworkBrandingModal({
                           min={0}
                           max={100}
                           value={toPercent(qrCentre.x)}
-                          onChange={(next) =>
-                            setQrCentre((current) => ({ ...current, x: clampFraction(next / 100) }))
-                          }
+                          onChange={(next) => setExactCentre('qr', 'x', next / 100)}
                         />
                         <NumberField
                           id={`${fieldId}-qr-y`}
@@ -646,9 +949,7 @@ export function ArtworkBrandingModal({
                           min={0}
                           max={100}
                           value={toPercent(qrCentre.y)}
-                          onChange={(next) =>
-                            setQrCentre((current) => ({ ...current, y: clampFraction(next / 100) }))
-                          }
+                          onChange={(next) => setExactCentre('qr', 'y', next / 100)}
                         />
                         <NumberField
                           id={`${fieldId}-qr-width`}
@@ -661,10 +962,10 @@ export function ArtworkBrandingModal({
                         />
                       </div>
 
-                      {qrBox && (
+                      {qrCodeBox && (
                         <p className="text-xs text-text-muted">
-                          Printed size: {qrBox.width} px, {qrMillimetres.toFixed(0)} mm on the A4
-                          poster.
+                          Printed size: {qrCodeBox.width} px, {qrMillimetres.toFixed(0)} mm on the
+                          A4 poster. The {QR_STRIP_LABEL} strip is printed beside it.
                         </p>
                       )}
 
@@ -682,6 +983,14 @@ export function ArtworkBrandingModal({
                   not talked over while someone is still moving things. */}
               <p role="status" aria-live="polite" className="min-h-[1.25rem] text-sm text-danger">
                 {qrCheck.ok ? '' : qrCheck.reason}
+              </p>
+
+              {/* The guide line is the sighted signal; this is the same news for
+                  anyone who cannot see it. It changes only when an axis catches
+                  or lets go, so a drag across the centre is announced once
+                  rather than on every pointer move. */}
+              <p role="status" aria-live="polite" className="sr-only">
+                {snapMessage}
               </p>
 
               {apiError && (
@@ -726,7 +1035,14 @@ interface PlacementOverlayProps {
   id: 'logo' | 'qr'
   testId: string
   label: string
+  /** The footprint: what is dragged, outlined and reported as `data-rect`. */
   rect: Rect
+  /**
+   * For the QR, the scannable square inside that footprint, published as
+   * `data-code-rect`. The stored width fraction still describes this rect and
+   * not the wider block, so the two are kept separately readable.
+   */
+  codeRect?: Rect
   imageW: number
   imageH: number
   draggable: boolean
@@ -747,6 +1063,7 @@ function PlacementOverlay({
   testId,
   label,
   rect,
+  codeRect,
   imageW,
   imageH,
   draggable,
@@ -780,6 +1097,11 @@ function PlacementOverlay({
       // The pixel rect the geometry module resolved, so a test can compare the
       // preview against the same function the server composites with.
       data-rect={`${rect.x},${rect.y},${rect.width},${rect.height}`}
+      data-code-rect={
+        codeRect
+          ? `${codeRect.x},${codeRect.y},${codeRect.width},${codeRect.height}`
+          : undefined
+      }
       aria-label={label}
       disabled={!draggable}
       {...listeners}

--- a/src/lib/events/artwork/branding-service.test.ts
+++ b/src/lib/events/artwork/branding-service.test.ts
@@ -21,9 +21,11 @@ import {
   logoRectFree,
   qrRect,
   insetPx,
+  logoShadowSpec,
   type Corner,
   type Rect,
 } from './geometry'
+import { logoShadowPaddingPx } from './composite'
 import type { CompositeResult, CompositeSpec, LogoColour } from './composite'
 import { EVENT_IMAGE_VARIANTS, type EventImageVariant } from '@/lib/events/imageVariants'
 
@@ -355,16 +357,33 @@ async function changedBounds(
   return { count, minX, minY, maxX, maxY }
 }
 
-/** Every changed pixel sits inside this rect, allowing for anti-aliased edges. */
+/**
+ * Every changed pixel sits inside this rect, allowing for anti-aliased edges
+ * AND for the logo's drop shadow.
+ *
+ * The logo now carries a shadow in the opposite colour, so the painted area is
+ * legitimately larger than `logoRect`. The blur pads the shape on all four
+ * sides by `logoShadowPaddingPx`, and the offset then pushes it down and right.
+ * So the extra room needed is `pad + offset` on the bottom and right, and only
+ * whatever the blur reaches beyond the offset on the top and left.
+ *
+ * Widened rather than dropped: the assertion still proves the logo landed where
+ * geometry said and that nothing else was painted, which is the whole point of
+ * it. `composite.test.ts` proves the mark itself is pixel exact by separating it
+ * from its shadow by colour.
+ */
 function expectWithin(
   bounds: { count: number; minX: number; minY: number; maxX: number; maxY: number },
   rect: Rect
 ): void {
+  const spec = logoShadowSpec(rect, 'white')
+  const pad = logoShadowPaddingPx(spec)
+
   expect(bounds.count).toBeGreaterThan(0)
-  expect(bounds.minX).toBeGreaterThanOrEqual(rect.x - 1)
-  expect(bounds.minY).toBeGreaterThanOrEqual(rect.y - 1)
-  expect(bounds.maxX).toBeLessThanOrEqual(rect.x + rect.width)
-  expect(bounds.maxY).toBeLessThanOrEqual(rect.y + rect.height)
+  expect(bounds.minX).toBeGreaterThanOrEqual(rect.x - 1 - Math.max(0, pad - spec.offsetXPx))
+  expect(bounds.minY).toBeGreaterThanOrEqual(rect.y - 1 - Math.max(0, pad - spec.offsetYPx))
+  expect(bounds.maxX).toBeLessThanOrEqual(rect.x + rect.width + pad + spec.offsetXPx + 1)
+  expect(bounds.maxY).toBeLessThanOrEqual(rect.y + rect.height + pad + spec.offsetYPx + 1)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/events/artwork/composite.test.ts
+++ b/src/lib/events/artwork/composite.test.ts
@@ -21,11 +21,25 @@ import {
   LOGO_SOURCES,
   compositeArtwork,
   loadLogoBuffer,
+  logoShadowPaddingPx,
+  qrStripSvg,
   renderQrAtWidth,
   type CompositeSpec,
   type LogoColour,
 } from './composite'
-import { logoRect, logoRectFree, qrRect, qrMinWidthPx, type Corner } from './geometry'
+import {
+  logoRect,
+  logoRectFree,
+  logoShadowSpec,
+  qrBlockRect,
+  qrCodeRectWithinCanvas,
+  qrMinWidthPx,
+  qrStripRect,
+  QR_STRIP_LABEL,
+  type Corner,
+  type Rect,
+} from './geometry'
+import { validateCompositeOutput } from './output'
 import { EVENT_IMAGE_VARIANTS } from '@/lib/events/imageVariants'
 
 const POSTER = EVENT_IMAGE_VARIANTS.print_poster
@@ -110,6 +124,69 @@ function meanBrightness(
   return seen === 0 ? 0 : total / seen
 }
 
+/**
+ * The bounding box of the MARK alone, told apart from its own drop shadow by
+ * colour rather than by position.
+ *
+ * The shadow is always the opposite of the mark, so over a mid grey background
+ * only the mark can make a pixel lighter than the grey when it is white, and
+ * only the mark can make one darker when it is black. That is what lets these
+ * tests still prove the logo lands exactly on the rect `geometry.ts` computed,
+ * which a plain changed-pixel box no longer can now that a blurred shadow spills
+ * past every edge of it.
+ */
+function markBounds(
+  image: RawImage,
+  colour: LogoColour
+): { count: number; minX: number; minY: number; maxX: number; maxY: number } {
+  let count = 0
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = -1
+  let maxY = -1
+
+  for (let y = 0; y < image.height; y += 1) {
+    for (let x = 0; x < image.width; x += 1) {
+      const [r, g, b] = pixelAt(image, x, y)
+      const mean = (r + g + b) / 3
+      const isMark = colour === 'white' ? mean > BACKGROUND.r : mean < BACKGROUND.r
+      if (!isMark) continue
+      count += 1
+      if (x < minX) minX = x
+      if (x > maxX) maxX = x
+      if (y < minY) minY = y
+      if (y > maxY) maxY = y
+    }
+  }
+
+  return { count, minX, minY, maxX, maxY }
+}
+
+/**
+ * How far outside its own rect the logo's shadow may legitimately paint, edge by
+ * edge.
+ *
+ * Taken from `logoShadowSpec` and the compositor's own padding rather than from
+ * numbers typed in here, so these bounds follow the shadow if it is ever
+ * retuned. The shadow is pushed down and right, so it reaches `pad + offset`
+ * that way and only `pad - offset` up and left. That asymmetry is asserted
+ * directly further down.
+ */
+function shadowReach(
+  logo: Rect,
+  colour: LogoColour
+): { left: number; top: number; right: number; bottom: number } {
+  const spec = logoShadowSpec(logo, colour)
+  const pad = logoShadowPaddingPx(spec)
+
+  return {
+    left: Math.max(0, pad - spec.offsetXPx),
+    top: Math.max(0, pad - spec.offsetYPx),
+    right: pad + spec.offsetXPx,
+    bottom: pad + spec.offsetYPx,
+  }
+}
+
 function unwrap(result: Awaited<ReturnType<typeof compositeArtwork>>): Buffer {
   if (!result.ok) {
     throw new Error(`Expected a composite, got ${result.failure.code}: ${result.failure.detail}`)
@@ -176,15 +253,21 @@ describe('compositeArtwork, logo placement', () => {
       cy,
       widthFrac
     )
-    const bounds = changedBounds(image)
+    // The mark itself, shadow excluded, fills exactly the rect geometry gave.
+    const mark = markBounds(image, 'white')
+    expect(mark.count).toBeGreaterThan(0)
+    expect(mark.minX).toBe(expected.x)
+    expect(mark.minY).toBe(expected.y)
+    expect(mark.maxX).toBe(expected.x + expected.width - 1)
+    expect(mark.maxY).toBe(expected.y + expected.height - 1)
 
-    expect(bounds.count).toBeGreaterThan(0)
-    expect(bounds.minX).toBeGreaterThanOrEqual(expected.x)
-    expect(bounds.minY).toBeGreaterThanOrEqual(expected.y)
-    expect(bounds.maxX).toBeLessThanOrEqual(expected.x + expected.width - 1)
-    expect(bounds.maxY).toBeLessThanOrEqual(expected.y + expected.height - 1)
-    expect(bounds.minX - expected.x).toBeLessThanOrEqual(2)
-    expect(bounds.minY - expected.y).toBeLessThanOrEqual(2)
+    // Everything painted, shadow included, stays inside the shadow's reach.
+    const reach = shadowReach(expected, 'white')
+    const bounds = changedBounds(image)
+    expect(bounds.minX).toBeGreaterThanOrEqual(expected.x - reach.left)
+    expect(bounds.minY).toBeGreaterThanOrEqual(expected.y - reach.top)
+    expect(bounds.maxX).toBeLessThanOrEqual(expected.x + expected.width - 1 + reach.right)
+    expect(bounds.maxY).toBeLessThanOrEqual(expected.y + expected.height - 1 + reach.bottom)
   })
 
   it('places a centred logo somewhere a corner never could', async () => {
@@ -222,23 +305,26 @@ describe('compositeArtwork, logo placement', () => {
 
     const image = await decode(buffer)
     const expected = logoRect(SQUARE.targetWidth, SQUARE.targetHeight, corner, widthFrac)
+
+    // The mark was drawn exactly on the rect geometry.ts specified, and filled
+    // it rather than landing as a speck inside it. The logo's own artwork
+    // reaches all four edges of its 934x421 canvas, so these are equalities.
+    // The shadow is excluded by colour, not by position, so this is still the
+    // placement proof it always was.
+    const mark = markBounds(image, 'white')
+    expect(mark.count).toBeGreaterThan(0)
+    expect(mark.minX).toBe(expected.x)
+    expect(mark.minY).toBe(expected.y)
+    expect(mark.maxX).toBe(expected.x + expected.width - 1)
+    expect(mark.maxY).toBe(expected.y + expected.height - 1)
+
+    // Nothing at all was painted beyond the shadow's own reach past that rect.
+    const reach = shadowReach(expected, 'white')
     const bounds = changedBounds(image)
-
-    expect(bounds.count).toBeGreaterThan(0)
-
-    // Nothing was drawn outside the rect geometry.ts specified.
-    expect(bounds.minX).toBeGreaterThanOrEqual(expected.x)
-    expect(bounds.minY).toBeGreaterThanOrEqual(expected.y)
-    expect(bounds.maxX).toBeLessThanOrEqual(expected.x + expected.width - 1)
-    expect(bounds.maxY).toBeLessThanOrEqual(expected.y + expected.height - 1)
-
-    // And it filled that rect rather than landing as a speck inside it. The
-    // logo's own artwork reaches all four edges of its 934x421 canvas, so the
-    // painted bounds should sit within a pixel or two of the rect's edges.
-    expect(bounds.minX - expected.x).toBeLessThanOrEqual(2)
-    expect(bounds.minY - expected.y).toBeLessThanOrEqual(2)
-    expect(expected.x + expected.width - 1 - bounds.maxX).toBeLessThanOrEqual(2)
-    expect(expected.y + expected.height - 1 - bounds.maxY).toBeLessThanOrEqual(2)
+    expect(bounds.minX).toBeGreaterThanOrEqual(expected.x - reach.left)
+    expect(bounds.minY).toBeGreaterThanOrEqual(expected.y - reach.top)
+    expect(bounds.maxX).toBeLessThanOrEqual(expected.x + expected.width - 1 + reach.right)
+    expect(bounds.maxY).toBeLessThanOrEqual(expected.y + expected.height - 1 + reach.bottom)
 
     // The other three corners are untouched: the inset margin at the opposite
     // corner is still exactly the background colour.
@@ -274,14 +360,21 @@ describe('compositeArtwork, logo placement', () => {
       )
     )
 
-    const narrowBounds = changedBounds(narrow)
-    const wideBounds = changedBounds(wide)
+    const narrowMark = markBounds(narrow, 'white')
+    const wideMark = markBounds(wide, 'white')
     const narrowExpected = logoRect(SQUARE.targetWidth, SQUARE.targetHeight, 'top_left', 0.12)
     const wideExpected = logoRect(SQUARE.targetWidth, SQUARE.targetHeight, 'top_left', 0.32)
 
-    expect(narrowBounds.maxX - narrowBounds.minX + 1).toBeLessThanOrEqual(narrowExpected.width)
-    expect(wideBounds.maxX - wideBounds.minX + 1).toBeLessThanOrEqual(wideExpected.width)
-    expect(wideBounds.maxX).toBeGreaterThan(narrowBounds.maxX)
+    // Measured on the mark, so the shadow cannot inflate either width.
+    expect(narrowMark.maxX - narrowMark.minX + 1).toBeLessThanOrEqual(narrowExpected.width)
+    expect(wideMark.maxX - wideMark.minX + 1).toBeLessThanOrEqual(wideExpected.width)
+    expect(wideMark.maxX).toBeGreaterThan(narrowMark.maxX)
+
+    // The shadow scales with the mark rather than staying a fixed size, so the
+    // wider logo also paints further past its own rect than the narrow one.
+    expect(shadowReach(wideExpected, 'white').right).toBeGreaterThan(
+      shadowReach(narrowExpected, 'white').right
+    )
   })
 
   it('produces visibly different output for the white and the black logo', async () => {
@@ -430,13 +523,13 @@ describe('compositeArtwork, QR code on the poster', () => {
     ...overrides,
   })
 
-  it('lands the QR where qrRect says, with its quiet zone plate intact', async () => {
+  it('lands the QR where the geometry says, with its quiet zone plate intact', async () => {
     const source = await createSource(POSTER.targetWidth, POSTER.targetHeight)
     const spec = posterSpec()
     const image = await decode(unwrap(await compositeArtwork(source, spec)))
 
     if (!spec.qr) throw new Error('unreachable')
-    const expected = qrRect(
+    const expected = qrCodeRectWithinCanvas(
       POSTER.targetWidth,
       POSTER.targetHeight,
       spec.qr.centreXFrac,
@@ -454,8 +547,10 @@ describe('compositeArtwork, QR code on the poster', () => {
       pixelAt(image, expected.x + expected.width - 1, expected.y + expected.height - 1)
     ).toEqual([255, 255, 255, 255])
 
-    // Just outside the rect is still untouched background, which pins the edge.
-    expect(pixelAt(image, expected.x - 1, expected.y - 1).slice(0, 3)).toEqual([
+    // Just above the rect is still untouched background, which pins the edge.
+    // Left of it is the BOOK NOW strip, not background, so the pin is taken
+    // from the row above the block rather than from the corner beside it.
+    expect(pixelAt(image, expected.x, expected.y - 1).slice(0, 3)).toEqual([
       BACKGROUND.r,
       BACKGROUND.g,
       BACKGROUND.b,
@@ -575,6 +670,387 @@ describe('compositeArtwork, output contract', () => {
   })
 })
 
+describe('compositeArtwork, the logo drop shadow', () => {
+  const CORNER: Corner = 'top_left'
+  const WIDTH_FRAC = 0.22
+  const RECT = logoRect(SQUARE.targetWidth, SQUARE.targetHeight, CORNER, WIDTH_FRAC)
+
+  async function shadowed(colour: LogoColour): Promise<RawImage> {
+    const source = await createSource(SQUARE.targetWidth, SQUARE.targetHeight)
+    return decode(
+      unwrap(
+        await compositeArtwork(source, {
+          variant: 'square',
+          logo: { placement: { mode: 'corner', corner: CORNER, widthFrac: WIDTH_FRAC }, colour },
+          qr: null,
+        })
+      )
+    )
+  }
+
+  /** Every painted pixel outside the logo's own rect, split by which way it moved. */
+  function outsideTheRect(
+    image: RawImage,
+    rect: Rect
+  ): { towardsShadow: number; awayFromShadow: number; strongest: number } {
+    let towardsShadow = 0
+    let awayFromShadow = 0
+    let strongest = 0
+
+    for (let y = 0; y < image.height; y += 1) {
+      for (let x = 0; x < image.width; x += 1) {
+        const inside =
+          x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height
+        if (inside) continue
+
+        const [r, g, b] = pixelAt(image, x, y)
+        const delta = (r + g + b) / 3 - BACKGROUND.r
+        if (delta === 0) continue
+        if (delta < 0) {
+          towardsShadow += 1
+        } else {
+          awayFromShadow += 1
+        }
+        strongest = Math.max(strongest, Math.abs(delta))
+      }
+    }
+
+    return { towardsShadow, awayFromShadow, strongest }
+  }
+
+  it('paints a BLACK shadow outside a white logo and a WHITE one outside a black logo', async () => {
+    // The logo overlay is exactly its own rect, so anything painted outside it
+    // is the shadow and nothing else. Over a mid grey background a black shadow
+    // can only darken and a white one can only lighten, so counting which way
+    // each pixel moved is a direct proof of the shadow's colour.
+    const white = outsideTheRect(await shadowed('white'), RECT)
+    expect(white.towardsShadow).toBeGreaterThan(0)
+    expect(white.awayFromShadow).toBe(0)
+    expect(white.strongest).toBeGreaterThan(4)
+
+    const black = await shadowed('black')
+    let lighter = 0
+    let darker = 0
+    for (let y = 0; y < black.height; y += 1) {
+      for (let x = 0; x < black.width; x += 1) {
+        const inside =
+          x >= RECT.x && x < RECT.x + RECT.width && y >= RECT.y && y < RECT.y + RECT.height
+        if (inside) continue
+        const [r, g, b] = pixelAt(black, x, y)
+        const delta = (r + g + b) / 3 - BACKGROUND.r
+        if (delta > 0) lighter += 1
+        if (delta < 0) darker += 1
+      }
+    }
+    expect(lighter).toBeGreaterThan(0)
+    expect(darker).toBe(0)
+  })
+
+  it('rescues a white logo on white artwork, which is the whole point of it', async () => {
+    const sharp = (await import('sharp')).default
+    const white = { r: 255, g: 255, b: 255, alpha: 1 }
+    const source = await sharp({
+      create: {
+        width: SQUARE.targetWidth,
+        height: SQUARE.targetHeight,
+        channels: 4,
+        background: white,
+      },
+    })
+      .png()
+      .toBuffer()
+
+    const image = await decode(
+      unwrap(
+        await compositeArtwork(source, {
+          variant: 'square',
+          logo: {
+            placement: { mode: 'corner', corner: CORNER, widthFrac: WIDTH_FRAC },
+            colour: 'white',
+          },
+          qr: null,
+        })
+      )
+    )
+
+    // Without a shadow a white logo on white artwork paints nothing a reader
+    // could see. Count how much of it is now visible, and how strongly.
+    let visible = 0
+    let strongest = 0
+    for (let y = 0; y < image.height; y += 1) {
+      for (let x = 0; x < image.width; x += 1) {
+        const [r] = pixelAt(image, x, y)
+        const delta = white.r - r
+        if (delta <= 0) continue
+        visible += 1
+        strongest = Math.max(strongest, delta)
+      }
+    }
+
+    expect(visible).toBeGreaterThan(RECT.width * RECT.height * 0.5)
+    expect(strongest).toBeGreaterThan(40)
+  })
+
+  it('offsets the shadow down and right, not up and left', async () => {
+    const image = await shadowed('white')
+    const bounds = changedBounds(image)
+
+    const overhangLeft = RECT.x - bounds.minX
+    const overhangTop = RECT.y - bounds.minY
+    const overhangRight = bounds.maxX - (RECT.x + RECT.width - 1)
+    const overhangBottom = bounds.maxY - (RECT.y + RECT.height - 1)
+
+    expect(overhangRight).toBeGreaterThan(overhangLeft)
+    expect(overhangBottom).toBeGreaterThan(overhangTop)
+    expect(overhangRight).toBeGreaterThan(0)
+    expect(overhangBottom).toBeGreaterThan(0)
+  })
+
+  it.each(['top_left', 'top_right', 'bottom_left', 'bottom_right'] as Corner[])(
+    'keeps a full width logo at %s inside the canvas, at the same size it started',
+    async (corner) => {
+      // The widest logo the geometry permits, in every corner, because branding
+      // must never resize the artwork whatever the shadow does at the edge.
+      const source = await createSource(SQUARE.targetWidth, SQUARE.targetHeight)
+
+      const buffer = unwrap(
+        await compositeArtwork(source, {
+          variant: 'square',
+          logo: { placement: { mode: 'corner', corner, widthFrac: 0.35 }, colour: 'white' },
+          qr: null,
+        })
+      )
+
+      const image = await decode(buffer)
+      expect(image.width).toBe(SQUARE.targetWidth)
+      expect(image.height).toBe(SQUARE.targetHeight)
+
+      const validation = await validateCompositeOutput(buffer, 'square', {
+        width: SQUARE.targetWidth,
+        height: SQUARE.targetHeight,
+      })
+      expect(validation.ok).toBe(true)
+
+      // Nothing escaped: the painted box is still inside the canvas.
+      const bounds = changedBounds(image)
+      expect(bounds.minX).toBeGreaterThanOrEqual(0)
+      expect(bounds.minY).toBeGreaterThanOrEqual(0)
+      expect(bounds.maxX).toBeLessThanOrEqual(SQUARE.targetWidth - 1)
+      expect(bounds.maxY).toBeLessThanOrEqual(SQUARE.targetHeight - 1)
+    }
+  )
+
+  it('cuts the shadow at the canvas edge instead of letting it off', async () => {
+    // The bottom right corner at the widest permitted logo is where the shadow
+    // genuinely overruns: its reach past the mark is larger than the inset
+    // margin left below and beside it. That is the case the clipping exists for,
+    // and this asserts it is really being exercised rather than assumed.
+    const rect = logoRect(SQUARE.targetWidth, SQUARE.targetHeight, 'bottom_right', 0.35)
+    const reach = shadowReach(rect, 'white')
+    expect(rect.x + rect.width - 1 + reach.right).toBeGreaterThan(SQUARE.targetWidth - 1)
+    expect(rect.y + rect.height - 1 + reach.bottom).toBeGreaterThan(SQUARE.targetHeight - 1)
+
+    const source = await createSource(SQUARE.targetWidth, SQUARE.targetHeight)
+    const buffer = unwrap(
+      await compositeArtwork(source, {
+        variant: 'square',
+        logo: {
+          placement: { mode: 'corner', corner: 'bottom_right', widthFrac: 0.35 },
+          colour: 'white',
+        },
+        qr: null,
+      })
+    )
+
+    const image = await decode(buffer)
+    expect(image.width).toBe(SQUARE.targetWidth)
+    expect(image.height).toBe(SQUARE.targetHeight)
+  })
+})
+
+describe('compositeArtwork, the BOOK NOW strip', () => {
+  const CENTRE_X = 0.5
+  const CENTRE_Y = 0.82
+  const WIDTH_FRAC = 0.25
+
+  const CODE = qrCodeRectWithinCanvas(
+    POSTER.targetWidth,
+    POSTER.targetHeight,
+    CENTRE_X,
+    CENTRE_Y,
+    WIDTH_FRAC
+  )
+  const STRIP = qrStripRect(CODE)
+
+  async function poster(
+    qr: CompositeSpec['qr'] = {
+      centreXFrac: CENTRE_X,
+      centreYFrac: CENTRE_Y,
+      widthFrac: WIDTH_FRAC,
+      url: BOOKING_URL,
+    }
+  ): Promise<RawImage> {
+    const source = await createSource(POSTER.targetWidth, POSTER.targetHeight)
+    return decode(
+      unwrap(
+        await compositeArtwork(source, {
+          variant: 'print_poster',
+          logo: {
+            placement: { mode: 'corner', corner: 'top_left', widthFrac: 0.22 },
+            colour: 'white',
+          },
+          qr,
+        })
+      )
+    )
+  }
+
+  it('leaves every module of the code untouched', async () => {
+    // The strongest possible statement of "the strip does not overlap the code":
+    // the composited code region is compared pixel for pixel against the code
+    // rendered on its own, with no strip anywhere near it. A strip that took out
+    // even one column of modules would show up here immediately.
+    const image = await poster()
+    const bare = await decode(await renderQrAtWidth(BOOKING_URL, CODE.width))
+
+    expect(bare.width).toBe(CODE.width)
+    expect(bare.height).toBe(CODE.height)
+
+    let differing = 0
+    for (let y = 0; y < CODE.height; y += 1) {
+      for (let x = 0; x < CODE.width; x += 1) {
+        const placed = pixelAt(image, CODE.x + x, CODE.y + y).slice(0, 3)
+        const alone = pixelAt(bare, x, y).slice(0, 3)
+        if (placed.join() !== alone.join()) differing += 1
+      }
+    }
+
+    expect(differing).toBe(0)
+  })
+
+  it('draws the strip beside the code, never over it', () => {
+    expect(STRIP.width).toBeGreaterThan(0)
+    expect(STRIP.height).toBe(CODE.height)
+    expect(STRIP.y).toBe(CODE.y)
+    // Left of the code, ending exactly where the code begins.
+    expect(STRIP.x + STRIP.width).toBe(CODE.x)
+  })
+
+  it('paints a black strip carrying light lettering', async () => {
+    const image = await poster()
+
+    let dark = 0
+    let light = 0
+    let lightMinX = Number.POSITIVE_INFINITY
+    let lightMinY = Number.POSITIVE_INFINITY
+    let lightMaxX = -1
+    let lightMaxY = -1
+
+    for (let y = STRIP.y; y < STRIP.y + STRIP.height; y += 1) {
+      for (let x = STRIP.x; x < STRIP.x + STRIP.width; x += 1) {
+        const [r, g, b] = pixelAt(image, x, y)
+        const mean = (r + g + b) / 3
+        if (mean < 40) dark += 1
+        if (mean > 200) {
+          light += 1
+          if (x < lightMinX) lightMinX = x
+          if (x > lightMaxX) lightMaxX = x
+          if (y < lightMinY) lightMinY = y
+          if (y > lightMaxY) lightMaxY = y
+        }
+      }
+    }
+
+    const area = STRIP.width * STRIP.height
+    // Mostly black plate, with real lettering on it. The glyphs cannot be read
+    // back, so this asserts coverage: enough light pixels to be a word rather
+    // than a stray mark, and far fewer of them than there is plate.
+    expect(dark / area).toBeGreaterThan(0.5)
+    expect(light / area).toBeGreaterThan(0.02)
+    expect(light).toBeLessThan(dark)
+
+    // And that lettering sits inside the strip rather than spilling over the
+    // code beside it.
+    expect(lightMinX).toBeGreaterThanOrEqual(STRIP.x)
+    expect(lightMaxX).toBeLessThan(STRIP.x + STRIP.width)
+    expect(lightMinY).toBeGreaterThanOrEqual(STRIP.y)
+    expect(lightMaxY).toBeLessThan(STRIP.y + STRIP.height)
+
+    // The label runs the long way down the strip, which is what tells a reader
+    // it belongs to the code beside it.
+    expect(lightMaxY - lightMinY).toBeGreaterThan(lightMaxX - lightMinX)
+  })
+
+  it('keeps the whole block on the canvas when the code is pushed hard against an edge', async () => {
+    // A centre fraction of 0 parks the code against the left margin. The strip
+    // sits on that side, so placing the code alone would hang it off the canvas.
+    const code = qrCodeRectWithinCanvas(POSTER.targetWidth, POSTER.targetHeight, 0, 0.5, 0.1905)
+    const block = qrBlockRect(code)
+
+    expect(block.x).toBeGreaterThanOrEqual(0)
+    expect(block.x + block.width).toBeLessThanOrEqual(POSTER.targetWidth)
+    expect(block.y).toBeGreaterThanOrEqual(0)
+    expect(block.y + block.height).toBeLessThanOrEqual(POSTER.targetHeight)
+
+    const image = await poster({
+      centreXFrac: 0,
+      centreYFrac: 0.5,
+      widthFrac: 0.1905,
+      url: BOOKING_URL,
+    })
+    expect(image.width).toBe(POSTER.targetWidth)
+    expect(image.height).toBe(POSTER.targetHeight)
+
+    // The strip really is drawn there, hard against the margin.
+    const strip = qrStripRect(code)
+    const middle = pixelAt(image, strip.x + Math.floor(strip.width / 2), strip.y + 4)
+    expect((middle[0] + middle[1] + middle[2]) / 3).toBeLessThan(40)
+  })
+
+  it('states its font family and takes its label from geometry.ts', () => {
+    const svg = qrStripSvg(STRIP).toString('utf8')
+
+    expect(svg).toContain(QR_STRIP_LABEL)
+    // A generic family, never a named face that may be absent on Vercel.
+    expect(svg).toContain('font-family="sans-serif"')
+    // Reads bottom to top, the usual convention for a vertical label.
+    expect(svg).toContain('rotate(-90')
+    // Sized to the rect geometry.ts computed, so the rasterised strip lands
+    // exactly where the block says it does.
+    expect(svg).toContain(`width="${STRIP.width}"`)
+    expect(svg).toContain(`height="${STRIP.height}"`)
+  })
+
+  it('rasterises the strip at exactly the rect size, with a legible label', async () => {
+    const sharp = (await import('sharp')).default
+    const rendered = await sharp(qrStripSvg(STRIP)).png().toBuffer()
+    const metadata = await sharp(rendered).metadata()
+
+    expect(metadata.width).toBe(STRIP.width)
+    expect(metadata.height).toBe(STRIP.height)
+
+    // At the 40mm print minimum on A4 the strip is narrower than this one, so
+    // check the label is still worth printing there too.
+    const smallest = qrStripRect({
+      x: 0,
+      y: 0,
+      width: qrMinWidthPx(POSTER.targetWidth),
+      height: qrMinWidthPx(POSTER.targetWidth),
+    })
+    const small = await sharp(qrStripSvg(smallest)).png().toBuffer()
+    const image = await decode(small)
+
+    let light = 0
+    for (let y = 0; y < image.height; y += 1) {
+      for (let x = 0; x < image.width; x += 1) {
+        const [r, g, b] = pixelAt(image, x, y)
+        if ((r + g + b) / 3 > 200) light += 1
+      }
+    }
+    expect(light / (image.width * image.height)).toBeGreaterThan(0.02)
+  })
+})
+
 describe('composite.ts implementation guarantees', () => {
   let sourceText = ''
 
@@ -599,8 +1075,21 @@ describe('composite.ts implementation guarantees', () => {
     expect(sourceText).toMatch(/from '\.\/geometry'/)
     // Either the direct corner helper or the union resolver; both live in geometry.ts.
     expect(sourceText).toMatch(/\b(logoRect|resolveLogoRect)\(/)
-    expect(sourceText).toContain('qrRect(')
+    // The block-aware placement, not the bare code rect: the strip has to fit
+    // on the canvas too.
+    expect(sourceText).toContain('qrCodeRectWithinCanvas(')
+    expect(sourceText).toContain('qrStripRect(')
+    expect(sourceText).toContain('logoShadowSpec(')
     expect(sourceText).toContain('validateQrPlacement(')
+
+    // The shadow measurements and the strip's label belong to geometry.ts and
+    // are imported, never retyped here. The preview reads the same numbers, and
+    // two copies would drift within a release.
+    expect(sourceText).toContain('QR_STRIP_LABEL')
+    expect(sourceText).not.toContain("'BOOK NOW'")
+    expect(sourceText).not.toContain('0.025')
+    expect(sourceText).not.toContain('0.035')
+    expect(sourceText).not.toContain('0.22')
 
     // The numbers geometry.ts owns must not appear here at all: the inset
     // fraction, the logo aspect ratio, the 40mm minimum and the A4 width.

--- a/src/lib/events/artwork/composite.ts
+++ b/src/lib/events/artwork/composite.ts
@@ -32,7 +32,16 @@
  *
  * 4. The QR code is rasterised straight at its final pixel width and its white
  *    quiet zone is left alone. Both are scanning requirements, explained at
- *    `renderQrAtWidth` below.
+ *    `renderQrAtWidth` below. Its BOOK NOW strip is drawn ALONGSIDE the code and
+ *    never over it: error correction H would survive some occlusion, but a strip
+ *    down one side takes out a whole column of modules, which is far worse for a
+ *    scanner than the centred marks that occlusion budget usually pays for.
+ *
+ * 5. The logo carries a drop shadow in the OPPOSITE colour, because a white mark
+ *    disappears on pale artwork and a black one disappears on dark artwork. The
+ *    shadow is the logo's own shape taken from its alpha channel, never a
+ *    rectangle, and it is clipped to the canvas so branding cannot change the
+ *    image's size.
  *
  * Output is always PNG, lossless, because these images are re-encoded again
  * downstream (storage, the poster PDF, social crops) and stacking lossy passes
@@ -48,12 +57,14 @@ import { QR_OPTIONS } from '@/lib/export/qr-pack'
 import type { EventImageVariant } from '@/lib/events/imageVariants'
 import { PRINT_POSTER_DENSITY_DPI } from './output'
 import {
-  logoRect,
   resolveLogoRect,
   type LogoPlacement,
-  qrRect,
+  logoShadowSpec,
+  type LogoShadowSpec,
+  qrCodeRectWithinCanvas,
+  qrStripRect,
   validateQrPlacement,
-  type Corner,
+  QR_STRIP_LABEL,
   type Rect,
 } from './geometry'
 
@@ -127,6 +138,239 @@ interface Overlay {
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * How far past the silhouette the shadow's own canvas is padded, in Gaussian
+ * sigmas. Three is where the tail is under half a percent of the peak, so the
+ * blur falls away inside its own frame. Without the padding the Gaussian is cut
+ * off at the silhouette's edge and the shadow ends in a hard line, which is the
+ * one thing a shadow must not do.
+ */
+const SHADOW_BLUR_SIGMAS = 3
+
+/** Fully transparent, used to pad the shadow's frame. */
+const TRANSPARENT = { r: 0, g: 0, b: 0, alpha: 0 }
+
+/**
+ * The BOOK NOW strip, in plain black and white on purpose.
+ *
+ * The design briefs have not supplied a brand colour for this, and flat white on
+ * flat black is what survives a photocopier, a cheap poster print and a phone
+ * camera in a dim corridor. Nothing here is decorative.
+ */
+const QR_STRIP_BACKGROUND = '#000000'
+const QR_STRIP_INK = '#ffffff'
+
+/**
+ * The font family written into the strip's SVG.
+ *
+ * A generic family, not a named face. Vercel's runtime carries a different set
+ * of fonts from a developer laptop, and naming a face that is absent there would
+ * silently fall back to something with different metrics, which is exactly the
+ * drift the strip sizing below is built to avoid.
+ */
+const QR_STRIP_FONT_STACK = 'sans-serif'
+
+/**
+ * Text size as a fraction of the strip WIDTH, which is the strip's short edge
+ * and therefore what the rotated label's height has to fit inside.
+ *
+ * 0.55 leaves the label at roughly two thirds of the strip's length in the
+ * fonts we have measured, so a fallback face up to about a third wider still
+ * fits without touching the ends. At the 40mm print minimum on A4 the strip is
+ * 104px wide and this gives a 57px label, which is comfortably legible.
+ */
+const QR_STRIP_FONT_FRAC_OF_STRIP_WIDTH = 0.55
+
+/** Letter spacing as a fraction of the font size. Enough to read as a label. */
+const QR_STRIP_TRACKING_FRAC_OF_FONT = 0.06
+
+/**
+ * How far below the strip's centre line the text baseline sits, as a fraction of
+ * the font size, so the label is optically centred across the strip.
+ *
+ * Roughly half a capital's height. `dominant-baseline` would say this more
+ * directly but is not honoured by every SVG rasteriser, and a label that drifts
+ * to one edge on the server while looking centred locally is worse than an
+ * approximation that both agree on.
+ */
+const QR_STRIP_BASELINE_FRAC_OF_FONT = 0.35
+
+/** Below this the label is not worth drawing at all. */
+const QR_STRIP_MIN_FONT_PX = 8
+
+/**
+ * How far the shadow's own frame is padded beyond the logo rectangle, in pixels.
+ *
+ * Exported so a test can work out how far outside the logo rect the shadow may
+ * legitimately paint without hard coding `SHADOW_BLUR_SIGMAS` in two places.
+ * Combined with the spec's offset it gives the reach on each edge: `pad +
+ * offset` down and right, `pad - offset` up and left.
+ */
+export function logoShadowPaddingPx(spec: LogoShadowSpec): number {
+  return Math.max(1, Math.round(spec.blurPx * SHADOW_BLUR_SIGMAS))
+}
+
+/** A rectangle cut down to what actually lands on the canvas. */
+interface ClippedOverlay {
+  /** Where the visible part goes on the canvas. */
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Where that visible part starts inside the overlay itself. */
+  sourceX: number
+  sourceY: number
+}
+
+/**
+ * Cut an overlay rectangle down to the part that lands on the canvas.
+ *
+ * A blurred shadow beside a logo in a corner reaches past the canvas edge by
+ * design. sharp does trim an overhanging overlay itself, but it refuses one
+ * larger than the base image outright, and neither behaviour is worth leaning on
+ * for something whose failure mode is a resized poster. Cutting the overlay here
+ * keeps the output the same size as the input, which `validateCompositeOutput`
+ * asserts and a printed poster would reveal.
+ *
+ * Returns null when nothing of the rectangle is on the canvas.
+ */
+function clipToCanvas(
+  rect: Rect,
+  canvas: { width: number; height: number }
+): ClippedOverlay | null {
+  const x = Math.max(rect.x, 0)
+  const y = Math.max(rect.y, 0)
+  const right = Math.min(rect.x + rect.width, canvas.width)
+  const bottom = Math.min(rect.y + rect.height, canvas.height)
+
+  if (right <= x || bottom <= y) return null
+
+  return {
+    x,
+    y,
+    width: right - x,
+    height: bottom - y,
+    sourceX: x - rect.x,
+    sourceY: y - rect.y,
+  }
+}
+
+/**
+ * The logo's drop shadow as a ready-to-composite overlay, or null when it falls
+ * entirely off the canvas.
+ *
+ * Built in four steps, none of them optional:
+ *
+ * 1. The logo is resized to its final rectangle and padded with transparency so
+ *    the blur has room to fall away (see `SHADOW_BLUR_SIGMAS`).
+ * 2. Its ALPHA channel becomes the mask. That is what makes the shadow the
+ *    logo's shape rather than a rectangle over the artwork.
+ * 3. That mask is faded to the spec's opacity, then joined as the alpha channel
+ *    of a flat plate in the shadow colour.
+ * 4. The result is offset and clipped to the canvas.
+ *
+ * Each of those is its own sharp call rather than one chained pipeline, and both
+ * PNG round trips are load bearing. sharp flags a freshly extracted alpha band
+ * as premultiplied and then silently ignores tone operations applied to it, so
+ * fading the mask in that state is a no-op and the shadow comes out fully
+ * opaque; re-encoding clears the flag. Chaining also reorders operations into
+ * sharp's own fixed pipeline order rather than the order they are written in,
+ * which is how an earlier attempt ended up compositing a four band overlay onto
+ * a three band plate and failing with `images do not have same numbers of
+ * bands`.
+ *
+ * `spec.blurPx` is a Gaussian sigma, which is what `.blur()` takes directly.
+ */
+async function renderLogoShadow(
+  logoBuffer: Buffer,
+  logo: Rect,
+  spec: LogoShadowSpec,
+  canvas: { width: number; height: number }
+): Promise<Overlay | null> {
+  const sharp = (await import('sharp')).default
+
+  const pad = logoShadowPaddingPx(spec)
+  const width = logo.width + pad * 2
+  const height = logo.height + pad * 2
+
+  const padded = await sharp(logoBuffer)
+    .resize(logo.width, logo.height, { fit: 'fill', kernel: 'lanczos3' })
+    .ensureAlpha()
+    .extend({ top: pad, bottom: pad, left: pad, right: pad, background: TRANSPARENT })
+    .png()
+    .toBuffer()
+
+  const mask = await sharp(padded).extractChannel('alpha').png().toBuffer()
+  const blurred = await sharp(mask).blur(spec.blurPx).png().toBuffer()
+  const faded = await sharp(blurred).linear(spec.opacity, 0).raw().toBuffer()
+
+  const shadow = await sharp({
+    create: { width, height, channels: 3, background: spec.colour },
+  })
+    .joinChannel(faded, { raw: { width, height, channels: 1 } })
+    .png()
+    .toBuffer()
+
+  const clipped = clipToCanvas(
+    {
+      x: logo.x - pad + spec.offsetXPx,
+      y: logo.y - pad + spec.offsetYPx,
+      width,
+      height,
+    },
+    canvas
+  )
+  if (!clipped) return null
+
+  const input = await sharp(shadow)
+    .extract({
+      left: clipped.sourceX,
+      top: clipped.sourceY,
+      width: clipped.width,
+      height: clipped.height,
+    })
+    .png()
+    .toBuffer()
+
+  return { input, left: clipped.x, top: clipped.y }
+}
+
+/**
+ * The BOOK NOW strip as an SVG, sized to the rectangle `qrStripRect` returned.
+ *
+ * The label runs vertically and reads bottom to top, the usual convention for a
+ * vertical label, which is what `rotate(-90)` about the strip's centre gives.
+ * Exported so a test can rasterise it on its own rather than only ever seeing it
+ * through a full composite.
+ *
+ * `QR_STRIP_LABEL` is plain capitals with a single space, so there is nothing
+ * here to escape for XML. Anything else would need escaping before it went into
+ * the markup.
+ */
+export function qrStripSvg(strip: Rect): Buffer {
+  const fontSize = Math.max(
+    QR_STRIP_MIN_FONT_PX,
+    Math.round(strip.width * QR_STRIP_FONT_FRAC_OF_STRIP_WIDTH)
+  )
+  const tracking = Math.max(1, Math.round(fontSize * QR_STRIP_TRACKING_FRAC_OF_FONT))
+  const centreX = strip.width / 2
+  const centreY = strip.height / 2
+  const baselineY = centreY + Math.round(fontSize * QR_STRIP_BASELINE_FRAC_OF_FONT)
+
+  return Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${strip.width}" height="${strip.height}" ` +
+      `viewBox="0 0 ${strip.width} ${strip.height}">` +
+      `<rect x="0" y="0" width="${strip.width}" height="${strip.height}" fill="${QR_STRIP_BACKGROUND}"/>` +
+      `<g transform="rotate(-90 ${centreX} ${centreY})">` +
+      `<text x="${centreX}" y="${baselineY}" fill="${QR_STRIP_INK}" ` +
+      `font-family="${QR_STRIP_FONT_STACK}" font-size="${fontSize}" font-weight="700" ` +
+      `letter-spacing="${tracking}" text-anchor="middle">${QR_STRIP_LABEL}</text>` +
+      `</g>` +
+      `</svg>`,
+    'utf8'
+  )
 }
 
 /**
@@ -240,8 +484,17 @@ export async function compositeArtwork(
     ? resolveLogoRect(imageW, imageH, spec.logo.placement)
     : null
 
+  // `qrCodeRectWithinCanvas`, not `qrRect`: the code is only half of what gets
+  // drawn, and a code pushed hard against an edge would otherwise hang its BOOK
+  // NOW strip off the canvas. `validateQrPlacement` checks the whole block too.
   const qrPlacement: Rect | null = spec.qr
-    ? qrRect(imageW, imageH, spec.qr.centreXFrac, spec.qr.centreYFrac, spec.qr.widthFrac)
+    ? qrCodeRectWithinCanvas(
+        imageW,
+        imageH,
+        spec.qr.centreXFrac,
+        spec.qr.centreYFrac,
+        spec.qr.widthFrac
+      )
     : null
 
   if (qrPlacement) {
@@ -305,6 +558,17 @@ export async function compositeArtwork(
         .png()
         .toBuffer()
 
+      // The shadow goes on first so the mark sits over it, and its colour is the
+      // opposite of the mark's: that contrast is the only reason a white logo
+      // survives pale artwork and a black one survives dark artwork.
+      const shadow = await renderLogoShadow(
+        logoBuffer,
+        logoPlacement,
+        logoShadowSpec(logoPlacement, spec.logo.colour),
+        { width: imageW, height: imageH }
+      )
+      if (shadow) overlays.push(shadow)
+
       overlays.push({ input: resized, left: logoPlacement.x, top: logoPlacement.y })
     } catch (error) {
       return {
@@ -320,6 +584,17 @@ export async function compositeArtwork(
   if (spec.qr && qrPlacement) {
     try {
       const qrBuffer = await renderQrAtWidth(spec.qr.url, qrPlacement.width)
+
+      // A bare code tells nobody what it is for. The strip is placed by
+      // `qrStripRect`, which puts it beside the code and never over it, and
+      // `validateQrPlacement` has already confirmed the pair fits on the canvas,
+      // so there is nothing here to clip. It shares the QR's catch on purpose:
+      // if the SVG cannot be rasterised the whole composite fails visibly rather
+      // than quietly shipping a code with no label on it.
+      const strip = qrStripRect(qrPlacement)
+      const stripBuffer = await sharp(qrStripSvg(strip)).png().toBuffer()
+
+      overlays.push({ input: stripBuffer, left: strip.x, top: strip.y })
       overlays.push({ input: qrBuffer, left: qrPlacement.x, top: qrPlacement.y })
     } catch (error) {
       return {

--- a/src/lib/events/artwork/geometry.test.ts
+++ b/src/lib/events/artwork/geometry.test.ts
@@ -23,6 +23,14 @@ import {
   resolveLogoRect,
   QR_MIN_WIDTH_FRAC,
   QR_MIN_WIDTH_FRAC_EXACT,
+  shadowColourFor,
+  logoShadowSpec,
+  cssDropShadow,
+  qrStripRect,
+  qrBlockRect,
+  qrCodeRectWithinCanvas,
+  snapFrac,
+  SNAP_THRESHOLD_FRAC,
 } from './geometry'
 import { EVENT_IMAGE_VARIANTS, EVENT_IMAGE_VARIANT_ORDER } from '@/lib/events/imageVariants'
 import {
@@ -394,7 +402,15 @@ describe('validateQrPlacement', () => {
     const side = qrMinWidthPx(posterW)
     // Sat just below the reservation, inside the gap, so it does not intersect
     // the logo itself but is still too close to it.
-    const qr: Rect = { x: reserved.x, y: reserved.y + reserved.height + Math.floor(gap / 2), width: side, height: side }
+    // Shifted right by the strip width so the whole BLOCK stays on the canvas.
+    // Without that the bounds check fires first and this stops testing the gap.
+    const stripWidth = qrStripRect({ x: 0, y: 0, width: side, height: side }).width
+    const qr: Rect = {
+      x: reserved.x + insetPx(posterW, posterH) + stripWidth,
+      y: reserved.y + reserved.height + Math.floor(gap / 2),
+      width: side,
+      height: side,
+    }
     expect(rectsOverlap(qr, logo, 0)).toBe(false)
     const result = validateQrPlacement(posterW, posterH, qr, logo)
     expect(result.ok).toBe(false)
@@ -547,5 +563,105 @@ describe('the QR minimum width floor agrees everywhere it is written down', () =
     const mm = (widthPx / 2480) * 210
     expect(mm).toBeGreaterThanOrEqual(40)
     expect(widthPx).toBeGreaterThanOrEqual(qrMinWidthPx(2480))
+  })
+})
+
+describe('logo drop shadow', () => {
+  it('shadows a white logo in black and a black logo in white', () => {
+    expect(shadowColourFor('white')).toBe('#000000')
+    expect(shadowColourFor('black')).toBe('#ffffff')
+  })
+
+  it('scales with the logo, not the canvas', () => {
+    const small = logoShadowSpec(logoRect(1080, 1080, 'top_left', 0.08), 'white')
+    const large = logoShadowSpec(logoRect(2480, 3508, 'top_left', 0.35), 'white')
+    expect(large.offsetXPx).toBeGreaterThan(small.offsetXPx)
+    expect(large.blurPx).toBeGreaterThan(small.blurPx)
+  })
+
+  it('never collapses to a zero offset or blur on a tiny logo', () => {
+    const spec = logoShadowSpec({ x: 0, y: 0, width: 10, height: 5 }, 'black')
+    expect(spec.offsetXPx).toBeGreaterThanOrEqual(1)
+    expect(spec.blurPx).toBeGreaterThanOrEqual(1)
+  })
+
+  it('renders a CSS filter that doubles the sigma for the blur radius', () => {
+    const spec = logoShadowSpec(logoRect(1920, 1080, 'top_left', 0.22), 'white')
+    const css = cssDropShadow(spec)
+    expect(css).toContain(`${spec.blurPx * 2}px`)
+    expect(css).toContain('rgba(0, 0, 0,')
+    expect(cssDropShadow(logoShadowSpec(logoRect(1920, 1080, 'top_left', 0.22), 'black')))
+      .toContain('rgba(255, 255, 255,')
+  })
+})
+
+describe('the BOOK NOW strip', () => {
+  const CODE = qrRect(2480, 3508, 0.5, 0.5, 0.2)
+
+  it('sits beside the code and never over it', () => {
+    const strip = qrStripRect(CODE)
+    expect(rectsOverlap(strip, CODE, 0)).toBe(false)
+  })
+
+  it('does not reduce the scannable code, so the 40mm rule still holds', () => {
+    // qr_width_frac keeps meaning the CODE width. The block is simply wider.
+    expect(CODE.width).toBeGreaterThanOrEqual(qrMinWidthPx(2480))
+    expect(qrBlockRect(CODE).width).toBeGreaterThan(CODE.width)
+  })
+
+  it('makes the block exactly code plus strip, at the code height', () => {
+    const strip = qrStripRect(CODE)
+    const block = qrBlockRect(CODE)
+    expect(block.width).toBe(CODE.width + strip.width)
+    expect(block.height).toBe(CODE.height)
+  })
+
+  it('keeps the whole block on the canvas even when pushed into the edge', () => {
+    for (const [cx, cy] of [[0, 0], [1, 1], [0, 1], [1, 0], [0.5, 0.5]] as const) {
+      const code = qrCodeRectWithinCanvas(2480, 3508, cx, cy, 0.2)
+      const block = qrBlockRect(code)
+      const inset = insetPx(2480, 3508)
+      expect(block.x, `block left at ${cx},${cy}`).toBeGreaterThanOrEqual(inset)
+      expect(block.x + block.width, `block right at ${cx},${cy}`).toBeLessThanOrEqual(2480 - inset)
+    }
+  })
+
+  it('rejects a placement whose STRIP falls off, not just the code', () => {
+    // A code hard against the left edge is legal on its own; with a strip to its
+    // left it is not, and that is the case this guard exists for.
+    const code = qrRect(2480, 3508, 0, 0.5, 0.2)
+    const verdict = validateQrPlacement(2480, 3508, code, null)
+    expect(verdict.ok).toBe(false)
+    if (verdict.ok) throw new Error('expected a rejection')
+    expect(verdict.reason).toContain('outside the poster')
+  })
+})
+
+describe('snapFrac', () => {
+  it('snaps onto the centre when close', () => {
+    expect(snapFrac(0.49)).toEqual({ value: 0.5, snappedTo: 0.5 })
+    expect(snapFrac(0.51)).toEqual({ value: 0.5, snappedTo: 0.5 })
+  })
+
+  it('leaves a deliberate off-centre placement alone', () => {
+    expect(snapFrac(0.3)).toEqual({ value: 0.3, snappedTo: null })
+    expect(snapFrac(0.8)).toEqual({ value: 0.8, snappedTo: null })
+  })
+
+  it('releases as soon as the drag passes the threshold', () => {
+    const justInside = snapFrac(0.5 + SNAP_THRESHOLD_FRAC)
+    const justOutside = snapFrac(0.5 + SNAP_THRESHOLD_FRAC + 0.001)
+    expect(justInside.snappedTo).toBe(0.5)
+    expect(justOutside.snappedTo).toBeNull()
+    expect(justOutside.value).toBeCloseTo(0.521, 3)
+  })
+
+  it('reports which target it caught, so a guide can be drawn there', () => {
+    expect(snapFrac(0.2, [0.2, 0.5, 0.8]).snappedTo).toBe(0.2)
+    expect(snapFrac(0.79, [0.2, 0.5, 0.8]).snappedTo).toBe(0.8)
+  })
+
+  it('picks the nearest target when two are in range', () => {
+    expect(snapFrac(0.51, [0.5, 0.53], 0.05).snappedTo).toBe(0.5)
   })
 })

--- a/src/lib/events/artwork/geometry.ts
+++ b/src/lib/events/artwork/geometry.ts
@@ -283,6 +283,13 @@ export const QR_MIN_WIDTH_FRAC_EXACT = QR_MIN_MM / A4_WIDTH_MM
 export const QR_MAX_WIDTH_FRAC = 0.4
 
 /**
+ * What a new QR starts at before anyone changes it: 0.20 of the width, which is
+ * 42mm on A4. Comfortably over the 40mm floor without dominating the poster.
+ * The previous 0.22 (46mm) started larger than most artwork wanted.
+ */
+export const QR_DEFAULT_WIDTH_FRAC = 0.2
+
+/**
  * The 40mm print minimum in pixels for a poster of a given pixel width.
  *
  * Rounded UP, on purpose. On the 2480px A4 canvas the exact figure is
@@ -368,11 +375,14 @@ export function validateQrPlacement(
     return { ok: false, reason: 'The QR code has no size.' }
   }
 
+  // The BLOCK is what lands on the artwork: the code plus its BOOK NOW strip.
+  // Validating the code alone would let the strip hang off the edge.
+  const block = qrBlockRect(qr)
   if (
-    qr.x < 0 ||
-    qr.y < 0 ||
-    qr.x + qr.width > posterW ||
-    qr.y + qr.height > posterH
+    block.x < 0 ||
+    block.y < 0 ||
+    block.x + block.width > posterW ||
+    block.y + block.height > posterH
   ) {
     return { ok: false, reason: 'The QR code falls outside the poster.' }
   }
@@ -385,9 +395,214 @@ export function validateQrPlacement(
     }
   }
 
-  if (logo && rectsOverlap(qr, logo, insetPx(posterW, posterH))) {
+  if (logo && rectsOverlap(block, logo, insetPx(posterW, posterH))) {
     return { ok: false, reason: 'The QR code is too close to the logo.' }
   }
 
   return { ok: true }
+}
+
+// ---------------------------------------------------------------------------
+// Logo drop shadow
+//
+// A white logo disappears on pale artwork and a black one disappears on dark
+// artwork, so each carries a shadow in the opposite colour. It is the contrast
+// that does the work, not decoration: without it the mark is invisible on
+// exactly the artwork where it matters most.
+//
+// The measurements are fractions of the LOGO width, not the canvas, so the
+// shadow scales with the mark rather than growing on a poster and vanishing on
+// a story.
+// ---------------------------------------------------------------------------
+
+/** How far the shadow is pushed down and right, as a fraction of logo width. */
+export const LOGO_SHADOW_OFFSET_FRAC = 0.025
+
+/** Gaussian sigma for the shadow, as a fraction of logo width. */
+export const LOGO_SHADOW_BLUR_FRAC = 0.035
+
+/** Deliberately short of opaque, so the shadow reads as depth and not an outline. */
+export const LOGO_SHADOW_OPACITY = 0.55
+
+export type LogoColour = 'white' | 'black'
+
+/** The shadow is always the opposite of the mark, which is the entire point. */
+export function shadowColourFor(logoColour: LogoColour): '#000000' | '#ffffff' {
+  return logoColour === 'white' ? '#000000' : '#ffffff'
+}
+
+export interface LogoShadowSpec {
+  colour: '#000000' | '#ffffff'
+  offsetXPx: number
+  offsetYPx: number
+  blurPx: number
+  opacity: number
+}
+
+/**
+ * The shadow measurements in pixels for a given logo rectangle.
+ *
+ * Both the server compositor and the browser preview call this, so what is seen
+ * on screen is what gets rendered. `blurPx` is a Gaussian sigma: sharp takes it
+ * directly, and CSS `drop-shadow` takes roughly twice it as its blur radius,
+ * which `cssDropShadow` below already accounts for.
+ */
+export function logoShadowSpec(logo: Rect, logoColour: LogoColour): LogoShadowSpec {
+  const offset = Math.max(1, Math.round(logo.width * LOGO_SHADOW_OFFSET_FRAC))
+  return {
+    colour: shadowColourFor(logoColour),
+    offsetXPx: offset,
+    offsetYPx: offset,
+    blurPx: Math.max(1, Math.round(logo.width * LOGO_SHADOW_BLUR_FRAC)),
+    opacity: LOGO_SHADOW_OPACITY,
+  }
+}
+
+/**
+ * The same shadow as a CSS `drop-shadow` filter value, for the preview.
+ *
+ * CSS expresses blur as a radius of about twice the Gaussian sigma sharp uses,
+ * so the sigma is doubled here rather than in the caller. The two will never be
+ * pixel identical (different rasterisers), but they agree on placement, colour
+ * and weight, which is what someone positioning a logo is judging.
+ */
+export function cssDropShadow(spec: LogoShadowSpec): string {
+  const rgb = spec.colour === '#000000' ? '0, 0, 0' : '255, 255, 255'
+  return `drop-shadow(${spec.offsetXPx}px ${spec.offsetYPx}px ${spec.blurPx * 2}px rgba(${rgb}, ${spec.opacity}))`
+}
+
+// ---------------------------------------------------------------------------
+// The BOOK NOW strip
+//
+// A bare QR on a poster tells nobody what it is for. A labelled strip beside it
+// does. It sits ALONGSIDE the code and never over it: error correction H would
+// survive some occlusion, but a strip down one side removes a whole column of
+// modules, which is far worse for a scanner than the centred logos that
+// occlusion budget is usually spent on.
+//
+// `qr_width_frac` keeps meaning the CODE width, so the 40mm print minimum and
+// the database CHECK constraints all still mean what they say. The strip makes
+// the placed BLOCK wider than the code, and it is the block that has to fit on
+// the canvas and clear the logo.
+// ---------------------------------------------------------------------------
+
+/** Strip width as a fraction of the code width. */
+export const QR_STRIP_WIDTH_FRAC_OF_CODE = 0.22
+
+/** The label. Short, imperative, and legible rotated at small sizes. */
+export const QR_STRIP_LABEL = 'BOOK NOW'
+
+/**
+ * Which side of the code the strip sits on.
+ *
+ * Left, so the label is read before the code on a left-to-right poster. One
+ * constant, so moving it to the right is a single edit.
+ */
+export const QR_STRIP_SIDE: 'left' | 'right' = 'left'
+
+/** The strip beside a given code rectangle. */
+export function qrStripRect(code: Rect): Rect {
+  const width = Math.max(1, Math.round(code.width * QR_STRIP_WIDTH_FRAC_OF_CODE))
+  return {
+    x: QR_STRIP_SIDE === 'left' ? code.x - width : code.x + code.width,
+    y: code.y,
+    width,
+    height: code.height,
+  }
+}
+
+/**
+ * The code and its strip as one rectangle.
+ *
+ * This is what gets validated and what the preview draws a box around, because
+ * it is what actually lands on the artwork.
+ */
+export function qrBlockRect(code: Rect): Rect {
+  const strip = qrStripRect(code)
+  return {
+    x: Math.min(code.x, strip.x),
+    y: code.y,
+    width: code.width + strip.width,
+    height: code.height,
+  }
+}
+
+/**
+ * Place the code so that the whole BLOCK, strip included, stays on the canvas.
+ *
+ * `qrRect` positions the code alone, which would let the strip hang off the
+ * edge when the code is pushed hard against it. This shifts the code back by
+ * however much the strip overhangs.
+ */
+export function qrCodeRectWithinCanvas(
+  posterW: number,
+  posterH: number,
+  centreXFrac: number,
+  centreYFrac: number,
+  widthFrac: number
+): Rect {
+  const inset = insetPx(posterW, posterH)
+  const code = qrRect(posterW, posterH, centreXFrac, centreYFrac, widthFrac)
+  const block = qrBlockRect(code)
+
+  let dx = 0
+  if (block.x < inset) dx = inset - block.x
+  const blockRight = block.x + block.width
+  if (blockRight > posterW - inset) dx = Math.min(dx, posterW - inset - blockRight)
+
+  return { ...code, x: code.x + dx }
+}
+
+// ---------------------------------------------------------------------------
+// Snapping
+//
+// Dragging to a visual centre by eye is guesswork, and being one pixel out is
+// obvious once printed. Snap targets pull a drag onto the exact centre when it
+// is already close, and let go as soon as the drag moves past the threshold, so
+// a deliberate off-centre placement is still possible.
+// ---------------------------------------------------------------------------
+
+/** Centre of the canvas on each axis. Thirds were considered and left out: on
+ *  artwork this small they produce more false snaps than useful ones. */
+export const SNAP_TARGETS_FRAC: readonly number[] = [0.5]
+
+/** How close a drag has to get before it snaps, as a fraction of the edge. */
+export const SNAP_THRESHOLD_FRAC = 0.02
+
+export interface SnapResult {
+  /** The value to use, snapped when within the threshold. */
+  value: number
+  /** The target it snapped to, or null when it did not snap. Drives the guide. */
+  snappedTo: number | null
+}
+
+/**
+ * Snap a 0-to-1 position onto the nearest target when it is close enough.
+ *
+ * Pure, so the preview and any test agree. Returns which target it caught so
+ * the caller can draw a guide line exactly where the snap happened rather than
+ * guessing.
+ */
+export function snapFrac(
+  value: number,
+  targets: readonly number[] = SNAP_TARGETS_FRAC,
+  threshold: number = SNAP_THRESHOLD_FRAC
+): SnapResult {
+  let best: number | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+
+  // A hair of tolerance, because 0.5 + 0.02 is 0.5200000000000001 in binary
+  // floating point and a drag that lands exactly on the threshold should snap
+  // rather than fall through on a rounding artefact.
+  const limit = threshold + 1e-9
+
+  for (const target of targets) {
+    const distance = Math.abs(value - target)
+    if (distance <= limit && distance < bestDistance) {
+      best = target
+      bestDistance = distance
+    }
+  }
+
+  return best === null ? { value, snappedTo: null } : { value: best, snappedTo: best }
 }


### PR DESCRIPTION
Four changes requested after using the branding editor.

## 1. Drop shadow on the logo, in the opposite colour
A white mark disappears on pale artwork and a black one on dark artwork, which is exactly the artwork where branding matters most. Sized as a fraction of the logo width rather than the canvas, so it scales with the mark instead of growing on a poster and vanishing on a story.

Proved by sampled pixels: a white logo on white artwork now paints 25,590 visible pixels where it previously painted none, and outside the logo rect 10,266 pixels moved toward black with zero moving the other way.

## 2. BOOK NOW strip beside the poster QR
A bare code tells nobody what it is for.

**It sits alongside the code and never over it.** Error correction H would survive some occlusion, but a strip down one side removes a whole column of modules, far worse than the centred logos that occlusion budget is normally spent on. Proved by rendering the composited code region and asserting it is byte-identical to a standalone QR render: zero differing pixels.

`qr_width_frac` still means the CODE width, so the 40mm print minimum and every database CHECK still mean what they say. The BLOCK (code plus strip) is what must now fit the canvas and clear the logo, and `validateQrPlacement` checks it. Strip on the left so the label reads before the code.

## 3. Smaller default QR
0.22 to 0.20, which is 46mm to 42mm on A4, still clear of the 40mm floor. Named in geometry rather than left in the component.

## 4. Snap to centre, with a guide
Dragging within 2% of an axis centre snaps exactly onto it and draws a guide line; moving past the threshold releases it. Arrow keys snap too. The numeric fields deliberately do not, or typing 0.49 would silently become 0.5.

## Two traps worth knowing

Sharp flags a freshly extracted alpha band as **premultiplied** and silently ignores `.linear()` on it, so without a PNG round trip the shadow rendered fully opaque. And chaining `.joinChannel().composite()` reorders into sharp's fixed pipeline order, so the composite ran against a 3-band plate and failed.

Snapping the committed position alone made the logo **impossible to nudge off centre**: from dead centre every 1% arrow press landed back inside the 2% threshold and was pulled straight back. The true un-snapped position is now held separately and only the stored value is snapped.

## On the widened test helper

`branding-service.test.ts`'s `expectWithin` is widened, not dropped. The shadow legitimately enlarges the painted area, and the assertion still proves the logo landed where geometry said and that nothing else was painted. `composite.test.ts` proves the mark itself is pixel exact by separating it from its shadow by colour, which is tighter than the 2px slack the old test allowed.

## Verification

6803 tests passing in both Europe/London and UTC, lint clean, typecheck clean, production build succeeds with the composite route present.

No schema change: all four are code-side.

## Still not covered

No poster has been printed and scanned. That matters more now, since the strip changes what the printed block looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)