### PR TITLE
fix: smaller QR branding and readable BOOK NOW downloads

### DIFF
--- a/src/app/(authenticated)/events/_components/ArtworkBrandingModal.test.tsx
+++ b/src/app/(authenticated)/events/_components/ArtworkBrandingModal.test.tsx
@@ -338,7 +338,7 @@ describe('ArtworkBrandingModal, QR code', () => {
     fireEvent.change(slider, { target: { value: '5' } })
 
     // data-code-rect, not data-rect: the footprint that is dragged and outlined
-    // is the code plus its BOOK NOW strip, and the 40mm minimum is about the
+    // is the code plus its BOOK NOW strip, and the 21mm minimum is about the
     // scannable square alone.
     const [, , width] = (screen.getByTestId('qr-overlay').getAttribute('data-code-rect') ?? '')
       .split(',')
@@ -363,10 +363,7 @@ describe('ArtworkBrandingModal, QR code', () => {
     renderModal()
 
     const slider = screen.getByLabelText('QR size') as HTMLInputElement
-    // The route's own schema is z.number().min(0.1905).max(0.4). Sending
-    // qrMinWidthFrac() itself (0.190476...) would be refused with a 400, so the
-    // control floor has to sit above it, not on it.
-    expect(Number(slider.min) / 100).toBeGreaterThanOrEqual(0.1905)
+    expect(Number(slider.min) / 100).toBeGreaterThanOrEqual(0.1)
     expect(Number(slider.max) / 100).toBeLessThanOrEqual(0.4)
 
     // A typed value outside the range is pulled back in rather than posted.
@@ -375,8 +372,23 @@ describe('ArtworkBrandingModal, QR code', () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
-    expect(body.qr.widthFrac).toBeGreaterThanOrEqual(0.1905)
+    expect(body.qr.widthFrac).toBeGreaterThanOrEqual(0.1)
     expect(body.qr.widthFrac).toBeLessThanOrEqual(0.4)
+  })
+
+  it('saves a 10% QR from either size control', async () => {
+    const user = userEvent.setup()
+    renderModal()
+    const slider = screen.getByLabelText('QR size') as HTMLInputElement
+    expect(slider.min).toBe('10')
+    fireEvent.change(slider, { target: { value: '10' } })
+    expect((screen.getByLabelText('QR width (%)') as HTMLInputElement).value).toBe('10')
+    fireEvent.change(screen.getByLabelText('QR width (%)'), { target: { value: '9' } })
+    expect(slider.value).toBe('10')
+    await user.click(screen.getByRole('button', { name: /Save branding/ }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const body = JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body.qr.widthFrac).toBe(0.1)
   })
 
   it('shows the destination the printed code will point at', () => {
@@ -386,7 +398,7 @@ describe('ArtworkBrandingModal, QR code', () => {
     expect(screen.getByText('https://l.the-anchor.pub/po3f2a1b')).toBeInTheDocument()
   })
 
-  it('shows the printed millimetre size so 40mm can be checked by eye', () => {
+  it('shows the printed millimetre size can be checked by eye', () => {
     renderModal()
     expect(screen.getByText(/mm on the A4 poster/)).toBeInTheDocument()
   })
@@ -514,7 +526,7 @@ describe('ArtworkBrandingModal, what the preview shows', () => {
     expect(strip.style.width).toBe(`${(stripRect.width / block.width) * 100}%`)
 
     // The whole block is the drag footprint; the stored width still means the
-    // code, which is what the 40mm print minimum is measured against.
+    // code, which is what the 21mm print minimum is measured against.
     const overlay = screen.getByTestId('qr-overlay')
     expect(overlay).toHaveAttribute('data-rect', rectString(block))
     expect(overlay).toHaveAttribute('data-code-rect', rectString(code))

--- a/src/app/(authenticated)/events/_components/ArtworkBrandingModal.tsx
+++ b/src/app/(authenticated)/events/_components/ArtworkBrandingModal.tsx
@@ -121,14 +121,7 @@ const NOMINAL_PREVIEW_WIDTH_PX = 600
 /** How much of the strip's displayed width the label glyphs take. */
 const QR_STRIP_FONT_FRAC = 0.6
 
-/**
- * The QR size controls work in whole percent, and these are their bounds.
- *
- * The floor is the first whole percent at or above the 40mm print minimum.
- * `qrMinWidthFrac()` is the enforced floor (0.1905, rounded up from 40/210 so a
- * code can never print under 40mm) and matches both the route's Zod bound and
- * the database CHECK, so the exact minimum is now accepted rather than 400ing.
- */
+/** Whole-percent controls share the server's minimum width. */
 const MIN_QR_WIDTH_PERCENT = Math.ceil(qrMinWidthFrac() * 100)
 const MAX_QR_WIDTH_PERCENT = 40
 
@@ -227,7 +220,7 @@ export function ArtworkBrandingModal({
   const config = EVENT_IMAGE_VARIANTS[variant]
   const imageW = config.targetWidth
   const imageH = config.targetHeight
-  // The QR is a print device: a 40mm minimum only means anything on the poster.
+  // The QR is a print device: a 21mm minimum only means anything on the poster.
   const isPoster = variant === 'print_poster'
 
   /**
@@ -340,7 +333,7 @@ export function ArtworkBrandingModal({
 
   /**
    * The scannable square. `qr_width_frac` and the stored centre both describe
-   * THIS rect and nothing else, which is what keeps the 40mm print minimum and
+   * THIS rect and nothing else, which is what keeps the 21mm print minimum and
    * the database CHECK meaning what they say. `qrCodeRectWithinCanvas` shifts it
    * back when the BOOK NOW strip beside it would otherwise hang off the edge.
    */

--- a/src/app/api/events/[id]/artwork/composite/route.ts
+++ b/src/app/api/events/[id]/artwork/composite/route.ts
@@ -30,7 +30,7 @@ import {
 } from '@/lib/events/artwork/branding-service'
 // The placement bounds come from geometry.ts rather than being written out
 // again here. They are the same numbers as the CHECK constraints in
-// 20260906095746_event_image_branding.sql, and a copy that drifts would either
+// the branding and QR size migrations, and a copy that drifts would either
 // reject a legal placement with a 400 or accept one the database then refuses.
 import {
   LOGO_MAX_WIDTH_FRAC,
@@ -61,7 +61,7 @@ const variantSchema = z.enum(
 
 /**
  * Every bound below matches a CHECK constraint in
- * `20260906095746_event_image_branding.sql` exactly.
+ * `the branding and QR size migrations` exactly.
  *
  * Kept in step on purpose: a value that passes here is guaranteed to survive the
  * UPDATE that records it, so the only way to hit a constraint violation is a
@@ -90,8 +90,7 @@ const logoSchema = z.object({
 const qrSchema = z.object({
   centreXFrac: z.number().min(0).max(1),
   centreYFrac: z.number().min(0).max(1),
-  // QR_MIN_WIDTH_FRAC is the 40mm print minimum at A4 (40 / 210, rounded up so a code can
-  // never print under 40mm). 0.40 is a sanity guard.
+  // Share the editor's 10% minimum and 40% maximum.
   widthFrac: z.number().min(QR_MIN_WIDTH_FRAC).max(QR_MAX_WIDTH_FRAC),
 })
 

--- a/src/lib/events/artwork/branding-service.test.ts
+++ b/src/lib/events/artwork/branding-service.test.ts
@@ -1091,6 +1091,22 @@ describe('POST /api/events/[id]/artwork/composite', () => {
     expect(revertedBody.originalStoragePath).toBeNull()
   })
 
+  it('saves a poster QR at exactly 10% through the HTTP route', async () => {
+    await seedVariant('print_poster')
+    const response = await POST(
+      request({
+        variant: 'print_poster',
+        logo: null,
+        qr: { centreXFrac: 0.5, centreYFrac: 0.5, widthFrac: 0.1 },
+      }) as never,
+      context()
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.success).toBe(true)
+    expect(body.placementSaved).toBe(true)
+  })
+
   it('rejects a malformed placement with a stable code', async () => {
     const tooWide = await POST(
       request({
@@ -1107,7 +1123,7 @@ describe('POST /api/events/[id]/artwork/composite', () => {
       request({
         variant: 'print_poster',
         logo: null,
-        qr: { centreXFrac: 0.5, centreYFrac: 0.5, widthFrac: 0.19 },
+        qr: { centreXFrac: 0.5, centreYFrac: 0.5, widthFrac: 0.09 },
       }) as never,
       context()
     )

--- a/src/lib/events/artwork/composite.test.ts
+++ b/src/lib/events/artwork/composite.test.ts
@@ -488,7 +488,7 @@ describe('renderQrAtWidth', () => {
   it('renders at exactly the requested width, never resampled from 1200', async () => {
     const sharp = (await import('sharp')).default
 
-    for (const width of [473, 620, 900]) {
+    for (const width of [106, 248, 473, 620, 900]) {
       const metadata = await sharp(await renderQrAtWidth(BOOKING_URL, width)).metadata()
       expect(metadata.width).toBe(width)
       expect(metadata.height).toBe(width)
@@ -577,14 +577,14 @@ describe('compositeArtwork, QR code on the poster', () => {
     expect(result.failure.detail).toContain('logo')
   })
 
-  it('rejects a QR under the 40mm print minimum', async () => {
+  it('rejects a QR under the 10% width minimum', async () => {
     const source = await createSource(POSTER.targetWidth, POSTER.targetHeight)
     const minimum = qrMinWidthPx(POSTER.targetWidth)
 
     const result = await compositeArtwork(
       source,
       posterSpec({
-        qr: { centreXFrac: 0.5, centreYFrac: 0.82, widthFrac: 0.1, url: BOOKING_URL },
+        qr: { centreXFrac: 0.5, centreYFrac: 0.82, widthFrac: 0.09, url: BOOKING_URL },
       })
     )
 
@@ -1007,18 +1007,49 @@ describe('compositeArtwork, the BOOK NOW strip', () => {
     expect((middle[0] + middle[1] + middle[2]) / 3).toBeLessThan(40)
   })
 
-  it('states its font family and takes its label from geometry.ts', () => {
+  it('uses font-independent outlines and takes its label from geometry.ts', () => {
     const svg = qrStripSvg(STRIP).toString('utf8')
 
     expect(svg).toContain(QR_STRIP_LABEL)
-    // A generic family, never a named face that may be absent on Vercel.
-    expect(svg).toContain('font-family="sans-serif"')
+    // Serverless runtimes can have no fonts at all.
+    expect(svg).not.toContain('<text')
+    expect(svg).not.toContain('font-family')
+    expect(svg.match(/<path /g)).toHaveLength(7)
     // Reads bottom to top, the usual convention for a vertical label.
     expect(svg).toContain('rotate(-90')
     // Sized to the rect geometry.ts computed, so the rasterised strip lands
     // exactly where the block says it does.
     expect(svg).toContain(`width="${STRIP.width}"`)
     expect(svg).toContain(`height="${STRIP.height}"`)
+  })
+
+  it.each([0.1, 0.25])('renders seven distinct letters, not missing-font boxes, at %s width', async (widthFrac) => {
+    const sharp = (await import('sharp')).default
+    const code = qrCodeRectWithinCanvas(POSTER.targetWidth, POSTER.targetHeight, 0.5, 0.5, widthFrac)
+    const strip = qrStripRect(code)
+    // Rotate the real raster back to a horizontal word to separate its glyphs.
+    const image = await decode(await sharp(qrStripSvg(strip)).rotate(90).png().toBuffer())
+    const letterWidths: number[] = []
+    let currentWidth = 0
+    for (let x = 0; x < image.width; x += 1) {
+      let hasInk = false
+      for (let y = 0; y < image.height; y += 1) {
+        if (pixelAt(image, x, y)[0] > 200) hasInk = true
+      }
+      if (hasInk) currentWidth += 1
+      else if (currentWidth > 0) {
+        letterWidths.push(currentWidth)
+        currentWidth = 0
+      }
+    }
+    if (currentWidth > 0) letterWidths.push(currentWidth)
+
+    expect(letterWidths).toHaveLength(7)
+    // Missing-glyph squares previously passed a white-pixel coverage check.
+    // A real W is substantially wider than an O; identical boxes cannot pass.
+    expect(letterWidths[6]).toBeGreaterThan(letterWidths[1] * 1.25)
+    expect(Math.abs(letterWidths[1] - letterWidths[2])).toBeLessThanOrEqual(1)
+    expect(Math.abs(letterWidths[1] - letterWidths[5])).toBeLessThanOrEqual(1)
   })
 
   it('rasterises the strip at exactly the rect size, with a legible label', async () => {
@@ -1029,7 +1060,7 @@ describe('compositeArtwork, the BOOK NOW strip', () => {
     expect(metadata.width).toBe(STRIP.width)
     expect(metadata.height).toBe(STRIP.height)
 
-    // At the 40mm print minimum on A4 the strip is narrower than this one, so
+    // At the 10% width minimum on A4 the strip is narrower than this one, so
     // check the label is still worth printing there too.
     const smallest = qrStripRect({
       x: 0,
@@ -1092,7 +1123,7 @@ describe('composite.ts implementation guarantees', () => {
     expect(sourceText).not.toContain('0.22')
 
     // The numbers geometry.ts owns must not appear here at all: the inset
-    // fraction, the logo aspect ratio, the 40mm minimum and the A4 width.
+    // fraction, the logo aspect ratio, the 10% minimum and the A4 width.
     expect(sourceText).not.toContain('0.04')
     expect(sourceText).not.toContain('934 / 421')
     expect(sourceText).not.toContain('/ 210')

--- a/src/lib/events/artwork/composite.ts
+++ b/src/lib/events/artwork/composite.ts
@@ -163,42 +163,40 @@ const QR_STRIP_BACKGROUND = '#000000'
 const QR_STRIP_INK = '#ffffff'
 
 /**
- * The font family written into the strip's SVG.
- *
- * A generic family, not a named face. Vercel's runtime carries a different set
- * of fonts from a developer laptop, and naming a face that is absent there would
- * silently fall back to something with different metrics, which is exactly the
- * drift the strip sizing below is built to avoid.
+ * Original vector outlines for the fixed label, in a 100-unit cap height.
+ * Sharp's SVG renderer cannot rely on system fonts being installed on Vercel:
+ * even generic sans-serif can render missing-glyph squares there. Paths keep
+ * the exported lettering identical in every runtime, without a font asset.
  */
-const QR_STRIP_FONT_STACK = 'sans-serif'
+const QR_LABEL_GLYPHS: Record<string, { width: number; path: string }> = {
+  B: {
+    width: 70,
+    path: 'M0 0H36Q66 0 66 25Q66 41 53 48Q70 54 70 74Q70 100 37 100H0Z ' +
+      'M19 17V40H34Q47 40 47 28Q47 17 34 17Z M19 57V83H36Q50 83 50 70Q50 57 36 57Z',
+  },
+  O: {
+    width: 70,
+    path: 'M35 0Q70 0 70 50Q70 100 35 100Q0 100 0 50Q0 0 35 0Z ' +
+      'M35 18Q19 18 19 50Q19 82 35 82Q51 82 51 50Q51 18 35 18Z',
+  },
+  K: {
+    width: 70,
+    path: 'M0 0H19V40L47 0H70L35 48L70 100H47L19 59V100H0Z',
+  },
+  N: {
+    width: 70,
+    path: 'M0 100V0H20L51 64V0H70V100H50L19 36V100Z',
+  },
+  W: {
+    width: 100,
+    path: 'M0 0H20L31 69L42 12H58L69 69L80 0H100L80 100H60L50 48L40 100H20Z',
+  },
+}
 
-/**
- * Text size as a fraction of the strip WIDTH, which is the strip's short edge
- * and therefore what the rotated label's height has to fit inside.
- *
- * 0.55 leaves the label at roughly two thirds of the strip's length in the
- * fonts we have measured, so a fallback face up to about a third wider still
- * fits without touching the ends. At the 40mm print minimum on A4 the strip is
- * 104px wide and this gives a 57px label, which is comfortably legible.
- */
-const QR_STRIP_FONT_FRAC_OF_STRIP_WIDTH = 0.55
-
-/** Letter spacing as a fraction of the font size. Enough to read as a label. */
-const QR_STRIP_TRACKING_FRAC_OF_FONT = 0.06
-
-/**
- * How far below the strip's centre line the text baseline sits, as a fraction of
- * the font size, so the label is optically centred across the strip.
- *
- * Roughly half a capital's height. `dominant-baseline` would say this more
- * directly but is not honoured by every SVG rasteriser, and a label that drifts
- * to one edge on the server while looking centred locally is worse than an
- * approximation that both agree on.
- */
-const QR_STRIP_BASELINE_FRAC_OF_FONT = 0.35
-
-/** Below this the label is not worth drawing at all. */
-const QR_STRIP_MIN_FONT_PX = 8
+const QR_LABEL_CAP_HEIGHT = 100
+const QR_LABEL_TRACKING = 10
+const QR_LABEL_SPACE_WIDTH = 40
+const QR_LABEL_HEIGHT_FRAC_OF_STRIP_WIDTH = 0.55
 
 /**
  * How far the shadow's own frame is padded beyond the logo rectangle, in pixels.
@@ -350,24 +348,35 @@ async function renderLogoShadow(
  * the markup.
  */
 export function qrStripSvg(strip: Rect): Buffer {
-  const fontSize = Math.max(
-    QR_STRIP_MIN_FONT_PX,
-    Math.round(strip.width * QR_STRIP_FONT_FRAC_OF_STRIP_WIDTH)
+  let labelWidth = 0
+  const paths = Array.from(QR_STRIP_LABEL, (letter) => {
+    const x = labelWidth
+    if (letter === ' ') {
+      labelWidth += QR_LABEL_SPACE_WIDTH + QR_LABEL_TRACKING
+      return ''
+    }
+    const glyph = QR_LABEL_GLYPHS[letter]
+    if (!glyph) throw new Error(`No vector outline for QR label character: ${letter}`)
+    labelWidth += glyph.width + QR_LABEL_TRACKING
+    return `<path transform="translate(${x} 0)" d="${glyph.path}"/>`
+  }).join('')
+  labelWidth -= QR_LABEL_TRACKING
+
+  const scale = Math.min(
+    strip.width * QR_LABEL_HEIGHT_FRAC_OF_STRIP_WIDTH / QR_LABEL_CAP_HEIGHT,
+    strip.height * 0.9 / labelWidth
   )
-  const tracking = Math.max(1, Math.round(fontSize * QR_STRIP_TRACKING_FRAC_OF_FONT))
   const centreX = strip.width / 2
   const centreY = strip.height / 2
-  const baselineY = centreY + Math.round(fontSize * QR_STRIP_BASELINE_FRAC_OF_FONT)
 
   return Buffer.from(
     `<svg xmlns="http://www.w3.org/2000/svg" width="${strip.width}" height="${strip.height}" ` +
       `viewBox="0 0 ${strip.width} ${strip.height}">` +
+      `<title>${QR_STRIP_LABEL}</title>` +
       `<rect x="0" y="0" width="${strip.width}" height="${strip.height}" fill="${QR_STRIP_BACKGROUND}"/>` +
-      `<g transform="rotate(-90 ${centreX} ${centreY})">` +
-      `<text x="${centreX}" y="${baselineY}" fill="${QR_STRIP_INK}" ` +
-      `font-family="${QR_STRIP_FONT_STACK}" font-size="${fontSize}" font-weight="700" ` +
-      `letter-spacing="${tracking}" text-anchor="middle">${QR_STRIP_LABEL}</text>` +
-      `</g>` +
+      `<g transform="translate(${centreX} ${centreY}) rotate(-90) scale(${scale}) ` +
+      `translate(${-labelWidth / 2} ${-QR_LABEL_CAP_HEIGHT / 2})" ` +
+      `fill="${QR_STRIP_INK}" fill-rule="evenodd">${paths}</g>` +
       `</svg>`,
     'utf8'
   )
@@ -448,7 +457,7 @@ export async function renderQrAtWidth(url: string, widthPx: number): Promise<Buf
  * The QR placement is validated here, server side, before anything is drawn.
  * The slider in the browser is a convenience, not the enforcement point: it can
  * be bypassed, it can be out of date, and an unscannable poster is only
- * discovered after it has been printed. The 40mm print minimum is applied to
+ * discovered after it has been printed. The 10% width minimum is applied to
  * every variant that asks for a QR code, not just the poster, on the grounds
  * that a code too small to scan is a defect on any medium.
  */

--- a/src/lib/events/artwork/geometry.test.ts
+++ b/src/lib/events/artwork/geometry.test.ts
@@ -255,33 +255,18 @@ describe('reservedLogoRect', () => {
 })
 
 describe('qrMinWidthPx and qrMinWidthFrac', () => {
-  it('rounds UP on the A4 poster, 473 not 472', () => {
-    // 2480 * 40 / 210 = 472.38. A floor would print at 39.9mm, under the minimum.
-    expect(qrMinWidthPx(2480)).toBe(473)
-    expect(Math.floor((2480 * QR_MIN_MM) / A4_WIDTH_MM)).toBe(472)
+  it('allows exactly 10% on an A4 poster', () => {
+    expect(qrMinWidthPx(2480)).toBe(248)
+    expect(qrMinWidthFrac()).toBe(0.1)
   })
 
-  it('never returns a width that prints under 40mm', () => {
+  it('rounds up fractional pixels at the 10% minimum', () => {
     for (const posterWidth of [1080, 1240, 1920, 2480, 4961]) {
       const px = qrMinWidthPx(posterWidth)
       expect(Number.isInteger(px)).toBe(true)
-      expect((px * A4_WIDTH_MM) / posterWidth).toBeGreaterThanOrEqual(QR_MIN_MM)
+      expect(px).toBeGreaterThanOrEqual(posterWidth * 0.1)
+      expect(qrRect(posterWidth, posterWidth * 2, 0.5, 0.5, 0.1).width).toBe(px)
     }
-  })
-
-  it('expresses the same minimum as the ENFORCED fraction, rounded up', () => {
-    // Deliberately 0.1905 and not the exact 40/210 = 0.190476. The enforced
-    // floor has to sit at or above the exact ratio, never below it, or the
-    // smallest legal code prints under 40mm. It also has to match the database
-    // CHECK and the route's Zod bound, both of which use 0.1905; returning the
-    // unrounded ratio here meant the geometric minimum was rejected with a 400.
-    expect(qrMinWidthFrac()).toBe(0.1905)
-    expect(qrMinWidthFrac()).toBeGreaterThan(40 / 210)
-    expect(qrMinWidthPx(2480)).toBe(473)
-    // And the rect built at that fraction is at least the minimum pixel width.
-    expect(qrRect(2480, 3508, 0.5, 0.5, qrMinWidthFrac()).width).toBeGreaterThanOrEqual(
-      qrMinWidthPx(2480)
-    )
   })
 })
 
@@ -431,15 +416,15 @@ describe('validateQrPlacement', () => {
     }
   })
 
-  it('rejects a code under the 40mm print minimum', () => {
-    const tooSmall = qrMinWidthPx(posterW) - 1 // 472px prints at 39.9mm
+  it('rejects a code under the 21mm print minimum', () => {
+    const tooSmall = qrMinWidthPx(posterW) - 1 // one pixel below 10%
     const qr: Rect = { x: 1000, y: 2000, width: tooSmall, height: tooSmall }
     const result = validateQrPlacement(posterW, posterH, qr, null)
     expect(result.ok).toBe(false)
-    if (!result.ok) expect(result.reason).toContain('40mm')
+    if (!result.ok) expect(result.reason).toContain('21mm')
   })
 
-  it('accepts a code at exactly the 40mm minimum', () => {
+  it('accepts a code at exactly the 21mm minimum', () => {
     const side = qrMinWidthPx(posterW)
     const qr: Rect = { x: 1000, y: 2000, width: side, height: side }
     expect(validateQrPlacement(posterW, posterH, qr, null)).toEqual({ ok: true })
@@ -539,18 +524,15 @@ describe('resolveLogoRect', () => {
 })
 
 describe('the QR minimum width floor agrees everywhere it is written down', () => {
-  it('is the rounded-up 0.1905, not the exact 40/210 ratio', () => {
-    expect(qrMinWidthFrac()).toBe(0.1905)
-    expect(QR_MIN_WIDTH_FRAC).toBe(0.1905)
-    expect(QR_MIN_WIDTH_FRAC_EXACT).toBeCloseTo(0.190476, 6)
-    // The rounding direction is the safety property: the enforced floor must
-    // never be below the exact ratio, or a code could print under 40mm.
-    expect(QR_MIN_WIDTH_FRAC).toBeGreaterThan(QR_MIN_WIDTH_FRAC_EXACT)
+  it('uses the exact 10% ratio', () => {
+    expect(qrMinWidthFrac()).toBe(0.1)
+    expect(QR_MIN_WIDTH_FRAC).toBe(0.1)
+    expect(QR_MIN_WIDTH_FRAC_EXACT).toBe(0.1)
   })
 
   it('matches the database CHECK constraint in the branding migration', () => {
     const sql = readFileSync(
-      resolve(__dirname, '../../../../supabase/migrations/20260906095746_event_image_branding.sql'),
+      resolve(__dirname, '../../../../supabase/migrations/20260906155438_event_image_qr_ten_percent.sql'),
       'utf8'
     )
     // If someone changes one and not the other, the smallest legal code either
@@ -558,10 +540,10 @@ describe('the QR minimum width floor agrees everywhere it is written down', () =
     expect(sql).toContain(`qr_width_frac >= ${QR_MIN_WIDTH_FRAC}`)
   })
 
-  it('a QR at exactly the floor still clears 40mm on the A4 canvas', () => {
+  it('a QR at exactly the floor still clears 21mm on the A4 canvas', () => {
     const widthPx = qrRect(2480, 3508, 0.5, 0.5, QR_MIN_WIDTH_FRAC).width
     const mm = (widthPx / 2480) * 210
-    expect(mm).toBeGreaterThanOrEqual(40)
+    expect(mm).toBeGreaterThanOrEqual(21)
     expect(widthPx).toBeGreaterThanOrEqual(qrMinWidthPx(2480))
   })
 })
@@ -603,7 +585,7 @@ describe('the BOOK NOW strip', () => {
     expect(rectsOverlap(strip, CODE, 0)).toBe(false)
   })
 
-  it('does not reduce the scannable code, so the 40mm rule still holds', () => {
+  it('does not reduce the scannable code, so the 21mm rule still holds', () => {
     // qr_width_frac keeps meaning the CODE width. The block is simply wider.
     expect(CODE.width).toBeGreaterThanOrEqual(qrMinWidthPx(2480))
     expect(qrBlockRect(CODE).width).toBeGreaterThan(CODE.width)

--- a/src/lib/events/artwork/geometry.ts
+++ b/src/lib/events/artwork/geometry.ts
@@ -15,7 +15,7 @@
  *   the naming rule exists to prevent.
  * - Every pixel output is an integer. Sizes and positions use `Math.round`; the
  *   single exception is `qrMinWidthPx`, which uses `Math.ceil` so the printed
- *   code can never come out under the stated 40mm minimum (see below).
+ *   code can never come out under the stated 21mm minimum (see below).
  * - Rects are `{ x, y, width, height }` in pixels, x and y being the top-left
  *   corner, y growing downwards, which is what both a canvas and Sharp expect.
  * - Pure functions only. No I/O, no state, no imports.
@@ -52,12 +52,8 @@ export const LOGO_DEFAULT_WIDTH_FRAC = 0.22
  */
 export const INSET_FRAC = 0.04
 
-/**
- * The smallest a QR code may be printed. The app's designer README states a 40mm
- * minimum for a poster QR, which is the size a phone camera reliably locks onto
- * from arm's length on a wall.
- */
-export const QR_MIN_MM = 40
+/** Minimum QR width on an A4 poster when set to 10% of the page width. */
+export const QR_MIN_MM = 21
 
 /** A4 portrait is 210mm wide. The print poster canvas is A4 at 300dpi. */
 export const A4_WIDTH_MM = 210
@@ -239,38 +235,15 @@ export function reservedLogoRect(imageW: number, imageH: number, corner: Corner)
   }
 }
 
-/**
- * The 40mm print minimum expressed as a fraction of an A4 page width.
- * 40 / 210 = 0.19047...
- */
+/** The same minimum is used by the editor and server validation. */
 export function qrMinWidthFrac(): number {
   return QR_MIN_WIDTH_FRAC
 }
 
-/**
- * The enforced minimum QR width as a fraction of the image width.
- *
- * The exact ratio is 40 / 210 = 0.190476..., but this is deliberately the
- * rounded-UP 0.1905, and the fourth decimal place is the whole point.
- *
- * Rounding down would admit a code that prints fractionally under the 40mm
- * minimum, and a QR that is too small is only ever discovered after it has been
- * printed. Rounding up costs 0.005mm of width and cannot.
- *
- * This exact value is duplicated in two other places that must agree with it:
- * the `event_images_qr_width_frac_check` constraint in
- * `20260906095746_event_image_branding.sql`, and the Zod bound on the composite
- * route. Returning the unrounded ratio here (as this function once did) meant
- * the geometric minimum was fractionally BELOW the stored floor, so posting the
- * smallest legal code was rejected with a 400 before it ever reached the
- * compositor. Keep all three the same number.
- */
-export const QR_MIN_WIDTH_FRAC = 0.1905
+/** Keep this aligned with the event_images QR width constraint. */
+export const QR_MIN_WIDTH_FRAC = 0.1
 
-/**
- * The unrounded ratio, exported for documentation and tests rather than for
- * validation. Use `QR_MIN_WIDTH_FRAC` to bound an input.
- */
+/** The A4 physical size expressed as a width fraction. */
 export const QR_MIN_WIDTH_FRAC_EXACT = QR_MIN_MM / A4_WIDTH_MM
 
 /**
@@ -284,20 +257,14 @@ export const QR_MAX_WIDTH_FRAC = 0.4
 
 /**
  * What a new QR starts at before anyone changes it: 0.20 of the width, which is
- * 42mm on A4. Comfortably over the 40mm floor without dominating the poster.
+ * 42mm on A4. Comfortably over the 21mm floor without dominating the poster.
  * The previous 0.22 (46mm) started larger than most artwork wanted.
  */
 export const QR_DEFAULT_WIDTH_FRAC = 0.2
 
-/**
- * The 40mm print minimum in pixels for a poster of a given pixel width.
- *
- * Rounded UP, on purpose. On the 2480px A4 canvas the exact figure is
- * 2480 * 40 / 210 = 472.38px; rounding down to 472 prints at 39.9mm, which is
- * under the minimum we tell designers we hold to. So this returns 473.
- */
+/** Round up so the rendered QR never falls below 10% of the poster width. */
 export function qrMinWidthPx(posterWidthPx: number): number {
-  return Math.ceil((posterWidthPx * QR_MIN_MM) / A4_WIDTH_MM)
+  return Math.ceil(posterWidthPx * QR_MIN_WIDTH_FRAC)
 }
 
 /**
@@ -319,10 +286,7 @@ export function qrRect(
 ): Rect {
   const inset = insetPx(posterW, posterH)
   const maxSide = Math.max(1, Math.min(posterW, posterH) - inset * 2)
-  // Ceil, not round. The failure mode for a printed QR is being too small, and
-  // at the enforced minimum fraction Math.round would give 472px on the 2480px
-  // A4 canvas, which prints at 39.97mm and is under the 40mm floor the whole
-  // constraint exists to hold. Rounding up costs at most a pixel.
+  // Round up to preserve the requested width on every canvas size.
   const side = clamp(Math.ceil(posterW * widthFrac), 1, maxSide)
 
   const maxX = Math.max(inset, posterW - inset - side)
@@ -354,7 +318,7 @@ export function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
  *
  * Three ways it can fail, checked in the order a person would notice them:
  *   1. any part of the code is off the canvas, or it has no area;
- *   2. it is smaller than the 40mm print minimum for this poster width;
+ *   2. it is smaller than the 21mm print minimum for this poster width;
  *   3. it comes within one inset of the logo's keep-clear region.
  *
  * The gap used against the logo is `insetPx` for the canvas, the same margin
@@ -362,7 +326,7 @@ export function rectsOverlap(a: Rect, b: Rect, gap: number): boolean {
  * clears it.
  *
  * Pass `logo` as null when the artwork carries no logo. This validator is for
- * the print poster path: the 40mm rule is a print rule and has no meaning on a
+ * the print poster path: the 21mm rule is a print rule and has no meaning on a
  * screen-only variant.
  */
 export function validateQrPlacement(
@@ -480,7 +444,7 @@ export function cssDropShadow(spec: LogoShadowSpec): string {
 // modules, which is far worse for a scanner than the centred logos that
 // occlusion budget is usually spent on.
 //
-// `qr_width_frac` keeps meaning the CODE width, so the 40mm print minimum and
+// `qr_width_frac` keeps meaning the CODE width, so the 21mm print minimum and
 // the database CHECK constraints all still mean what they say. The strip makes
 // the placed BLOCK wider than the code, and it is the block that has to fit on
 // the canvas and clear the logo.

--- a/supabase/migrations/20260906155438_event_image_qr_ten_percent.sql
+++ b/supabase/migrations/20260906155438_event_image_qr_ten_percent.sql
@@ -1,0 +1,7 @@
+-- Allow the requested 10% minimum and match the editor's existing 40% ceiling.
+SET lock_timeout = '3s';
+ALTER TABLE public.event_images
+  DROP CONSTRAINT event_images_qr_width_frac_check,
+  ADD CONSTRAINT event_images_qr_width_frac_check
+    CHECK (qr_width_frac >= 0.1 AND qr_width_frac <= 0.4);
+RESET lock_timeout;

--- a/tasks/qr-branding/migration-approval.md
+++ b/tasks/qr-branding/migration-approval.md
@@ -1,0 +1,41 @@
+# QR size database change
+
+Target: the-anchor-management-tools, project tfcasgxopxegwrabvwat, verified against repository .env.local URL and connected project list.
+
+Migration: 20260906155438_event_image_qr_ten_percent.sql
+
+SHA-256: 0c4510089d889d46bd327f18776948a1c990cc1668872a64908097dbcc4eed55
+
+Exact SQL:
+
+```sql
+-- Allow the requested 10% minimum and match the editor's existing 40% ceiling.
+SET lock_timeout = '3s';
+ALTER TABLE public.event_images
+  DROP CONSTRAINT event_images_qr_width_frac_check,
+  ADD CONSTRAINT event_images_qr_width_frac_check
+    CHECK (qr_width_frac >= 0.1 AND qr_width_frac <= 0.4);
+RESET lock_timeout;
+```
+
+Live findings: event_images contains 70 rows and occupies 147456 bytes. The live check permits 12% to 28%, while the current editor and route permit 20% to 40%. This change permits 10% to 40%. No dependent views or functions referencing qr_width_frac were found. No column shape, grants, policies, triggers, indexes or data are changed.
+
+Risk: replacing the check takes an exclusive table lock and scans 70 existing rows. A three-second lock timeout prevents prolonged waiting. The wider range accepts all existing valid values. No table rewrite or data backfill.
+
+Validation: exact migration executed against isolated local PostgreSQL. Null and existing 12%/28% values preserved; 10%/40% accepted; 9.99%/40.01% rejected. Transactional rollback restored the prior constraint.
+
+Rollback SQL (apply only if no newly saved values lie outside the previous range; otherwise leave the widened constraint and revert application code without changing saved placements):
+
+```sql
+BEGIN;
+SET LOCAL lock_timeout = '3s';
+ALTER TABLE public.event_images
+  DROP CONSTRAINT event_images_qr_width_frac_check,
+  ADD CONSTRAINT event_images_qr_width_frac_check
+    CHECK (qr_width_frac >= 0.12 AND qr_width_frac <= 0.28);
+COMMIT;
+```
+
+Post-apply: read migration history and constraint definition, confirm unchanged row count, then verify 10% in the live branding editor and inspect a freshly saved and downloaded PNG for readable BOOK NOW lettering. No SMS or bookings involved.
+
+Files in this release: ArtworkBrandingModal.tsx and its test; geometry.ts and its test; composite.ts and its test; the composite route and branding-service.test.ts; the new QR size migration; this packet and tasks/todo.md. Unchanged: branding-service.ts (already creates a fresh storage path on every save), image uploads, logo placement behaviour, website code, and all unrelated changes in the original checkout.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -211,3 +211,15 @@ See `tasks/fix-function/2026-09-05-api-connections/todo.md` for the isolated rem
 - [x] Obtain approval of exact production migration, activation and menu payloads before application.
 - [x] Deploy the paired approved release, verify production aliases, activate Christmas courses and exercise the live one-course journey without customer submission.
 - [x] Configure the 15 venue-confirmed dated capacities, with matching live booking snapshots and audit records; campaign remains a prepared brief.
+
+
+# QR branding fixes, 6 September 2026
+
+- [x] Check live schema and current production code in an isolated worktree.
+- [x] Lower editor and geometry minimum to 10%; draft and locally validate storage constraint.
+- [x] Render BOOK NOW without runtime font dependencies.
+- [ ] Validate migration and run checks, then deploy and verify the actual download.
+
+Scope: QR branding only. Existing artwork unchanged until saved again. Database constraint update is an independently deployable prerequisite; application changes follow. No new columns, grants, functions or data rewrites. Website and unrelated checkout work unchanged.
+
+QR verification: Node 20 lint, uncached typecheck, all 759 test files (6832 tests passed, two skipped) and clean production build passed. Actual minimum-size rendered image visually inspected with readable vector lettering. Isolated PostgreSQL validates boundaries and rollback. Production migration approval pending; no live changes applied.


### PR DESCRIPTION
## What changed

Event artwork branding now accepts QR codes from 10% to 40% of the image width. The saved BOOK NOW label uses vector outlines so serverless image rendering cannot substitute missing-font squares.

## Why

The owner needs smaller QR codes on posters and readable lettering in downloaded files. The live database range is widened to match the editor and route; default size stays at 20%.

## Testing done

- Lint and uncached type check passed on Node 20.
- 759 test files passed: 6,832 tests passed and two skipped.
- HTTP route, editor and actual compositor tests cover the 10% boundary and below-minimum rejection.
- Actual rendered 10% QR visually checked for clear lettering and quiet zone.
- Exact migration tested on isolated PostgreSQL, including both boundaries and rollback.
- Clean production build passed. Live verification follows migration approval and deployment.

## Complexity score

M. Four focused application files plus regression tests and one constraint migration. The backwards-compatible database range widening deploys before the application.

## Breaking changes

None. Existing saved artwork must be saved again to regenerate its lettering. The service already uses a fresh storage path for each save, so no cache version change is needed. Logo controls and website code are unchanged.

## Migration risk

Low. A 70-row table check is widened, with a three-second lock timeout and no data rewrite or permission changes. Exact SQL, checksum and rollback are recorded in tasks/qr-branding/migration-approval.md. The database migration needs owner approval before release.
