### PR TITLE
fix: restrict public standing tickets to seated sellout

### DIFF
--- a/scripts/testing/event-standing-postgres.py
+++ b/scripts/testing/event-standing-postgres.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Exercise the booking policy in an isolated socket-only PostgreSQL database.
+
+The real booking function runs against synthetic records. Capacity and table
+allocation are fixture functions; this checks the policy and its event-row lock,
+not the production allocator or external confirmations.
+"""
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+PG = Path('/opt/homebrew/bin')
+MIGRATION = ROOT / 'supabase/migrations/20260906134726_event_standing_after_seated_sold_out.sql'
+ROLLBACK = ROOT / 'tasks/standing-ticket-policy/rollback.sql'
+
+SETUP = r"""
+CREATE ROLE anon; CREATE ROLE authenticated; CREATE ROLE service_role;
+CREATE TABLE events(id uuid primary key, name text default 'Fixture Event', capacity integer default 5,
+ payment_mode text default 'cash_only', booking_mode text default 'communal', booking_open boolean default true,
+ event_status text default 'scheduled', start_datetime timestamptz default now()+interval '1 day',
+ date date, time time, end_time time, duration_minutes integer default 120,
+ seated_capacity integer default 2, standing_capacity integer default 3);
+CREATE TABLE bookings(id uuid primary key default gen_random_uuid(),customer_id uuid,event_id uuid,seats integer,
+ status text,source text,event_seating_type text,hold_expires_at timestamptz,created_at timestamptz,updated_at timestamptz);
+CREATE TABLE booking_holds(hold_type text,event_booking_id uuid,seats_or_covers_held integer,status text,
+ expires_at timestamptz,created_at timestamptz,updated_at timestamptz);
+CREATE TABLE fixture_allocations(booking_id uuid,seats integer);
+CREATE FUNCTION event_communal_window_v01(uuid) RETURNS TABLE(start_datetime timestamptz,end_datetime timestamptz)
+ LANGUAGE sql AS $$ SELECT e.start_datetime,e.start_datetime+interval '2 hours' FROM events e WHERE id=$1 $$;
+CREATE FUNCTION get_event_capacity_snapshot_v05(uuid[]) RETURNS TABLE(capacity integer,seats_remaining integer,
+ seated_remaining integer,standing_remaining integer,total_remaining integer,standing_capacity integer)
+ LANGUAGE sql AS $$ SELECT e.capacity,
+ e.capacity-coalesce(sum(b.seats),0)::integer,
+ e.seated_capacity-coalesce(sum(b.seats) FILTER(WHERE b.event_seating_type='seated'),0)::integer,
+ e.standing_capacity-coalesce(sum(b.seats) FILTER(WHERE b.event_seating_type='standing'),0)::integer,
+ e.capacity-coalesce(sum(b.seats),0)::integer,e.standing_capacity
+ FROM events e LEFT JOIN bookings b ON b.event_id=e.id AND b.status IN ('confirmed','pending_payment')
+ WHERE e.id=ANY($1) GROUP BY e.id $$;
+CREATE FUNCTION allocate_event_communal_seats_v01(uuid,uuid,integer,timestamptz,timestamptz) RETURNS jsonb
+ LANGUAGE plpgsql AS $$ BEGIN INSERT INTO fixture_allocations VALUES ($2,$3); RETURN '{"state":"confirmed"}'; END $$;
+CREATE FUNCTION fixture_assert(boolean,text) RETURNS void LANGUAGE plpgsql AS $$ BEGIN
+ IF $1 IS DISTINCT FROM true THEN RAISE EXCEPTION 'FAIL %',$2; END IF; RAISE NOTICE 'PASS %',$2; END $$;
+INSERT INTO events(id) VALUES ('00000000-0000-0000-0000-000000000001');
+"""
+
+def main():
+    with tempfile.TemporaryDirectory(prefix='standing-pg-') as folder:
+        work=Path(folder); socket=work/'socket'; socket.mkdir(); cluster=work/'db'
+        subprocess.run([str(PG/'initdb'),'-D',str(cluster),'-A','trust','--no-locale'],check=True,capture_output=True)
+        subprocess.run([str(PG/'pg_ctl'),'-D',str(cluster),'-l',str(work/'log'),'-o',f"-k {socket} -c listen_addresses=''",'-w','start'],check=True,capture_output=True)
+        cmd=[str(PG/'psql'),'-h',str(socket),'-d','postgres','-X','-q','-v','ON_ERROR_STOP=1']
+        def sql(value):
+            result=subprocess.run(cmd,input=value,text=True,capture_output=True)
+            if result.returncode: raise RuntimeError(result.stderr)
+            for line in result.stderr.splitlines():
+                if 'PASS ' in line: print(line)
+            return result.stdout
+        def call(seats, preference='seated', source='brand_site', customer=None):
+            cust="gen_random_uuid()" if customer is None else "'"+customer+"'::uuid"
+            return f"create_event_booking_v05('00000000-0000-0000-0000-000000000001',{cust},{seats},'{source}','{preference}')"
+        def check(expression,label): sql("SELECT fixture_assert("+expression+",'"+label+"');")
+        def reset(): sql('TRUNCATE bookings,booking_holds,fixture_allocations;')
+        try:
+            sql(SETUP);sql(ROLLBACK.read_text())
+            check("("+call(3)+"->>'event_seating_type')='standing'",'baseline reproduces silent conversion')
+            reset(); sql('BEGIN;'+MIGRATION.read_text()+'ROLLBACK;')
+            check("("+call(3)+"->>'event_seating_type')='standing'",'transaction rollback restores old behaviour')
+            reset();sql(MIGRATION.read_text())
+            check("("+call(1,'standing')+"->>'reason')='standing_not_available_until_seated_full'",'standing blocked while seats remain')
+            check("("+call(3)+"->>'reason')='seated_capacity_changed'",'oversized seated group never becomes standing')
+            check('(SELECT count(*) FROM bookings)=0','blocked requests create no bookings')
+            sql('UPDATE events SET seated_capacity=NULL;')
+            check("("+call(1,'standing')+"->>'reason')='standing_not_available_until_seated_full'",'unknown seat availability blocks standing')
+            sql('UPDATE events SET seated_capacity=2;')
+            check("("+call(2)+"->>'event_seating_type')='seated'",'public seats book normally')
+            check("("+call(3,'standing')+"->>'event_seating_type')='standing'",'standing books after seats sell out')
+            check('(SELECT count(*) FROM fixture_allocations)=1','standing has no table allocation')
+            check("("+call(1,'standing')+"->>'state')='full_with_waitlist_option'",'standing sellout cannot overbook')
+            check("("+call(1)+"->>'state')='full_with_waitlist_option'",'complete sellout retains seated waitlist path')
+            reset()
+            for source in ['admin','foh','walk-in']:
+                check("("+call(1,'standing',source)+"->>'event_seating_type')='standing'",'staff '+source+' can choose standing');reset()
+            for source in ['sms_reply','unknown']:
+                check("("+call(1,'standing',source)+"->>'reason')='standing_not_available_until_seated_full'",source+' cannot bypass policy')
+            sql("UPDATE events SET payment_mode='prepaid';")
+            check("("+call(2)+"->>'state')='pending_payment'",'prepaid seats create payment hold')
+            check("("+call(1,'standing')+"->>'state')='pending_payment'",'prepaid standing creates payment hold')
+            check('(SELECT count(*) FROM booking_holds)=2','both payment holds recorded')
+            reset();sql("UPDATE events SET payment_mode='cash_only';")
+            customer='00000000-0000-0000-0000-000000000002'
+            check("("+call(1,customer=customer)+"->>'state')='confirmed'",'initial customer booking accepted')
+            check("("+call(1,customer=customer)+"->>'reason')='customer_conflict'",'duplicate customer remains blocked')
+            check("("+call(0)+"->>'reason')='invalid_seats'",'invalid quantity rejected')
+            reset();sql("UPDATE events SET payment_mode='cash_only',seated_capacity=1,capacity=2;")
+            processes=[subprocess.Popen(cmd,stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,text=True) for _ in range(2)]
+            for proc in processes:
+                proc.stdin.write('SELECT '+call(1)+';');proc.stdin.close()
+            outputs=[]
+            for proc in processes:
+                outputs.append(proc.stdout.read());err=proc.stderr.read()
+                if proc.wait(): raise RuntimeError(err)
+            check('(SELECT count(*) FROM bookings)=1','concurrent requests create only one seated booking')
+            if sum('seated_capacity_changed' in output for output in outputs)!=1: raise RuntimeError('race did not return capacity change')
+            print('PASS concurrent losing request requires guest review')
+            check("NOT has_function_privilege('anon','create_event_booking_v05(uuid,uuid,integer,text,text)','EXECUTE')",'anon cannot call mutation')
+            check("NOT has_function_privilege('authenticated','create_event_booking_v05(uuid,uuid,integer,text,text)','EXECUTE')",'authenticated grant remains restricted')
+            check("has_function_privilege('service_role','create_event_booking_v05(uuid,uuid,integer,text,text)','EXECUTE')",'service role retains execute')
+            sql(ROLLBACK.read_text());reset()
+            check("("+call(1,'standing')+"->>'event_seating_type')='standing'",'rollback restores original standing choice')
+        finally:
+            subprocess.run([str(PG/'pg_ctl'),'-D',str(cluster),'-m','immediate','-w','stop'],check=True,capture_output=True)
+
+if __name__=='__main__': main()

--- a/src/app/api/event-bookings/route.ts
+++ b/src/app/api/event-bookings/route.ts
@@ -459,6 +459,15 @@ export async function POST(request: NextRequest) {
         }
       }
 
+      // Capacity can change before the guest retries. No booking exists for
+      // these results, so let finally release the claim instead of caching it.
+      if (resolvedState === 'blocked' && (
+        resolvedReason === 'seated_capacity_changed' ||
+        resolvedReason === 'standing_not_available_until_seated_full'
+      )) {
+        return createApiResponse(responsePayload, responseStatus)
+      }
+
       try {
         await persistIdempotencyResponse(supabase, idempotencyKey, requestHash, responsePayload)
         claimHeld = false

--- a/src/lib/events/event-payments.ts
+++ b/src/lib/events/event-payments.ts
@@ -793,7 +793,7 @@ export async function sendEventPaymentConfirmationSms(
 ): Promise<EventPaymentSmsMeta> {
   const { data: booking, error: bookingError } = await supabase
     .from('bookings')
-    .select('id, customer_id, event_id, seats, events(id, name, start_datetime, date, time)')
+    .select('id, customer_id, event_id, seats, event_seating_type, events(id, name, start_datetime, date, time)')
     .eq('id', input.bookingId)
     .maybeSingle()
 
@@ -872,7 +872,9 @@ export async function sendEventPaymentConfirmationSms(
   const eventRow = Array.isArray(eventRaw) ? eventRaw[0] : eventRaw
   const eventName = eventRow?.name || input.eventName
   const seats = Math.max(1, Number((booking as any).seats ?? input.seats))
-  const seatLabel = seats === 1 ? 'seat' : 'seats'
+  const seatLabel = booking.event_seating_type === 'standing'
+    ? (seats === 1 ? 'standing ticket' : 'standing tickets')
+    : (seats === 1 ? 'seat' : 'seats')
   const datePart = eventDateFormatted ? ` on ${eventDateFormatted}` : ''
 
   // Multi-type bookings get a compact per-type note (e.g. " (1x Regular, 1x Non-Alcohol)").

--- a/src/services/__tests__/event-bookings.test.ts
+++ b/src/services/__tests__/event-bookings.test.ts
@@ -494,6 +494,20 @@ describe('EventBookingService.createBooking', () => {
     expect(result.smsMeta).toMatchObject({ success: true })
   })
 
+
+  it.each(['confirmed', 'pending_payment'] as const)('names standing tickets in %s SMS', async (state) => {
+    const rpcResult = state === 'confirmed' ? CONFIRMED_RPC_RESULT : PENDING_PAYMENT_RPC_RESULT
+    const supabase = makeSupabaseMock({
+      rpcResults: { create_event_booking_v05: { data: { ...rpcResult, event_seating_type: 'standing' }, error: null } },
+      fromResults: { customers: { data: ACTIVE_CUSTOMER_ROW, error: null } }
+    })
+    vi.mocked(createAdminClient).mockReturnValue(supabase)
+    await EventBookingService.createBooking({ ...BASE_PARAMS, bookingMode: 'communal', seatingPreference: 'standing', shouldSendSms: true })
+    const body = vi.mocked(sendSMS).mock.calls[0][1]
+    expect(body).toContain('2 standing tickets')
+    expect(body).not.toMatch(/undefined|Invalid Date|NaN|\bseats?\b/)
+  })
+
   it('does not send SMS when shouldSendSms=false', async () => {
     const supabase = makeSupabaseMock({
       rpcResults: {

--- a/src/services/event-bookings.ts
+++ b/src/services/event-bookings.ts
@@ -227,21 +227,24 @@ function buildEventBookingSms(
     seats: number
     eventStart: string
     paymentMode?: EventBookingRpcResult['payment_mode']
+    seatingType?: EventBookingRpcResult['event_seating_type']
     paymentLink?: string | null
     manageLink?: string | null
   }
 ): string {
-  const seatWord = payload.seats === 1 ? 'seat' : 'seats'
+  const seatWord = payload.seatingType === 'standing'
+    ? (payload.seats === 1 ? 'standing ticket' : 'standing tickets')
+    : (payload.seats === 1 ? 'seat' : 'seats')
 
   if (state === 'pending_payment') {
     const managePart = payload.manageLink ? ` ${payload.manageLink}` : ''
     if (payload.paymentLink) {
-      return `The Anchor: ${payload.firstName}! ${payload.seats} ${seatWord} held for ${payload.eventName} on ${payload.eventStart} — nice one! Pay here: ${payload.paymentLink}.${managePart}`
+      return `The Anchor: ${payload.firstName}! ${payload.seats} ${seatWord} held for ${payload.eventName} on ${payload.eventStart}, nice one! Pay here: ${payload.paymentLink}.${managePart}`
     }
-    return `The Anchor: ${payload.firstName}! ${payload.seats} ${seatWord} held for ${payload.eventName} on ${payload.eventStart} — nice one! We'll ping you a payment link shortly.${managePart}`
+    return `The Anchor: ${payload.firstName}! ${payload.seats} ${seatWord} held for ${payload.eventName} on ${payload.eventStart}, nice one! We'll ping you a payment link shortly.${managePart}`
   }
 
-  return `The Anchor: ${payload.firstName}! You're in — ${payload.seats} ${seatWord} locked in for ${payload.eventName} on ${payload.eventStart}. See you there!${payload.manageLink ? ` ${payload.manageLink}` : ''}`
+  return `The Anchor: ${payload.firstName}! You're in, ${payload.seats} ${seatWord} locked in for ${payload.eventName} on ${payload.eventStart}. See you there!${payload.manageLink ? ` ${payload.manageLink}` : ''}`
 }
 
 async function sendBookingSmsIfAllowed(
@@ -294,6 +297,7 @@ async function sendBookingSmsIfAllowed(
       seats,
       eventStart,
       paymentMode: bookingResult.payment_mode,
+      seatingType: bookingResult.event_seating_type,
       paymentLink,
       manageLink
     }),

--- a/supabase/migrations/20260906134726_event_standing_after_seated_sold_out.sql
+++ b/supabase/migrations/20260906134726_event_standing_after_seated_sold_out.sql
@@ -1,0 +1,296 @@
+-- Public guests choose standing only after seated places sell out.
+-- Existing event row lock makes the capacity decision atomic with creation.
+CREATE OR REPLACE FUNCTION public.create_event_booking_v05(p_event_id uuid, p_customer_id uuid, p_seats integer, p_source text DEFAULT 'brand_site'::text, p_seating_preference text DEFAULT 'seated'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_event RECORD;
+  v_capacity_snapshot RECORD;
+  v_after_snapshot RECORD;
+  v_existing_active RECORD;
+  v_status text;
+  v_booking_id uuid;
+  v_hold_expires_at timestamptz;
+  v_event_start timestamptz;
+  v_event_end timestamptz;
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+  v_requested_seating text := CASE WHEN p_seating_preference = 'standing' THEN 'standing' ELSE 'seated' END;
+  v_effective_seating text := 'seated';
+  v_allocation jsonb := '{}'::jsonb;
+BEGIN
+  IF p_seats IS NULL OR p_seats < 1 THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_seats');
+  END IF;
+
+  SELECT
+    e.id,
+    e.name,
+    e.capacity,
+    e.payment_mode,
+    e.booking_mode,
+    e.booking_open,
+    e.event_status,
+    e.start_datetime,
+    e.date,
+    e.time,
+    e.end_time,
+    e.duration_minutes
+  INTO v_event
+  FROM public.events e
+  WHERE e.id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_not_found');
+  END IF;
+
+  v_event_start := COALESCE(
+    v_event.start_datetime,
+    CASE
+      WHEN v_event.date IS NOT NULL AND v_event.time IS NOT NULL
+        THEN ((v_event.date::text || ' ' || v_event.time::text)::timestamp AT TIME ZONE 'Europe/London')
+      ELSE NULL
+    END
+  );
+
+  IF v_event_start IS NULL THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_datetime_missing');
+  END IF;
+
+  v_event_end := COALESCE(
+    CASE
+      WHEN v_event.date IS NOT NULL AND v_event.end_time IS NOT NULL
+        THEN ((v_event.date::text || ' ' || v_event.end_time::text)::timestamp AT TIME ZONE 'Europe/London')
+      ELSE NULL
+    END,
+    v_event_start + make_interval(mins => GREATEST(COALESCE(v_event.duration_minutes, 180), 30))
+  );
+
+  IF v_event_end <= v_event_start THEN
+    v_event_end := v_event_end + INTERVAL '1 day';
+  END IF;
+
+  SELECT start_datetime, end_datetime
+  INTO v_window_start, v_window_end
+  FROM public.event_communal_window_v01(p_event_id);
+
+  IF v_window_start IS NULL OR v_window_end IS NULL THEN
+    v_window_start := v_event_start;
+    v_window_end := v_event_end;
+  END IF;
+
+  IF v_event_start <= now() THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+  END IF;
+
+  IF COALESCE(v_event.booking_open, true) = false THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_closed');
+  END IF;
+
+  IF COALESCE(v_event.event_status, 'scheduled') IN ('cancelled', 'draft') THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'not_bookable');
+  END IF;
+
+  SELECT b.id, b.status
+  INTO v_existing_active
+  FROM public.bookings b
+  WHERE b.event_id = p_event_id
+    AND b.customer_id = p_customer_id
+    AND b.status IN ('pending_payment', 'confirmed')
+  ORDER BY b.created_at DESC
+  LIMIT 1
+  FOR UPDATE;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'state', 'blocked',
+      'reason', 'customer_conflict',
+      'booking_id', v_existing_active.id,
+      'status', v_existing_active.status
+    );
+  END IF;
+
+  SELECT *
+  INTO v_capacity_snapshot
+  FROM public.get_event_capacity_snapshot_v05(ARRAY[p_event_id]::uuid[])
+  LIMIT 1;
+
+  IF COALESCE(v_event.booking_mode, 'table') = 'communal' THEN
+    IF v_requested_seating = 'standing' THEN
+      -- Only staff may choose standing while seated places remain.
+      IF COALESCE(p_source, '') NOT IN ('admin', 'foh', 'walk-in')
+         AND v_capacity_snapshot.seated_remaining IS DISTINCT FROM 0 THEN
+        RETURN jsonb_build_object(
+          'state', 'blocked', 'reason', 'standing_not_available_until_seated_full',
+          'seated_remaining', v_capacity_snapshot.seated_remaining,
+          'standing_remaining', v_capacity_snapshot.standing_remaining,
+          'total_remaining', v_capacity_snapshot.total_remaining
+        );
+      END IF;
+
+      IF COALESCE(v_capacity_snapshot.standing_capacity, 0) <= 0 THEN
+        RETURN jsonb_build_object('state', 'blocked', 'reason', 'standing_capacity_not_configured');
+      END IF;
+
+      IF COALESCE(v_capacity_snapshot.standing_remaining, 0) < p_seats THEN
+        RETURN jsonb_build_object(
+          'state', 'full_with_waitlist_option',
+          'reason', 'insufficient_capacity',
+          'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+          'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+          'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+          'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+        );
+      END IF;
+
+      v_effective_seating := 'standing';
+    ELSE
+      IF COALESCE(v_capacity_snapshot.seated_remaining, 0) >= p_seats THEN
+        v_effective_seating := 'seated';
+      ELSIF COALESCE(p_source, '') NOT IN ('admin', 'foh', 'walk-in')
+         AND (COALESCE(v_capacity_snapshot.seated_remaining, 0) > 0
+              OR COALESCE(v_capacity_snapshot.standing_remaining, 0) > 0) THEN
+        -- The guest must review standing tickets before making a new request.
+        RETURN jsonb_build_object(
+          'state', 'blocked', 'reason', 'seated_capacity_changed',
+          'seated_remaining', v_capacity_snapshot.seated_remaining,
+          'standing_remaining', v_capacity_snapshot.standing_remaining,
+          'total_remaining', v_capacity_snapshot.total_remaining
+        );
+      ELSIF COALESCE(v_capacity_snapshot.standing_remaining, 0) >= p_seats THEN
+        v_effective_seating := 'standing';
+      ELSE
+        RETURN jsonb_build_object(
+          'state', 'full_with_waitlist_option',
+          'reason', 'insufficient_capacity',
+          'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+          'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+          'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+          'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+        );
+      END IF;
+    END IF;
+  ELSE
+    IF v_capacity_snapshot.capacity IS NOT NULL
+       AND (v_capacity_snapshot.seats_remaining IS NULL OR v_capacity_snapshot.seats_remaining < p_seats) THEN
+      RETURN jsonb_build_object(
+        'state', 'full_with_waitlist_option',
+        'reason', 'insufficient_capacity',
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0)
+      );
+    END IF;
+  END IF;
+
+  v_status := CASE
+    WHEN COALESCE(v_event.payment_mode, 'free') = 'prepaid' THEN 'pending_payment'
+    ELSE 'confirmed'
+  END;
+
+  IF v_status = 'pending_payment' THEN
+    v_hold_expires_at := LEAST(v_event_start, now() + INTERVAL '24 hours');
+    IF v_hold_expires_at <= now() THEN
+      RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+    END IF;
+  END IF;
+
+  INSERT INTO public.bookings (
+    customer_id,
+    event_id,
+    seats,
+    status,
+    source,
+    event_seating_type,
+    hold_expires_at,
+    created_at,
+    updated_at
+  ) VALUES (
+    p_customer_id,
+    p_event_id,
+    p_seats,
+    v_status,
+    COALESCE(NULLIF(TRIM(p_source), ''), 'brand_site'),
+    v_effective_seating,
+    v_hold_expires_at,
+    now(),
+    now()
+  )
+  RETURNING id INTO v_booking_id;
+
+  IF v_status = 'pending_payment' THEN
+    INSERT INTO public.booking_holds (
+      hold_type,
+      event_booking_id,
+      seats_or_covers_held,
+      status,
+      expires_at,
+      created_at,
+      updated_at
+    ) VALUES (
+      'payment_hold',
+      v_booking_id,
+      p_seats,
+      'active',
+      v_hold_expires_at,
+      now(),
+      now()
+    );
+  END IF;
+
+  IF COALESCE(v_event.booking_mode, 'table') = 'communal' AND v_effective_seating = 'seated' THEN
+    v_allocation := public.allocate_event_communal_seats_v01(
+      p_event_id,
+      v_booking_id,
+      p_seats,
+      v_window_start,
+      v_window_end
+    );
+
+    IF COALESCE(v_allocation->>'state', 'blocked') <> 'confirmed' THEN
+      DELETE FROM public.booking_holds WHERE event_booking_id = v_booking_id;
+      DELETE FROM public.bookings WHERE id = v_booking_id;
+      RETURN jsonb_build_object(
+        'state', 'full_with_waitlist_option',
+        'reason', COALESCE(v_allocation->>'reason', 'insufficient_seated_capacity'),
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+        'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+        'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+        'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+      );
+    END IF;
+  END IF;
+
+  SELECT *
+  INTO v_after_snapshot
+  FROM public.get_event_capacity_snapshot_v05(ARRAY[p_event_id]::uuid[])
+  LIMIT 1;
+
+  RETURN jsonb_build_object(
+    'state', CASE WHEN v_status = 'pending_payment' THEN 'pending_payment' ELSE 'confirmed' END,
+    'booking_id', v_booking_id,
+    'status', v_status,
+    'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+    'event_id', v_event.id,
+    'event_name', v_event.name,
+    'event_start_datetime', v_event_start,
+    'hold_expires_at', v_hold_expires_at,
+    'event_seating_type', v_effective_seating,
+    'seats_remaining', v_after_snapshot.seats_remaining,
+    'seated_remaining', v_after_snapshot.seated_remaining,
+    'standing_remaining', v_after_snapshot.standing_remaining,
+    'total_remaining', v_after_snapshot.total_remaining,
+    'table_name', v_allocation->>'table_name',
+    'table_names', COALESCE(v_allocation->'table_names', '[]'::jsonb),
+    'table_ids', COALESCE(v_allocation->'table_ids', '[]'::jsonb)
+  );
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'customer_conflict');
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.create_event_booking_v05(uuid, uuid, integer, text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_event_booking_v05(uuid, uuid, integer, text, text) TO service_role;

--- a/tasks/standing-ticket-policy/approval.md
+++ b/tasks/standing-ticket-policy/approval.md
@@ -1,0 +1,58 @@
+# Standing ticket policy, production approval packet
+
+Status: exact migration and both application releases approved by the owner on 6 September 2026. Migration not yet applied. Complexity: 4, delivered in three separable pieces: website recovery/UI, booking/SMS application changes, database policy migration. Deploy the compatible application changes before applying the policy migration.
+
+## Exact production target and SQL
+
+Project: the-anchor-management-tools. Ref: `tfcasgxopxegwrabvwat`, matched against `supabase/.temp/project-ref` and the connected project record.
+Migration: `20260906134726_event_standing_after_seated_sold_out.sql`.
+Migration name: `event_standing_after_seated_sold_out`.
+SHA-256: `fc98f0fd9cb61d202452c98ddd29eb12dbef209ac3000300c69e0c792e9c51c6`.
+Exact SQL: [migration](/Users/peterpitcher/Cursor/OJ-AnchorManagementTools/supabase/migrations/20260906134726_event_standing_after_seated_sold_out.sql).
+Rollback SQL: [rollback.sql](/Users/peterpitcher/Cursor/OJ-AnchorManagementTools/tasks/standing-ticket-policy/rollback.sql).
+
+## Live read-only findings
+
+The live `create_event_booking_v05(uuid,uuid,integer,text,text)` was captured on 6 September 2026. It allows standing while seats remain and silently falls back from a seated request when the whole group will not fit. `create_event_booking_v06` calls this function, including the website service path. Current EXECUTE ACL is postgres and service_role only. Latest applied migration at inspection: `20260906130911`.
+
+The Detention Disco snapshot returned 43 seated places and 11 standing places remaining, with 6 seated tickets booked. An aggregate query found no stored standing bookings. No customer details were retrieved for this review.
+
+Schema read: events, bookings, booking_holds. Existing dependent views are customer_communications, recent_reminder_activity and reminder_timing_debug. No table, column or view shape changes.
+
+## Effects, risks and rollback
+
+Only the function body changes. It uses the existing event row lock before reading capacity. No data backfill, row rewrite or existing booking changes. Public and unknown sources can book standing only when seated_remaining is exactly zero; public seated requests never silently become standing. Known staff sources admin, foh and walk-in retain existing flexibility. This source distinction is trusted because the function remains service-role-only and the website API sets its source itself.
+
+New recoverable blocked reasons are seated_capacity_changed and standing_not_available_until_seated_full; both return current capacity. Full sellout keeps the existing waitlist state. The accompanying API change releases idempotency claims for these two non-mutating responses, and website changes require another deliberate guest click.
+
+High-risk statement: CREATE OR REPLACE of an existing SECURITY DEFINER booking function. SECURITY DEFINER and search_path remain unchanged. REVOKE/GRANT restates the existing restricted ACL. No new public or authenticated access. Deployment takes a short function-catalogue lock; normal booking calls retain the existing event-row serialisation. There is no added table-wide lock or data migration.
+
+Rollback executes the captured original function plus its original restricted grants. Rollback changes future booking policy only; existing bookings are untouched. The isolated harness executed both transactional rollback and the rollback file successfully.
+
+## Validation
+
+- `python3 scripts/testing/event-standing-postgres.py`: 28 checks passed. Real PostgreSQL function execution, synthetic tables and fixture capacity/allocation functions. Includes standing and seated, paid holds, blocked/no-write cases, unknown capacity, total sellout, duplicate customer, staff choices, role grants, concurrent last-seat attempts and rollback.
+- Focused Vitest: 46 tests passed in Europe/London and 46 passed in UTC across the service, API and payment-confirmation SMS tests. External effects mocked.
+- Full management tests in both Europe/London and UTC: 733 files passed; 6394 tests passed and 2 skipped in each zone.
+- Management lint passed. Standalone `npx tsc --noEmit` passed with exit 0.
+- Production build passed with exit 0 using `NODE_OPTIONS=--max-old-space-size=8192 npm run build`: compiled, typechecked, generated all 154 static pages and completed build traces. The initial default-heap attempt exhausted Node memory during type validation. No configuration file was changed.
+
+The fixture allocator is deliberately simplified. This proves the policy and row lock, not a new production booking or provider delivery. No production writes, live bookings, messages or payments were run.
+
+## Post-apply verification plan
+
+Recheck migration history, live function definition and ACL. Re-run the read-only anonymous surface assertion and capacity snapshot. Check the website live page and read-only capacity response. A real booking/provider delivery test remains outside this read-only verification unless separately authorised with a dedicated test record and cleanup.
+
+## Files changed
+
+- src/services/event-bookings.ts
+- src/lib/events/event-payments.ts
+- src/app/api/event-bookings/route.ts
+- src/services/__tests__/event-bookings.test.ts
+- tests/lib/eventPaymentSmsSafetyMeta.test.ts
+- tests/api/eventBookingsRouteSmsMeta.test.ts
+- supabase/migrations/20260906134726_event_standing_after_seated_sold_out.sql
+- scripts/testing/event-standing-postgres.py
+- tasks/standing-ticket-policy/approval.md and rollback.sql
+
+All pre-existing unrelated dirty files were left untouched. Email wording already uses tickets and was left unchanged. Staff booking source paths were inspected and left unchanged. No new or changed table schema and no other migration applied.

--- a/tasks/standing-ticket-policy/rollback.sql
+++ b/tasks/standing-ticket-policy/rollback.sql
@@ -1,0 +1,274 @@
+CREATE OR REPLACE FUNCTION public.create_event_booking_v05(p_event_id uuid, p_customer_id uuid, p_seats integer, p_source text DEFAULT 'brand_site'::text, p_seating_preference text DEFAULT 'seated'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_event RECORD;
+  v_capacity_snapshot RECORD;
+  v_after_snapshot RECORD;
+  v_existing_active RECORD;
+  v_status text;
+  v_booking_id uuid;
+  v_hold_expires_at timestamptz;
+  v_event_start timestamptz;
+  v_event_end timestamptz;
+  v_window_start timestamptz;
+  v_window_end timestamptz;
+  v_requested_seating text := CASE WHEN p_seating_preference = 'standing' THEN 'standing' ELSE 'seated' END;
+  v_effective_seating text := 'seated';
+  v_allocation jsonb := '{}'::jsonb;
+BEGIN
+  IF p_seats IS NULL OR p_seats < 1 THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'invalid_seats');
+  END IF;
+
+  SELECT
+    e.id,
+    e.name,
+    e.capacity,
+    e.payment_mode,
+    e.booking_mode,
+    e.booking_open,
+    e.event_status,
+    e.start_datetime,
+    e.date,
+    e.time,
+    e.end_time,
+    e.duration_minutes
+  INTO v_event
+  FROM public.events e
+  WHERE e.id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_not_found');
+  END IF;
+
+  v_event_start := COALESCE(
+    v_event.start_datetime,
+    CASE
+      WHEN v_event.date IS NOT NULL AND v_event.time IS NOT NULL
+        THEN ((v_event.date::text || ' ' || v_event.time::text)::timestamp AT TIME ZONE 'Europe/London')
+      ELSE NULL
+    END
+  );
+
+  IF v_event_start IS NULL THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_datetime_missing');
+  END IF;
+
+  v_event_end := COALESCE(
+    CASE
+      WHEN v_event.date IS NOT NULL AND v_event.end_time IS NOT NULL
+        THEN ((v_event.date::text || ' ' || v_event.end_time::text)::timestamp AT TIME ZONE 'Europe/London')
+      ELSE NULL
+    END,
+    v_event_start + make_interval(mins => GREATEST(COALESCE(v_event.duration_minutes, 180), 30))
+  );
+
+  IF v_event_end <= v_event_start THEN
+    v_event_end := v_event_end + INTERVAL '1 day';
+  END IF;
+
+  SELECT start_datetime, end_datetime
+  INTO v_window_start, v_window_end
+  FROM public.event_communal_window_v01(p_event_id);
+
+  IF v_window_start IS NULL OR v_window_end IS NULL THEN
+    v_window_start := v_event_start;
+    v_window_end := v_event_end;
+  END IF;
+
+  IF v_event_start <= now() THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+  END IF;
+
+  IF COALESCE(v_event.booking_open, true) = false THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'booking_closed');
+  END IF;
+
+  IF COALESCE(v_event.event_status, 'scheduled') IN ('cancelled', 'draft') THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'not_bookable');
+  END IF;
+
+  SELECT b.id, b.status
+  INTO v_existing_active
+  FROM public.bookings b
+  WHERE b.event_id = p_event_id
+    AND b.customer_id = p_customer_id
+    AND b.status IN ('pending_payment', 'confirmed')
+  ORDER BY b.created_at DESC
+  LIMIT 1
+  FOR UPDATE;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'state', 'blocked',
+      'reason', 'customer_conflict',
+      'booking_id', v_existing_active.id,
+      'status', v_existing_active.status
+    );
+  END IF;
+
+  SELECT *
+  INTO v_capacity_snapshot
+  FROM public.get_event_capacity_snapshot_v05(ARRAY[p_event_id]::uuid[])
+  LIMIT 1;
+
+  IF COALESCE(v_event.booking_mode, 'table') = 'communal' THEN
+    IF v_requested_seating = 'standing' THEN
+      IF COALESCE(v_capacity_snapshot.standing_capacity, 0) <= 0 THEN
+        RETURN jsonb_build_object('state', 'blocked', 'reason', 'standing_capacity_not_configured');
+      END IF;
+
+      IF COALESCE(v_capacity_snapshot.standing_remaining, 0) < p_seats THEN
+        RETURN jsonb_build_object(
+          'state', 'full_with_waitlist_option',
+          'reason', 'insufficient_capacity',
+          'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+          'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+          'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+          'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+        );
+      END IF;
+
+      v_effective_seating := 'standing';
+    ELSE
+      IF COALESCE(v_capacity_snapshot.seated_remaining, 0) >= p_seats THEN
+        v_effective_seating := 'seated';
+      ELSIF COALESCE(v_capacity_snapshot.standing_remaining, 0) >= p_seats THEN
+        v_effective_seating := 'standing';
+      ELSE
+        RETURN jsonb_build_object(
+          'state', 'full_with_waitlist_option',
+          'reason', 'insufficient_capacity',
+          'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+          'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+          'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+          'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+        );
+      END IF;
+    END IF;
+  ELSE
+    IF v_capacity_snapshot.capacity IS NOT NULL
+       AND (v_capacity_snapshot.seats_remaining IS NULL OR v_capacity_snapshot.seats_remaining < p_seats) THEN
+      RETURN jsonb_build_object(
+        'state', 'full_with_waitlist_option',
+        'reason', 'insufficient_capacity',
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0)
+      );
+    END IF;
+  END IF;
+
+  v_status := CASE
+    WHEN COALESCE(v_event.payment_mode, 'free') = 'prepaid' THEN 'pending_payment'
+    ELSE 'confirmed'
+  END;
+
+  IF v_status = 'pending_payment' THEN
+    v_hold_expires_at := LEAST(v_event_start, now() + INTERVAL '24 hours');
+    IF v_hold_expires_at <= now() THEN
+      RETURN jsonb_build_object('state', 'blocked', 'reason', 'event_started');
+    END IF;
+  END IF;
+
+  INSERT INTO public.bookings (
+    customer_id,
+    event_id,
+    seats,
+    status,
+    source,
+    event_seating_type,
+    hold_expires_at,
+    created_at,
+    updated_at
+  ) VALUES (
+    p_customer_id,
+    p_event_id,
+    p_seats,
+    v_status,
+    COALESCE(NULLIF(TRIM(p_source), ''), 'brand_site'),
+    v_effective_seating,
+    v_hold_expires_at,
+    now(),
+    now()
+  )
+  RETURNING id INTO v_booking_id;
+
+  IF v_status = 'pending_payment' THEN
+    INSERT INTO public.booking_holds (
+      hold_type,
+      event_booking_id,
+      seats_or_covers_held,
+      status,
+      expires_at,
+      created_at,
+      updated_at
+    ) VALUES (
+      'payment_hold',
+      v_booking_id,
+      p_seats,
+      'active',
+      v_hold_expires_at,
+      now(),
+      now()
+    );
+  END IF;
+
+  IF COALESCE(v_event.booking_mode, 'table') = 'communal' AND v_effective_seating = 'seated' THEN
+    v_allocation := public.allocate_event_communal_seats_v01(
+      p_event_id,
+      v_booking_id,
+      p_seats,
+      v_window_start,
+      v_window_end
+    );
+
+    IF COALESCE(v_allocation->>'state', 'blocked') <> 'confirmed' THEN
+      DELETE FROM public.booking_holds WHERE event_booking_id = v_booking_id;
+      DELETE FROM public.bookings WHERE id = v_booking_id;
+      RETURN jsonb_build_object(
+        'state', 'full_with_waitlist_option',
+        'reason', COALESCE(v_allocation->>'reason', 'insufficient_seated_capacity'),
+        'seats_remaining', COALESCE(v_capacity_snapshot.seats_remaining, 0),
+        'seated_remaining', COALESCE(v_capacity_snapshot.seated_remaining, 0),
+        'standing_remaining', COALESCE(v_capacity_snapshot.standing_remaining, 0),
+        'total_remaining', COALESCE(v_capacity_snapshot.total_remaining, 0)
+      );
+    END IF;
+  END IF;
+
+  SELECT *
+  INTO v_after_snapshot
+  FROM public.get_event_capacity_snapshot_v05(ARRAY[p_event_id]::uuid[])
+  LIMIT 1;
+
+  RETURN jsonb_build_object(
+    'state', CASE WHEN v_status = 'pending_payment' THEN 'pending_payment' ELSE 'confirmed' END,
+    'booking_id', v_booking_id,
+    'status', v_status,
+    'payment_mode', COALESCE(v_event.payment_mode, 'free'),
+    'event_id', v_event.id,
+    'event_name', v_event.name,
+    'event_start_datetime', v_event_start,
+    'hold_expires_at', v_hold_expires_at,
+    'event_seating_type', v_effective_seating,
+    'seats_remaining', v_after_snapshot.seats_remaining,
+    'seated_remaining', v_after_snapshot.seated_remaining,
+    'standing_remaining', v_after_snapshot.standing_remaining,
+    'total_remaining', v_after_snapshot.total_remaining,
+    'table_name', v_allocation->>'table_name',
+    'table_names', COALESCE(v_allocation->'table_names', '[]'::jsonb),
+    'table_ids', COALESCE(v_allocation->'table_ids', '[]'::jsonb)
+  );
+EXCEPTION
+  WHEN unique_violation THEN
+    RETURN jsonb_build_object('state', 'blocked', 'reason', 'customer_conflict');
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.create_event_booking_v05(uuid, uuid, integer, text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_event_booking_v05(uuid, uuid, integer, text, text) TO service_role;
+

--- a/tests/api/eventBookingsRouteSmsMeta.test.ts
+++ b/tests/api/eventBookingsRouteSmsMeta.test.ts
@@ -93,6 +93,24 @@ describe('event booking route SMS safety meta', () => {
     vi.clearAllMocks()
   })
 
+  it.each(['seated_capacity_changed', 'standing_not_available_until_seated_full'])('releases capacity retry claim for %s', async (reason) => {
+    const eventId = '11111111-1111-4111-8111-111111111111'
+    vi.mocked(ensureCustomerForPhone).mockResolvedValue({ customerId: '22222222-2222-4222-8222-222222222222' })
+    const supabase = {
+      from: vi.fn(() => ({ select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { id: eventId, booking_mode: 'communal' }, error: null }) })) })) })),
+      rpc: vi.fn().mockResolvedValue({ data: { state: 'blocked', reason, seated_remaining: 0, standing_remaining: 3, total_remaining: 3 }, error: null })
+    }
+    vi.mocked(createAdminClient).mockReturnValue(supabase as never)
+    const response = await POST(new NextRequest('https://example.com/api/event-bookings', {
+      method: 'POST', headers: { 'content-type': 'application/json', 'idempotency-key': 'capacity-retry' },
+      body: JSON.stringify({ event_id: eventId, phone: '+447700900123', first_name: 'Pat', seats: 2 })
+    }))
+    expect(await response.json()).toMatchObject({ data: { state: 'blocked', reason, seated_remaining: 0, standing_remaining: 3 } })
+    expect(persistIdempotencyResponse).not.toHaveBeenCalled()
+    expect(releaseIdempotencyClaim).toHaveBeenCalledOnce()
+    expect(sendSMS).not.toHaveBeenCalled()
+  })
+
   it('surfaces logging_failed meta without returning a retry-triggering 500', async () => {
     const eventId = '11111111-1111-4111-8111-111111111111'
     const customerId = '22222222-2222-4222-8222-222222222222'

--- a/tests/lib/eventPaymentSmsSafetyMeta.test.ts
+++ b/tests/lib/eventPaymentSmsSafetyMeta.test.ts
@@ -37,10 +37,11 @@ vi.mock('@/lib/logger', () => ({
 import { sendSMS } from '@/lib/twilio'
 import { sendEventPaymentConfirmationSms, sendEventPaymentRetrySms } from '@/lib/events/event-payments'
 
-function buildSupabaseForConfirmation() {
+function buildSupabaseForConfirmation(seatingType: 'seated' | 'standing' = 'seated') {
   const bookingMaybeSingle = vi.fn().mockResolvedValue({
     data: {
       id: 'booking-1',
+      event_seating_type: seatingType,
       customer_id: 'customer-1',
       event_id: 'event-1',
     },
@@ -144,6 +145,17 @@ function buildSupabaseForRetry() {
 describe('event payment SMS safety meta logging', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+
+  it.each([1, 2])('labels %i standing tickets in payment confirmation', async (seats) => {
+    vi.mocked(sendSMS).mockResolvedValueOnce({ success: true })
+    await sendEventPaymentConfirmationSms(buildSupabaseForConfirmation('standing') as never, {
+      bookingId: 'booking-1', eventName: 'Test Event', seats
+    })
+    const body = vi.mocked(sendSMS).mock.calls[0][1]
+    expect(body).toContain(`${seats} standing ticket${seats === 1 ? '' : 's'}`)
+    expect(body).not.toMatch(/undefined|Invalid Date|NaN|\bseats?\b/)
   })
 
   it('logs an error when event payment confirmation SMS returns logging_failed', async () => {


### PR DESCRIPTION
## What changed
Public standing tickets become available only after seated capacity reaches zero. Guests whose seated request no longer fits receive updated capacity and can review their booking; retries remain possible and standing confirmation texts say tickets.

## Why
Prevent unexpected standing bookings and unnecessary ticket choices on the website.

## Testing done
- 28 real PostgreSQL policy, concurrency, permissions and rollback checks passed.
- Final latest-main release: lint, types, production build and both London/UTC suites passed (759 files, 6829 passed, 2 skipped per zone).
- Website fixture exercised seated, standing, capacity loss and failed requests without sending customer messages.

## Complexity score
M, separated application changes and database policy.

## Breaking changes
None. Deploy compatible apps before applying the migration.

## Migration risk
High: replaces an existing restricted SECURITY DEFINER function. Exact SQL checksum and rollback explicitly approved by the owner. Apply only through Supabase MCP after app deployment; no live bookings or messages in verification. See tasks/standing-ticket-policy/approval.md.
