### PR TITLE
feat: add marketing campaign filters and sorting

### DIFF
--- a/src/app/(authenticated)/marketing/__tests__/page.test.tsx
+++ b/src/app/(authenticated)/marketing/__tests__/page.test.tsx
@@ -1,0 +1,123 @@
+import type { ComponentProps, ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/app/actions/rbac', () => ({ checkUserPermission: vi.fn() }))
+vi.mock('@/app/actions/marketing-campaigns', () => ({
+  listMarketingCampaigns: vi.fn(),
+  getMarketingSettings: vi.fn(),
+  getMarketingCampaignStats: vi.fn(),
+}))
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }))
+vi.mock('../UnsubscribeEmailCard', () => ({ UnsubscribeEmailCard: () => null }))
+
+// Keep semantic HTML while isolating this server page from app-shell providers.
+vi.mock('@/ds', () => ({
+  PageLayout: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+  Card: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+  Alert: ({ title, children }: { title: string; children: ReactNode }) => <div role="alert">{title}{children}</div>,
+  Button: ({ children, type }: { children: ReactNode; type?: 'submit' }) => <button type={type}>{children}</button>,
+  LinkButton: ({ children, href }: { children: ReactNode; href: string }) => <a href={href}>{children}</a>,
+  Input: ({ label, ...props }: ComponentProps<'input'> & { label: string }) => <label>{label}<input {...props} /></label>,
+  Select: ({ label, children, ...props }: ComponentProps<'select'> & { label: string }) => <label>{label}<select {...props}>{children}</select></label>,
+  Empty: ({ title, action }: { title: string; action: ReactNode }) => <div>{title}{action}</div>,
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+  TableHeader: ({ children }: { children: ReactNode }) => <thead>{children}</thead>,
+  TableBody: ({ children }: { children: ReactNode }) => <tbody>{children}</tbody>,
+  TableRow: ({ children }: { children: ReactNode }) => <tr>{children}</tr>,
+  TableHead: ({ children }: { children: ReactNode }) => <th>{children}</th>,
+  TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+}))
+
+import { redirect } from 'next/navigation'
+import { checkUserPermission } from '@/app/actions/rbac'
+import { getMarketingSettings, listMarketingCampaigns } from '@/app/actions/marketing-campaigns'
+import MarketingCampaignsPage from '../page'
+
+const renderPage = async (params: Record<string, string | string[] | undefined> = {}) =>
+  render(await MarketingCampaignsPage({ searchParams: Promise.resolve(params) }))
+
+describe('marketing campaign list page', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(checkUserPermission).mockResolvedValue(true)
+    vi.mocked(listMarketingCampaigns).mockResolvedValue({ data: { campaigns: [], total: 0 } })
+    vi.mocked(getMarketingSettings).mockResolvedValue({ error: 'Settings unavailable for test' })
+    vi.mocked(redirect).mockImplementation((url) => { throw new Error(`Redirect: ${url}`) })
+  })
+
+  afterEach(cleanup)
+
+  it('defaults to drafts and scheduled emails with earliest sends first', async () => {
+    await renderPage()
+    expect(listMarketingCampaigns).toHaveBeenCalledWith({
+      page: 1, pageSize: 50, search: '', sort: 'scheduled_asc',
+      audienceType: undefined, statuses: ['draft', 'scheduled'],
+    })
+    expect(screen.getByLabelText('Status')).toHaveValue('upcoming')
+    expect(screen.getByLabelText('Sort by')).toHaveValue('scheduled_asc')
+    expect(screen.getByText(/Showing scheduled and draft emails only/)).toBeInTheDocument()
+  })
+
+  it('passes explicit filters to the action and restores their form values', async () => {
+    await renderPage({ status: 'completed', search: '  Christmas  ', audience: 'business', sort: 'name_desc' })
+    expect(listMarketingCampaigns).toHaveBeenCalledWith({
+      page: 1, pageSize: 50, search: 'Christmas', sort: 'name_desc',
+      audienceType: 'business', statuses: ['completed'],
+    })
+    expect(screen.getByLabelText('Search campaigns')).toHaveValue('Christmas')
+    expect(screen.getByLabelText('Status')).toHaveValue('completed')
+    expect(screen.getByLabelText('Audience')).toHaveValue('business')
+    expect(screen.getByLabelText('Sort by')).toHaveValue('name_desc')
+  })
+
+  it('uses a GET form with Apply and a reset to the default view', async () => {
+    await renderPage()
+    const form = screen.getByRole('form', { name: 'Campaign filters' })
+    expect(form).toHaveAttribute('method', 'get')
+    expect(form).toHaveAttribute('action', '/marketing')
+    expect(screen.getByRole('button', { name: 'Apply' })).toHaveAttribute('type', 'submit')
+    expect(screen.getByRole('link', { name: 'Reset' })).toHaveAttribute('href', '/marketing')
+    expect(form.querySelector('[name="page"]')).toBeNull()
+  })
+
+  it('allows completed emails to be included through All statuses', async () => {
+    await renderPage({ status: 'all' })
+    expect(listMarketingCampaigns).toHaveBeenCalledWith(expect.objectContaining({ statuses: undefined }))
+    expect(screen.getByLabelText('Status')).toHaveValue('all')
+  })
+
+  it('preserves search, audience, status and sort on both pagination links', async () => {
+    vi.mocked(listMarketingCampaigns).mockResolvedValue({ data: { campaigns: [], total: 125 } })
+    await renderPage({ status: 'completed', search: 'Food & drink', audience: 'business', sort: 'oldest', page: '2' })
+    for (const [name, page] of [['Previous', '1'], ['Next', '3']]) {
+      const href = screen.getByRole('link', { name }).getAttribute('href')!
+      const query = new URL(href, 'https://example.test').searchParams
+      expect(Object.fromEntries(query)).toEqual({ status: 'completed', sort: 'oldest', page, search: 'Food & drink', audience: 'business' })
+    }
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument()
+  })
+
+  it('redirects an out-of-range page to the final page without losing filters', async () => {
+    vi.mocked(listMarketingCampaigns).mockResolvedValue({ data: { campaigns: [], total: 75 } })
+    await expect(renderPage({ status: 'completed', search: 'Quiz', audience: 'customer', sort: 'newest', page: '99' })).rejects.toThrow('Redirect:')
+    const href = vi.mocked(redirect).mock.calls[0][0]
+    expect(Object.fromEntries(new URL(href, 'https://example.test').searchParams)).toEqual({
+      status: 'completed', search: 'Quiz', audience: 'customer', sort: 'newest', page: '2',
+    })
+  })
+
+  it('falls back to defaults for invalid query parameters', async () => {
+    await renderPage({ status: 'invalid', audience: 'unknown', sort: 'bad', page: '-2' })
+    expect(listMarketingCampaigns).toHaveBeenCalledWith(expect.objectContaining({
+      page: 1, statuses: ['draft', 'scheduled'], audienceType: undefined, sort: 'scheduled_asc',
+    }))
+  })
+
+  it('stops unauthorised requests before loading campaigns', async () => {
+    vi.mocked(checkUserPermission).mockResolvedValue(false)
+    await expect(renderPage()).rejects.toThrow('Redirect: /unauthorized')
+    expect(listMarketingCampaigns).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/(authenticated)/marketing/page.tsx
+++ b/src/app/(authenticated)/marketing/page.tsx
@@ -10,6 +10,9 @@ import {
 import {
   Alert,
   Card,
+  Button,
+  Input,
+  Select,
   Empty,
   LinkButton,
   PageLayout,
@@ -20,7 +23,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/ds'
-import type { MarketingCampaignStats } from '@/types/marketing'
+import type { MarketingCampaignStats, MarketingCampaignStatus } from '@/types/marketing'
 
 import {
   CampaignStatusBadge,
@@ -33,10 +36,30 @@ import { UnsubscribeEmailCard } from './UnsubscribeEmailCard'
 export const dynamic = 'force-dynamic'
 
 const PAGE_SIZE = 50
+const STATUSES: MarketingCampaignStatus[] = ['draft', 'scheduled', 'sending', 'paused', 'completed', 'cancelled']
+const SORTS = ['scheduled_asc', 'scheduled_desc', 'newest', 'oldest', 'name_asc', 'name_desc'] as const
+type SearchParams = Record<string, string | string[] | undefined>
+const firstValue = (value: string | string[] | undefined) => (Array.isArray(value) ? value[0] : value) ?? ''
 
-export default async function MarketingCampaignsPage() {
+export default async function MarketingCampaignsPage({ searchParams }: { searchParams: Promise<SearchParams> }) {
   const canView = await checkUserPermission('marketing', 'view')
   if (!canView) redirect('/unauthorized')
+
+  const params = await searchParams
+  const search = firstValue(params.search).trim().slice(0, 200)
+  const rawStatus = firstValue(params.status)
+  const status = rawStatus === 'all' || STATUSES.includes(rawStatus as MarketingCampaignStatus) ? rawStatus : 'upcoming'
+  const rawAudience = firstValue(params.audience)
+  const audience = rawAudience === 'business' || rawAudience === 'customer' ? rawAudience : ''
+  const sort = SORTS.find(value => value === firstValue(params.sort)) ?? 'scheduled_asc'
+  const pageNumber = Number(firstValue(params.page))
+  const page = Number.isSafeInteger(pageNumber) && pageNumber > 0 ? Math.min(pageNumber, 1000000) : 1
+  const pageHref = (nextPage: number) => {
+    const query = new URLSearchParams({ status, sort, page: String(nextPage) })
+    if (search) query.set('search', search)
+    if (audience) query.set('audience', audience)
+    return `/marketing?${query}`
+  }
 
   const [canCreate, canEdit] = await Promise.all([
     checkUserPermission('marketing', 'create'),
@@ -44,7 +67,10 @@ export default async function MarketingCampaignsPage() {
   ])
 
   const [campaignsResult, settingsResult] = await Promise.all([
-    listMarketingCampaigns({ page: 1, pageSize: PAGE_SIZE }),
+    listMarketingCampaigns({
+      page, pageSize: PAGE_SIZE, search, sort, audienceType: audience || undefined,
+      statuses: status === 'upcoming' ? ['draft', 'scheduled'] : status === 'all' ? undefined : [status as MarketingCampaignStatus],
+    }),
     getMarketingSettings(),
   ])
 
@@ -59,6 +85,9 @@ export default async function MarketingCampaignsPage() {
   }
 
   const campaigns = campaignsResult.data.campaigns
+  const total = campaignsResult.data.total
+  const pages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  if (page > pages) redirect(pageHref(pages))
   const settings = settingsResult.data
   const sendingOff = settings ? settings.sendsEnabled === false : false
 
@@ -77,7 +106,7 @@ export default async function MarketingCampaignsPage() {
   return (
     <PageLayout
       title="Marketing"
-      subtitle="Email campaigns to business contacts"
+      subtitle="Email campaigns to guests and business contacts"
       navItems={MARKETING_SECTION_NAV}
       headerActions={
         canCreate ? (
@@ -111,17 +140,44 @@ export default async function MarketingCampaignsPage() {
         {canEdit && <UnsubscribeEmailCard />}
 
         <Card>
+          <form key={`${search}:${status}:${audience}:${sort}`} action="/marketing" method="get" className="grid gap-4 border-b border-border p-4 sm:grid-cols-2 xl:grid-cols-5" aria-label="Campaign filters">
+            <Input label="Search campaigns" name="search" type="search" placeholder="Campaign name or subject" defaultValue={search} maxLength={200} />
+            <Select label="Status" name="status" defaultValue={status}>
+              <option value="upcoming">Scheduled and drafts</option>
+              <option value="all">All statuses</option>
+              {STATUSES.map(value => <option key={value} value={value}>{value.charAt(0).toUpperCase() + value.slice(1)}</option>)}
+            </Select>
+            <Select label="Audience" name="audience" defaultValue={audience}>
+              <option value="">All audiences</option>
+              <option value="customer">Guests</option>
+              <option value="business">Business contacts</option>
+            </Select>
+            <Select label="Sort by" name="sort" defaultValue={sort}>
+              <option value="scheduled_asc">Send date: earliest first</option>
+              <option value="scheduled_desc">Send date: latest first</option>
+              <option value="newest">Created: newest first</option>
+              <option value="oldest">Created: oldest first</option>
+              <option value="name_asc">Campaign name: A to Z</option>
+              <option value="name_desc">Campaign name: Z to A</option>
+            </Select>
+            <div className="flex items-end gap-2">
+              <Button type="submit" variant="primary">Apply</Button>
+              <LinkButton href="/marketing" variant="secondary">Reset</LinkButton>
+            </div>
+          </form>
+          <p className="px-4 py-3 text-sm text-text-muted" aria-live="polite">
+            {total === 0 ? 'No matching campaigns' : `${(page - 1) * PAGE_SIZE + 1} to ${Math.min(page * PAGE_SIZE, total)} of ${total} campaigns`}
+            {status === 'upcoming' && '. Showing scheduled and draft emails only.'}
+          </p>
           {campaigns.length === 0 ? (
             <Empty
               icon="inbox"
-              title="No campaigns yet"
-              description="Campaigns are written as content files and loaded here. Paste the JSON on the new campaign page, choose who it goes to, then schedule it."
+              title="No campaigns match these filters"
+              description="Try another search or choose All statuses to include completed campaigns."
               action={
-                canCreate ? (
-                  <LinkButton href="/marketing/campaigns/new" variant="primary">
-                    New campaign
+                  <LinkButton href="/marketing?status=all" variant="secondary">
+                    Show all campaigns
                   </LinkButton>
-                ) : undefined
               }
             />
           ) : (
@@ -204,6 +260,13 @@ export default async function MarketingCampaignsPage() {
                 </TableBody>
               </Table>
             </div>
+          )}
+          {pages > 1 && (
+            <nav aria-label="Campaign pages" className="flex items-center justify-between border-t border-border p-4">
+              {page > 1 ? <LinkButton href={pageHref(page - 1)} variant="secondary">Previous</LinkButton> : <span />}
+              <span className="text-sm text-text-muted">Page {page} of {pages}</span>
+              {page < pages ? <LinkButton href={pageHref(page + 1)} variant="secondary">Next</LinkButton> : <span />}
+            </nav>
           )}
         </Card>
 

--- a/src/app/actions/marketing-campaigns.ts
+++ b/src/app/actions/marketing-campaigns.ts
@@ -113,6 +113,10 @@ const audienceSchema = z.object({
 
 const listSchema = z.object({
   status: campaignStatusSchema.optional(),
+  statuses: z.array(campaignStatusSchema).max(6).optional(),
+  search: z.string().trim().max(200).optional(),
+  audienceType: z.enum(['business', 'customer']).optional(),
+  sort: z.enum(['newest', 'oldest', 'scheduled_asc', 'scheduled_desc', 'name_asc', 'name_desc']).optional(),
   page: z.number().int().min(1).optional(),
   pageSize: z.number().int().min(1).max(200).optional(),
 })

--- a/src/services/__tests__/marketing-list.test.ts
+++ b/src/services/__tests__/marketing-list.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/supabase/admin', () => ({ createAdminClient: vi.fn() }))
+
+import { createAdminClient } from '@/lib/supabase/admin'
+import { listCampaigns } from '../marketing-campaigns'
+
+type Operation = { method: string; args: unknown[] }
+
+const operations: Operation[] = []
+let queryResult: { data: never[]; count: number | null; error: { message: string } | null }
+
+function mockCampaignQuery() {
+  const query = {
+    select: (...args: unknown[]) => record('select', args),
+    eq: (...args: unknown[]) => record('eq', args),
+    in: (...args: unknown[]) => record('in', args),
+    or: (...args: unknown[]) => record('or', args),
+    order: (...args: unknown[]) => record('order', args),
+    range: (...args: unknown[]) => record('range', args),
+    then: (resolve: (result: typeof queryResult) => unknown) =>
+      Promise.resolve(queryResult).then(resolve),
+  }
+
+  function record(method: string, args: unknown[]) {
+    operations.push({ method, args })
+    return query
+  }
+
+  const client = {
+    from: vi.fn((table: string) => {
+      expect(table).toBe('marketing_campaigns')
+      return query
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(
+    client as unknown as ReturnType<typeof createAdminClient>,
+  )
+}
+
+describe('listCampaigns filtering and sorting', () => {
+  beforeEach(() => {
+    operations.length = 0
+    queryResult = { data: [], count: 0, error: null }
+    mockCampaignQuery()
+  })
+
+  it('filters statuses, audience and search before paginating and returns the filtered count', async () => {
+    queryResult.count = 31
+
+    const result = await listCampaigns({
+      statuses: ['scheduled', 'draft'],
+      audienceType: 'business',
+      search: '  Christmas  ',
+      page: 2,
+      pageSize: 10,
+    })
+
+    expect(operations).toContainEqual({ method: 'select', args: ['*', { count: 'exact' }] })
+    expect(operations).toContainEqual({ method: 'in', args: ['status', ['scheduled', 'draft']] })
+    expect(operations).toContainEqual({ method: 'eq', args: ['audience_type', 'business'] })
+    expect(operations).toContainEqual({ method: 'range', args: [10, 19] })
+    const rangeIndex = operations.findIndex(({ method }) => method === 'range')
+    for (const method of ['in', 'eq', 'or']) {
+      expect(operations.findIndex((operation) => operation.method === method)).toBeLessThan(rangeIndex)
+    }
+    const search = operations.find(({ method }) => method === 'or')?.args[0]
+    expect(search).toBe('name.ilike."%Christmas%",subject.ilike."%Christmas%"')
+    expect(result).toEqual({ campaigns: [], total: 31 })
+  })
+
+  it('retains the single-status option for existing callers', async () => {
+    await listCampaigns({ status: 'completed' })
+    expect(operations).toContainEqual({ method: 'eq', args: ['status', 'completed'] })
+  })
+
+  it('quotes punctuation and escapes LIKE wildcards so search cannot change the filters', async () => {
+    await listCampaigns({ search: String.raw`20%_ "offer",(status.eq.completed)\sale` })
+
+    const filter = operations.find(({ method }) => method === 'or')?.args[0] as string
+    const quotedValue = filter.slice('name.ilike.'.length, filter.indexOf(',subject.ilike.'))
+    expect(JSON.parse(quotedValue)).toBe(String.raw`%20\%\_ "offer",(status.eq.completed)\\sale%`)
+    expect(filter).toBe(`name.ilike.${quotedValue},subject.ilike.${quotedValue}`)
+  })
+
+  it('leaves the unrestricted service call unfiltered and ignores whitespace searches', async () => {
+    await listCampaigns({ search: '   ' })
+    expect(operations.some(({ method }) => ['eq', 'in', 'or'].includes(method))).toBe(false)
+    expect(operations).toContainEqual({ method: 'range', args: [0, 24] })
+  })
+
+  it.each([
+    ['newest', 'created_at', false],
+    ['oldest', 'created_at', true],
+    ['scheduled_asc', 'scheduled_for', true],
+    ['scheduled_desc', 'scheduled_for', false],
+    ['name_asc', 'name', true],
+    ['name_desc', 'name', false],
+  ] as const)('sorts %s with a stable ID tie-breaker', async (sort, column, ascending) => {
+    await listCampaigns({ sort })
+    const orders = operations.filter(({ method }) => method === 'order')
+    expect(orders[0].args[0]).toBe(column)
+    expect(orders[0].args[1]).toMatchObject({ ascending })
+    if (column === 'scheduled_for') {
+      expect(orders[0].args[1]).toMatchObject({ nullsFirst: false })
+    }
+    expect(orders.at(-1)?.args[0]).toBe('id')
+    expect(orders.at(-1)?.args[1]).toMatchObject({ ascending: true })
+    expect(orders.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('keeps newest first as the default for existing service callers', async () => {
+    await listCampaigns()
+    const firstOrder = operations.find(({ method }) => method === 'order')
+    expect(firstOrder?.args[0]).toBe('created_at')
+    expect(firstOrder?.args[1]).toMatchObject({ ascending: false })
+  })
+
+  it('reports query failures instead of presenting an empty filtered list', async () => {
+    queryResult.error = { message: 'Campaign query unavailable' }
+    await expect(listCampaigns({ statuses: ['draft'] })).rejects.toThrow('Campaign query unavailable')
+  })
+})

--- a/src/services/marketing-campaigns.ts
+++ b/src/services/marketing-campaigns.ts
@@ -223,8 +223,14 @@ async function fetchSummaries(
   return summaries
 }
 
+export type MarketingCampaignSort = 'newest' | 'oldest' | 'scheduled_asc' | 'scheduled_desc' | 'name_asc' | 'name_desc'
+
 export interface ListCampaignsOptions {
   status?: MarketingCampaignStatus
+  statuses?: MarketingCampaignStatus[]
+  search?: string
+  audienceType?: MarketingAudienceType
+  sort?: MarketingCampaignSort
   page?: number
   pageSize?: number
 }
@@ -245,9 +251,26 @@ export async function listCampaigns(
 
   let query = supabase.from('marketing_campaigns').select('*', { count: 'exact' })
   if (options.status) query = query.eq('status', options.status)
+  if (options.statuses?.length) query = query.in('status', options.statuses)
+  if (options.audienceType) query = query.eq('audience_type', options.audienceType)
+  const search = options.search?.trim()
+  if (search) {
+    // Quote the PostgREST value so punctuation cannot add another filter; escape LIKE wildcards.
+    const pattern = JSON.stringify(`%${search.replace(/[\\%_]/g, '\\$&')}%`)
+    query = query.or(`name.ilike.${pattern},subject.ilike.${pattern}`)
+  }
+
+  switch (options.sort) {
+    case 'oldest': query = query.order('created_at', { ascending: true }); break
+    case 'scheduled_asc': query = query.order('scheduled_for', { ascending: true, nullsFirst: false }); break
+    case 'scheduled_desc': query = query.order('scheduled_for', { ascending: false, nullsFirst: false }); break
+    case 'name_asc': query = query.order('name', { ascending: true }); break
+    case 'name_desc': query = query.order('name', { ascending: false }); break
+    default: query = query.order('created_at', { ascending: false })
+  }
 
   const { data, error, count } = await query
-    .order('created_at', { ascending: false })
+    .order('id', { ascending: true })
     .range(from, from + pageSize - 1)
 
   if (error) throw new Error(error.message)


### PR DESCRIPTION
## What changed
The marketing list now opens with scheduled and draft campaigns only, ordered by the earliest scheduled send. Added name/subject search, status and audience filters, six sort choices, and pagination that preserves the selected filters in the URL.

## Why
Upcoming work was mixed with completed campaigns, making the next emails difficult to find. Completed campaigns remain available through the status filter.

## Testing done
- Page and service tests cover defaults, permissions, filter parsing, literal search escaping, ordering, pagination and reset controls.
- Read-only queries against current campaign data confirm the default seven scheduled campaigns and explicit completed/search results.
- Full lint, typecheck, test suite and production build run on the isolated release before push.
- Live authenticated browser verification follows deployment.

## Complexity score
S: campaign list controls and query options, using existing design-system components and permission checks.

## Breaking changes
None. Campaign content and schedules are unchanged.

## Migration risk
None. No migration is required.
