### PR TITLE
fix(reviews): shorten the review link in the guest email, not just the SMS

### DIFF
--- a/src/app/api/cron/event-guest-engagement/route.ts
+++ b/src/app/api/cron/event-guest-engagement/route.ts
@@ -8,6 +8,7 @@ import { sendSMS } from '@/lib/twilio'
 import { getSmartFirstName } from '@/lib/sms/bulk'
 import { createEventManageToken } from '@/lib/events/manage-booking'
 import { createGuestToken } from '@/lib/guest/tokens'
+import { buildGuestReviewUrl } from '@/lib/guest/review-short-link'
 import { sendEmail } from '@/lib/email/emailService'
 import { sendCrossPromoForEvent, sendFollowUpForEvent, hasReachedDailyPromoLimit } from '@/lib/sms/cross-promo'
 import type { FollowUpRecipient } from '@/lib/sms/cross-promo'
@@ -1003,7 +1004,7 @@ async function processReviewFollowups(
   bookings: BookingWithRelations[],
   appBaseUrl: string,
   safety: EventEngagementCronSafetyState
-): Promise<{ sent: number; skipped: number; suppressed: number }> {
+): Promise<{ sent: number; skipped: number; suppressed: number; shortLinkFallbacks: number }> {
   const now = new Date()
   const nowMs = now.getTime()
   const maxAgeMs = EVENT_ENGAGEMENT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000
@@ -1083,7 +1084,7 @@ async function processReviewFollowups(
     safety.throwSafetyAbort()
   }
 
-  const result = { sent: 0, skipped: 0, suppressed: 0 }
+  const result = { sent: 0, skipped: 0, suppressed: 0, shortLinkFallbacks: 0 }
 
   for (const booking of boundedPastBookings) {
     const customer = booking.customer
@@ -1147,7 +1148,19 @@ async function processReviewFollowups(
       expiresAt: provisionalExpiry
     })
 
-    const redirectUrl = `${appBaseUrl}/r/${rawToken}`
+    // Shortened before it goes anywhere near the message body, so the guest sees
+    // l.the-anchor.pub/abc123 rather than 81 characters of token. Falls back to the
+    // long URL if shortening fails, so the ask still goes out. See
+    // src/lib/guest/review-short-link.ts.
+    const { url: redirectUrl, shortened } = await buildGuestReviewUrl({
+      appBaseUrl,
+      rawToken,
+      customerId: customer.id,
+      eventBookingId: booking.id,
+    })
+    // Counted, not just logged: the count rides out in the cron's JSON response, so a
+    // run where shortening quietly stopped working is visible in the Vercel log.
+    if (!shortened) result.shortLinkFallbacks += 1
     const firstName = getSmartFirstName(customer.first_name)
     const messageBody = ensureReplyInstruction(
       `The Anchor: ${firstName}! Hope you had a belter at ${event.name} last night. Got 30 seconds? A quick review means the world to us: ${redirectUrl}`,
@@ -1341,7 +1354,7 @@ async function processTableReviewFollowups(
   tableBookings: TableBookingWithCustomer[],
   appBaseUrl: string,
   safety: EventEngagementCronSafetyState
-): Promise<{ sent: number; skipped: number; suppressed: number }> {
+): Promise<{ sent: number; skipped: number; suppressed: number; shortLinkFallbacks: number }> {
   const now = Date.now()
   const maxAgeMs = TABLE_ENGAGEMENT_LOOKBACK_DAYS * 24 * 60 * 60 * 1000
   const supportPhone = process.env.NEXT_PUBLIC_CONTACT_PHONE_NUMBER || process.env.TWILIO_PHONE_NUMBER || undefined
@@ -1418,7 +1431,7 @@ async function processTableReviewFollowups(
     safety.throwSafetyAbort()
   }
 
-  const result = { sent: 0, skipped: 0, suppressed: 0 }
+  const result = { sent: 0, skipped: 0, suppressed: 0, shortLinkFallbacks: 0 }
 
   for (const booking of boundedEligibleBookings) {
     const customer = booking.customer
@@ -1492,7 +1505,18 @@ async function processTableReviewFollowups(
       expiresAt: provisionalExpiry
     })
 
-    const redirectUrl = `${appBaseUrl}/r/${rawToken}`
+    // Shortened here rather than at send time because this path is email-first and
+    // only `sendSMS` rewrites URLs. Doing it once, up front, shortens the email too
+    // and gives the email and the SMS fallback the same short code, so a click is
+    // counted once whichever channel the guest used. See
+    // src/lib/guest/review-short-link.ts.
+    const { url: redirectUrl, shortened } = await buildGuestReviewUrl({
+      appBaseUrl,
+      rawToken,
+      customerId: customer.id,
+      tableBookingId: booking.id,
+    })
+    if (!shortened) result.shortLinkFallbacks += 1
     const firstName = getSmartFirstName(customer.first_name)
     const messageBody = ensureReplyInstruction(
       `The Anchor: ${firstName}! Thanks for popping in. Got 30 seconds? A quick review means the world to us: ${redirectUrl}`,

--- a/src/lib/guest/review-short-link.ts
+++ b/src/lib/guest/review-short-link.ts
@@ -1,0 +1,108 @@
+/**
+ * Builds the review-ask link a guest actually receives, shortened.
+ *
+ * The raw link is `${appBaseUrl}/r/${rawToken}` where the token is 32 random
+ * bytes base64url, 43 characters on top of a 38-character origin. At 81
+ * characters it is the longest thing in the message by a wide margin.
+ *
+ * Why this exists when `shortenUrlsInSmsBody` already shortens outbound SMS:
+ *
+ * 1. **Email was never covered.** `sendSMS` rewrites URLs at send time
+ *    (src/lib/twilio.ts), but `sendEmail` does not, and the table-booking
+ *    review ask is email-first. So a guest with an email address received the
+ *    full 81-character URL in the message body while a guest with only a mobile
+ *    received a short one. Shortening here, at the point the link is built,
+ *    fixes the email and covers both channels from one place.
+ *
+ * 2. **One link per guest, not one per channel.** Both the email and the SMS
+ *    fallback now carry the same short code, so a click is one click no matter
+ *    which channel the guest used.
+ *
+ * 3. **Metadata worth having.** The generic SMS shortener can only tag a link
+ *    `source: 'sms_auto_shortener'`. Here we know the customer and the booking,
+ *    so the row can say what it is and be traced back later.
+ *
+ * Double-shortening is not a risk: `shortenUrlsInSmsBody` skips any URL already
+ * on a short-link host, so an SMS carrying the output of this module passes
+ * through untouched.
+ *
+ * FAILURE BEHAVIOUR: never throws, and never blocks the send. If the short link
+ * cannot be created the long URL is returned and the message still goes out
+ * with a working link. A shorter message is a nicety; a review ask that never
+ * arrives is a lost review. The failure is logged with the booking and customer
+ * so it is visible in Vercel logs rather than silent.
+ */
+
+import { hashGuestToken } from '@/lib/guest/tokens'
+import { logger } from '@/lib/logger'
+import { ShortLinkService } from '@/services/short-links'
+
+export interface GuestReviewLinkInput {
+  /** Origin of the management app, e.g. https://management.orangejelly.co.uk */
+  appBaseUrl: string
+  /** The raw (unhashed) guest token returned by createGuestToken. */
+  rawToken: string
+  customerId: string
+  eventBookingId?: string | null
+  tableBookingId?: string | null
+}
+
+export interface GuestReviewLinkResult {
+  /** The URL to put in front of the guest. Short when shortening worked. */
+  url: string
+  /** False when we fell back to the long /r/ URL. */
+  shortened: boolean
+}
+
+export function buildLongGuestReviewUrl(appBaseUrl: string, rawToken: string): string {
+  return `${appBaseUrl.replace(/\/+$/, '')}/r/${rawToken}`
+}
+
+export async function buildGuestReviewUrl(input: GuestReviewLinkInput): Promise<GuestReviewLinkResult> {
+  const longUrl = buildLongGuestReviewUrl(input.appBaseUrl, input.rawToken)
+
+  try {
+    const result = await ShortLinkService.createShortLinkInternal({
+      destination_url: longUrl,
+      // 'custom' is the only value in the short_links link_type CHECK constraint
+      // that fits a one-off guest link, so no migration is needed. The row is
+      // told apart from a staff-made link by metadata.guest_link_kind, and it
+      // stays out of the staff /short-links list because createShortLinkInternal
+      // leaves created_by NULL (see ShortLinkService.getShortLinks includeSystem).
+      link_type: 'custom',
+      // No explicit name: deriveShortLinkName already special-cases an `/r/` path
+      // and returns 'Review Link' (src/lib/short-links/names.ts). Review links
+      // shortened at SMS send time have carried that name for as long as the
+      // auto-shortener has existed, so naming these anything else would leave one
+      // kind of link with two names in the table.
+      metadata: {
+        source: 'guest_review_ask',
+        guest_link_kind: 'guest_review',
+        guest_action_type: 'review_redirect',
+        // The hash, never the raw token: this row is readable by every member of
+        // staff who can see short links, and the raw token IS the credential.
+        guest_token_hash: hashGuestToken(input.rawToken),
+        customer_id: input.customerId,
+        event_booking_id: input.eventBookingId ?? null,
+        table_booking_id: input.tableBookingId ?? null,
+      },
+    })
+
+    if (!result?.full_url) {
+      throw new Error('Short link service returned no URL')
+    }
+
+    return { url: result.full_url, shortened: true }
+  } catch (error) {
+    logger.warn('Failed to shorten guest review link; sending the full-length URL', {
+      error: error instanceof Error ? error : new Error(String(error)),
+      metadata: {
+        customerId: input.customerId,
+        eventBookingId: input.eventBookingId ?? null,
+        tableBookingId: input.tableBookingId ?? null,
+      },
+    })
+
+    return { url: longUrl, shortened: false }
+  }
+}

--- a/tests/api/tableReviewEmailShortLink.test.ts
+++ b/tests/api/tableReviewEmailShortLink.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * The table-booking review ask is email-first, and only `sendSMS` rewrites URLs
+ * at send time (src/lib/twilio.ts). So the email went out carrying the raw
+ * 81-character `/r/<43-char token>` URL while the SMS fallback carried a short
+ * one. A real guest received exactly that on 2026-09-06.
+ *
+ * This test drives the cron end to end and asserts on what actually lands in the
+ * guest's inbox: the short link, and no trace of the long one.
+ */
+
+vi.mock('@/lib/cron-auth', () => ({
+  authorizeCronRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('@/lib/cron-run-results', () => ({
+  persistCronRunResult: vi.fn().mockResolvedValue(undefined),
+  recoverCronRunLock: vi.fn().mockResolvedValue({ result: 'already_running', runId: 'run-1' }),
+}))
+
+vi.mock('@/lib/twilio', () => ({
+  sendSMS: vi.fn().mockResolvedValue({ success: true, sid: 'SM1' }),
+}))
+
+vi.mock('@/lib/email/emailService', () => ({
+  sendEmail: vi.fn().mockResolvedValue({ success: true }),
+}))
+
+const createShortLinkInternalMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/short-links', () => ({
+  ShortLinkService: {
+    createShortLinkInternal: createShortLinkInternalMock,
+  },
+}))
+
+vi.mock('@/lib/sms/review-once', () => ({
+  hasCustomerReviewed: vi.fn().mockResolvedValue(new Set<string>()),
+  getFirstVisitReviewEligibleCandidateKeys: vi
+    .fn()
+    .mockResolvedValue(new Set<string>(['table:booking-emailable'])),
+  reviewVisitCandidateKey: (candidate: { channel: string; bookingId: string }) =>
+    `${candidate.channel}:${candidate.bookingId}`,
+}))
+
+import { authorizeCronRequest } from '@/lib/cron-auth'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { sendEmail } from '@/lib/email/emailService'
+import { GET } from '@/app/api/cron/event-guest-engagement/route'
+
+const SHORT_URL = 'https://l.the-anchor.pub/rev123'
+
+function buildSupabase() {
+  const bookingStartIso = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString()
+
+  // Same permissive chain as tableReviewSuppressUncontactable.test.ts: the sweep
+  // touches a dozen tables with a dozen builder shapes and none of them matter
+  // to what the guest receives.
+  const emptyChain = (final: unknown = { data: [], error: null }) => {
+    const proxy: any = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (typeof prop === 'symbol') return undefined
+          if (prop === 'then') {
+            return (resolve: (value: unknown) => void) => resolve(final)
+          }
+          return () => proxy
+        },
+      }
+    )
+    return proxy
+  }
+
+  const theBooking = {
+    id: 'booking-emailable',
+    customer_id: 'customer-emailable',
+    status: 'confirmed',
+    booking_type: 'regular',
+    start_datetime: bookingStartIso,
+    review_sms_sent_at: null,
+    review_suppressed_at: null,
+    customer: {
+      id: 'customer-emailable',
+      first_name: 'Philippa',
+      mobile_number: null,
+      email: 'philippa@example.com',
+      sms_status: 'inactive',
+      email_status: 'active',
+      email_deactivated_at: null,
+    },
+  }
+
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'cron_job_runs') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                  })),
+                })),
+              })),
+            })),
+          })),
+          insert: vi.fn(() => ({
+            select: vi.fn(() => ({
+              single: vi.fn().mockResolvedValue({ data: { id: 'run-1' }, error: null }),
+            })),
+          })),
+          update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+        }
+      }
+
+      if (table === 'table_bookings') {
+        const readChain = emptyChain({ data: [theBooking], error: null, count: 0 })
+        return {
+          select: () => readChain,
+          update: vi.fn(() => emptyChain({ data: null, error: null })),
+        }
+      }
+
+      return emptyChain({ data: [], error: null, count: 0 })
+    }),
+  }
+}
+
+async function run() {
+  ;(createAdminClient as unknown as vi.Mock).mockReturnValue(buildSupabase())
+
+  const request: any = new Request('http://localhost/api/cron/event-guest-engagement')
+  request.nextUrl = new URL('http://localhost')
+
+  const response = await GET(request)
+  return { response, payload: await response.json() }
+}
+
+function reviewEmailCall() {
+  return (sendEmail as unknown as vi.Mock).mock.calls.find(
+    ([options]) => options?.subject === 'Thanks for visiting The Anchor'
+  )?.[0]
+}
+
+describe('table review email: link shortening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(authorizeCronRequest as unknown as vi.Mock).mockReturnValue({ authorized: true })
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'rev123',
+      full_url: SHORT_URL,
+      already_exists: false,
+    })
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-15T12:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the review email with the shortened link in both the html and the plain text', async () => {
+    await run()
+
+    const email = reviewEmailCall()
+    expect(email).toBeDefined()
+    expect(email.html).toContain(`href="${SHORT_URL}"`)
+    expect(email.text).toContain(SHORT_URL)
+  })
+
+  it('leaves no long /r/ token URL anywhere in the email', async () => {
+    await run()
+
+    const email = reviewEmailCall()
+    expect(email.html).not.toContain('/r/')
+    expect(email.text).not.toContain('/r/')
+    expect(email.html).not.toContain('management.orangejelly.co.uk')
+    expect(email.text).not.toContain('management.orangejelly.co.uk')
+  })
+
+  it('shortens the /r/ URL exactly once, tagged as a guest review link', async () => {
+    await run()
+
+    expect(createShortLinkInternalMock).toHaveBeenCalledTimes(1)
+    const [payload] = createShortLinkInternalMock.mock.calls[0]
+    expect(payload.destination_url).toMatch(/\/r\/[A-Za-z0-9_-]+$/)
+    expect(payload.link_type).toBe('custom')
+    expect(payload.metadata.guest_link_kind).toBe('guest_review')
+    expect(payload.metadata.table_booking_id).toBe('booking-emailable')
+    expect(payload.metadata.customer_id).toBe('customer-emailable')
+    // An expiry would send a late tapper to the venue homepage instead of the
+    // review funnel, so the row must not carry one.
+    expect(payload.expires_at).toBeUndefined()
+  })
+
+  // The character saving is worth less than the review. If the short link cannot
+  // be minted the guest still gets a working long URL.
+  it('still sends the ask with the long URL when shortening fails', async () => {
+    createShortLinkInternalMock.mockRejectedValue(new Error('short link service down'))
+
+    const { payload } = await run()
+
+    const email = reviewEmailCall()
+    expect(email).toBeDefined()
+    expect(email.text).toMatch(/https?:\/\/\S+\/r\/[A-Za-z0-9_-]{20,}/)
+    expect(email.html).toMatch(/href="https?:\/\/\S+\/r\/[A-Za-z0-9_-]{20,}"/)
+
+    // The fallback has to be countable, or a run where shortening silently stopped
+    // working would look identical to a healthy one.
+    expect(payload.tableReviews.shortLinkFallbacks).toBe(1)
+  })
+})

--- a/tests/lib/guestReviewShortLink.test.ts
+++ b/tests/lib/guestReviewShortLink.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { hashGuestToken } from '@/lib/guest/tokens'
+
+const createShortLinkInternalMock = vi.hoisted(() => vi.fn())
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/short-links', () => ({
+  ShortLinkService: {
+    createShortLinkInternal: createShortLinkInternalMock,
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    warn: loggerWarnMock,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+import { buildGuestReviewUrl, buildLongGuestReviewUrl } from '@/lib/guest/review-short-link'
+
+const APP_BASE_URL = 'https://management.orangejelly.co.uk'
+const RAW_TOKEN = 'VYAzgKJhiKGfsFtOcg5RFL5trUKknDwhsKfu9fAEYLA'
+const LONG_URL = `${APP_BASE_URL}/r/${RAW_TOKEN}`
+
+describe('buildLongGuestReviewUrl', () => {
+  it('builds the /r/ URL', () => {
+    expect(buildLongGuestReviewUrl(APP_BASE_URL, RAW_TOKEN)).toBe(LONG_URL)
+  })
+
+  it('does not double up the slash when the base URL has a trailing one', () => {
+    expect(buildLongGuestReviewUrl(`${APP_BASE_URL}/`, RAW_TOKEN)).toBe(LONG_URL)
+  })
+})
+
+describe('buildGuestReviewUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns the short URL and tags the link with the booking it belongs to', async () => {
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'abc123',
+      full_url: 'https://l.the-anchor.pub/abc123',
+      already_exists: false,
+    })
+
+    const result = await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      tableBookingId: 'table-booking-1',
+    })
+
+    expect(result).toEqual({ url: 'https://l.the-anchor.pub/abc123', shortened: true })
+    expect(createShortLinkInternalMock).toHaveBeenCalledTimes(1)
+    expect(createShortLinkInternalMock).toHaveBeenCalledWith({
+      destination_url: LONG_URL,
+      link_type: 'custom',
+      metadata: {
+        source: 'guest_review_ask',
+        guest_link_kind: 'guest_review',
+        guest_action_type: 'review_redirect',
+        guest_token_hash: hashGuestToken(RAW_TOKEN),
+        customer_id: 'customer-1',
+        event_booking_id: null,
+        table_booking_id: 'table-booking-1',
+      },
+    })
+  })
+
+  it('never stores the raw token on the short link row', async () => {
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'abc123',
+      full_url: 'https://l.the-anchor.pub/abc123',
+      already_exists: false,
+    })
+
+    await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      eventBookingId: 'event-booking-1',
+    })
+
+    const metadata = createShortLinkInternalMock.mock.calls[0][0].metadata
+    expect(JSON.stringify(metadata)).not.toContain(RAW_TOKEN)
+    expect(metadata.guest_token_hash).toBe(hashGuestToken(RAW_TOKEN))
+    expect(metadata.event_booking_id).toBe('event-booking-1')
+    expect(metadata.table_booking_id).toBeNull()
+  })
+
+  // The review ask is worth more than the character saving: a failure to shorten
+  // must degrade to the long URL, never to a missing or broken link.
+  it('falls back to the long URL when the short link service rejects', async () => {
+    createShortLinkInternalMock.mockRejectedValue(new Error('short link insert failed'))
+
+    const result = await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      tableBookingId: 'table-booking-1',
+    })
+
+    expect(result).toEqual({ url: LONG_URL, shortened: false })
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+    expect(loggerWarnMock.mock.calls[0][1].metadata).toEqual({
+      customerId: 'customer-1',
+      eventBookingId: null,
+      tableBookingId: 'table-booking-1',
+    })
+  })
+
+  it('falls back to the long URL when the short link service throws synchronously', async () => {
+    createShortLinkInternalMock.mockImplementation(() => {
+      throw new Error('destination host is not allowed')
+    })
+
+    const result = await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      eventBookingId: 'event-booking-1',
+    })
+
+    expect(result).toEqual({ url: LONG_URL, shortened: false })
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the long URL when the short link service returns no URL', async () => {
+    createShortLinkInternalMock.mockResolvedValue({ short_code: 'abc123', full_url: '' })
+
+    const result = await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      tableBookingId: 'table-booking-1',
+    })
+
+    expect(result).toEqual({ url: LONG_URL, shortened: false })
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('short link naming', () => {
+  // Guards the interaction with deriveShortLinkName: it special-cases an /r/ path,
+  // so review links shortened here and review links shortened at SMS send time
+  // both end up named 'Review Link' in the short_links table.
+  it('leaves the name to be derived from the /r/ path', async () => {
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'abc123',
+      full_url: 'https://l.the-anchor.pub/abc123',
+      already_exists: false,
+    })
+
+    await buildGuestReviewUrl({
+      appBaseUrl: APP_BASE_URL,
+      rawToken: RAW_TOKEN,
+      customerId: 'customer-1',
+      tableBookingId: 'table-booking-1',
+    })
+
+    expect(createShortLinkInternalMock.mock.calls[0][0]).not.toHaveProperty('name')
+  })
+})


### PR DESCRIPTION
## What

Guest review asks were going out with the raw 81-character URL
`https://management.orangejelly.co.uk/r/<43-char token>`.

The premise "review links are not shortened" turned out to be only half true.
`sendSMS` (`src/lib/twilio.ts:451`) has rewritten every URL at send time since
September 2025. `sendEmail` has no equivalent step, and the table-booking review
ask is **email-first** (SMS is only the fallback). Measured in production over
the 30 days to 2026-09-06:

| channel | total | short link | long `/r/` URL |
|---|---|---|---|
| review SMS | 23 | 23 | 0 |
| review email | 51 | 0 | 51 |

So the email was the only broken channel.

## How

New `src/lib/guest/review-short-link.ts` exporting `buildGuestReviewUrl`, called
at both review send sites in `src/app/api/cron/event-guest-engagement/route.ts`.
Shortening happens where the link is **built** rather than where it is sent, so:

- the email is fixed, and the plain-text part stops looking like phishing;
- the email and the SMS fallback share one short link, so a click is counted once
  whichever channel the guest used;
- the `short_links` row carries the customer and booking instead of the generic
  `{source:'sms_auto_shortener'}`.

The existing SMS auto-shortener becomes the safety net: it skips the URL because
it is already on a short-link host, so no second row is minted.

On the table review SMS this also drops the body from 2 segments to 1.

## Failure behaviour

Fail open, deliberately. A review ask is an outbound message, not a public write
path: if the short link cannot be minted the guest still gets the working long
URL. The fallback is counted into the cron's JSON response as
`shortLinkFallbacks`, so a run where shortening silently stopped working is
visible in the Vercel log rather than only in a warn line.

## Assumptions, checked against production

- `link_type 'custom'`, `created_by` NULL and no expiry match all 369 review
  short links already in `short_links`, so **no migration**, and these stay
  hidden from the staff `/short-links` list (it filters `created_by IS NULL`).
- No expiry is deliberate: an expired short link 302s to the venue homepage,
  whereas an expired or deleted token still reaches the feedback funnel. An
  orphaned row after a failed send is therefore harmless, so no compensating
  delete.
- Only `hashGuestToken(rawToken)` goes into metadata; `authenticated` holds
  SELECT on `short_links` and the raw token is the credential.
- No `name` passed: `deriveShortLinkName` already special-cases an `/r/` path.

## Verification

lint clean, `tsc --noEmit` clean, 761 files / 6844 tests green in **both**
Europe/London and UTC, production build compiled. Rebased onto `ef7724be` and
re-verified.

`tests/api/tableReviewEmailShortLink.test.ts` drives the cron end to end and
asserts the email carries the short link and no `/r/` URL, plus the injected
failure case.

## Not in scope

The same long-URL pattern exists in other guest emails (`/g/` manage-booking
links): `table_booking_confirmed` 156 of 174 in 90 days,
`event_payment_confirmation` 7, `table_booking_rescheduled` 5,
`event_payment_link` 1. Different template family, flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)