### PR TITLE
fix(email): shorten guest booking links in email, not just SMS

### DIFF
--- a/src/app/api/cron/preorder-reminders/route.ts
+++ b/src/app/api/cron/preorder-reminders/route.ts
@@ -33,6 +33,7 @@ import { reportCronFailure } from '@/lib/cron/alerting'
 import { sendEmail } from '@/lib/email/emailService'
 import { jobQueue } from '@/lib/unified-job-queue'
 import { createTableManageToken } from '@/lib/table-bookings/manage-booking'
+import { buildGuestShortLink } from '@/lib/guest/guest-short-link'
 import {
   decidePreorderChases,
   describePreorderGaps,
@@ -136,6 +137,8 @@ export async function GET(request: NextRequest) {
       managerEscalations: 0,
       skipped: 0,
       failed: 0,
+      // Chases that went out at full link length because shortening failed.
+      shortLinkFallbacks: 0,
     }
 
     // Cutoffs are per period, so the window has to reach the furthest one. Without this a period
@@ -260,8 +263,9 @@ export async function GET(request: NextRequest) {
 
         try {
           if (kind === 'booker_reminder') {
-            await sendBookerReminder(supabase, booking, booker)
+            const reminder = await sendBookerReminder(supabase, booking, booker)
             result.bookerReminders++
+            if (reminder.shortLinkFallback) result.shortLinkFallbacks++
           } else {
             await sendManagerEscalation(booking, booker, describePreorderGaps(completeness))
             result.managerEscalations++
@@ -355,7 +359,7 @@ async function sendBookerReminder(
   supabase: ReturnType<typeof createAdminClient>,
   booking: CandidateBooking,
   booker: Booker | null,
-): Promise<void> {
+): Promise<{ shortLinkFallback: boolean }> {
   if (!booker) throw new Error('Booking has no customer to chase')
   if (!booker.phone && !booker.email) throw new Error('Booker has neither a mobile number nor an email')
 
@@ -366,6 +370,14 @@ async function sendBookerReminder(
     appBaseUrl: process.env.NEXT_PUBLIC_APP_URL,
   })
 
+  // Shortened once here so the queued SMS and the email carry the same link.
+  const manage = await buildGuestShortLink({
+    longUrl: token.url,
+    linkKind: 'table_manage',
+    customerId: booker.id,
+    tableBookingId: booking.id,
+  })
+
   const bookingMoment = formatDateWithTimeForSms(booking.booking_date, booking.booking_time)
   const contactPhone = process.env.NEXT_PUBLIC_CONTACT_PHONE_NUMBER || null
 
@@ -373,7 +385,7 @@ async function sendBookerReminder(
     // Straight apostrophes and no dashes: one curly character drops the segment limit from 160 to 70.
     const message =
       `The Anchor: ${booker.firstName}, we still need the food choices for your booking on ` +
-      `${bookingMoment}. Every guest needs a main course. Choose here: ${token.url}`
+      `${bookingMoment}. Every guest needs a main course. Choose here: ${manage.url}`
 
     // No `unique` key on the enqueue: the ledger row claimed above is the idempotency, and a second
     // mechanism here would only add a lock round trip and another way for the two to disagree.
@@ -397,7 +409,7 @@ async function sendBookerReminder(
       `<p>We still need the food choices for your booking at The Anchor on ` +
         `${escapeHtml(bookingMoment)} (reference ${escapeHtml(booking.booking_reference)}).</p>`,
       '<p>Every guest needs to choose a main course. A starter and a dessert are optional.</p>',
-      `<p><a href="${escapeHtml(token.url)}">Choose your food here</a></p>`,
+      `<p><a href="${escapeHtml(manage.url)}">Choose your food here</a></p>`,
       contactPhone
         ? `<p>Prefer to do it over the telephone? Ring us on ${escapeHtml(contactPhone)}.</p>`
         : '<p>Prefer to do it over the telephone? Please give us a ring.</p>',
@@ -415,6 +427,8 @@ async function sendBookerReminder(
       throw new Error(emailResult.error || 'Failed to send the pre-order reminder email')
     }
   }
+
+  return { shortLinkFallback: !manage.shortened }
 }
 
 /**

--- a/src/lib/email/event-ticket-emails.ts
+++ b/src/lib/email/event-ticket-emails.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { sendEmail } from '@/lib/email/emailService'
 import { createEventManageToken } from '@/lib/events/manage-booking'
+import { buildGuestShortLink } from '@/lib/guest/guest-short-link'
 import {
   buildTicketBreakdownLines,
   eventTicketTypesEnabled,
@@ -81,7 +82,7 @@ async function createManageLink(
     eventStartIso: string | null
   },
   appBaseUrl?: string
-): Promise<string | null> {
+): Promise<{ url: string; shortened: boolean } | null> {
   try {
     const manageToken = await createEventManageToken(supabase, {
       customerId: context.customerId,
@@ -89,7 +90,15 @@ async function createManageLink(
       eventStartIso: context.eventStartIso,
       appBaseUrl,
     })
-    return manageToken.url
+    // Shortened here rather than inside createEventManageToken, whose URL is also
+    // returned to API callers. `shortened: false` means the guest got the full
+    // length URL, which each caller records on the email's metadata row.
+    return buildGuestShortLink({
+      longUrl: manageToken.url,
+      linkKind: 'event_manage',
+      customerId: context.customerId,
+      eventBookingId: context.bookingId,
+    })
   } catch {
     return null
   }
@@ -222,6 +231,18 @@ export async function sendEventPaymentLinkEmail(
   const context = await loadEventTicketEmailContext(supabase, input.bookingId)
   if (!context) return { success: false, skipped: true }
 
+  // Shortened here rather than in createEventPaymentToken, whose URL is also
+  // returned to the API caller as next_step_url. The SMS on this path carries the
+  // same long URL and is shortened at send time to the same destination, and
+  // createShortLinkInternal dedupes on destination_url, so both channels end up
+  // on one short code and one click count.
+  const payment = await buildGuestShortLink({
+    longUrl: input.paymentLink,
+    linkKind: 'event_payment',
+    customerId: context.customerId,
+    eventBookingId: context.bookingId,
+  })
+
   const subject = input.reminder
     ? `Reminder: complete payment for ${context.eventName}`
     : `Complete payment for ${context.eventName}`
@@ -231,14 +252,14 @@ export async function sendEventPaymentLinkEmail(
     : 'Your tickets are held for a limited time.'
   const safeName = escapeHtml(context.firstName)
   const safeEventName = escapeHtml(context.eventName)
-  const safePaymentLink = escapeHtml(input.paymentLink)
+  const safePaymentLink = escapeHtml(payment.url)
   const text = [
     `Hi ${context.firstName},`,
     '',
     `${context.seats} ${seatWord} are held for ${context.eventName} on ${context.eventStart}.`,
     expiryText,
     '',
-    `Pay securely here: ${input.paymentLink}`,
+    `Pay securely here: ${payment.url}`,
     '',
     'The Anchor',
   ].join('\n')
@@ -265,7 +286,9 @@ export async function sendEventPaymentLinkEmail(
     eventBookingId: context.bookingId,
     metadata: {
       template_key: input.reminder ? 'event_payment_reminder_email' : 'event_payment_link_email',
-      payment_link: input.paymentLink,
+      // The URL the guest actually received, not the one we were handed.
+      payment_link: payment.url,
+      short_link_fallback: !payment.shortened,
     },
   })
 }
@@ -290,7 +313,8 @@ export async function sendEventPaymentConfirmationEmail(
 
   const seatWord = context.seats === 1 ? 'ticket' : 'tickets'
   const amountText = formatCurrency(input.amount ?? null, input.currency || 'GBP')
-  const manageLink = await createManageLink(supabase, context, input.appBaseUrl)
+  const manageResult = await createManageLink(supabase, context, input.appBaseUrl)
+  const manageLink = manageResult?.url ?? null
 
   const subject = `Booking confirmed: ${context.eventName}`
   const safeName = escapeHtml(context.firstName)
@@ -364,6 +388,7 @@ export async function sendEventPaymentConfirmationEmail(
       amount: input.amount ?? null,
       currency: input.currency || 'GBP',
       manage_link_included: Boolean(manageLink),
+      short_link_fallback: manageResult?.shortened === false,
     },
   })
 }
@@ -605,10 +630,11 @@ export async function sendEventTicketTransferredEmail(
   })
   if (alreadySent) return { success: true, skipped: true }
 
-  const manageLink = await createManageLink(supabase, {
+  const manageResult = await createManageLink(supabase, {
     ...context,
     eventStartIso: input.eventStartIso || context.eventStartIso,
   }, input.appBaseUrl)
+  const manageLink = manageResult?.url ?? null
   const eventStart = input.eventStartIso ? formatLondonDateTime(input.eventStartIso) : context.eventStart
   const body = [
     `Hi ${context.firstName},`,
@@ -643,6 +669,7 @@ export async function sendEventTicketTransferredEmail(
       from_event_name: input.fromEventName,
       to_event_name: input.toEventName,
       manage_link_included: Boolean(manageLink),
+      short_link_fallback: manageResult?.shortened === false,
       overpayment: typeof input.overpayment === 'number' && input.overpayment > 0 ? input.overpayment : undefined,
     },
   })
@@ -677,10 +704,11 @@ export async function sendEventRescheduledEmail(
   if (alreadySent) return { success: true, skipped: true }
 
   const newStartIso = `${input.newDate}T${input.newTime || '00:00'}:00`
-  const manageLink = await createManageLink(supabase, {
+  const manageResult = await createManageLink(supabase, {
     ...context,
     eventStartIso: newStartIso,
   }, input.appBaseUrl)
+  const manageLink = manageResult?.url ?? null
   const newDateText = formatLondonDateTime(newStartIso)
   const body = [
     `Hi ${context.firstName},`,
@@ -711,6 +739,7 @@ export async function sendEventRescheduledEmail(
       template_key: 'event_rescheduled_email',
       ...metadataMatch,
       manage_link_included: Boolean(manageLink),
+      short_link_fallback: manageResult?.shortened === false,
     },
   })
 }

--- a/src/lib/guest/guest-short-link.ts
+++ b/src/lib/guest/guest-short-link.ts
@@ -1,0 +1,197 @@
+/**
+ * Shortens a guest link before it is put into a message.
+ *
+ * `sendSMS` rewrites every URL in an outbound body at send time
+ * (src/lib/twilio.ts), but `sendEmail` does not. So any flow that emails a guest
+ * a token link ships the raw ~80-character URL. Measured in production over the
+ * 90 days to 2026-09-07, every stored booking-confirmation email carried one.
+ *
+ * Shortening HERE, where the message is composed, rather than inside `sendEmail`
+ * or inside the token minters:
+ *
+ * - `sendEmail` is the wrong place. It would also rewrite unsubscribe links
+ *   (leaving the body disagreeing with the `List-Unsubscribe` header), PayPal
+ *   approve URLs (off the destination allowlist, which THROWS), marketing links
+ *   that already carry per-recipient tracking, and the cron alert email that
+ *   fires when the system is unhealthy. It would also need an HTML-aware parser,
+ *   because the SMS shortener's bare-URL regex eats `"` and `>` out of an anchor.
+ * - The token minters are the wrong place too. `createTableManageToken`,
+ *   `createTablePaymentToken`, `createEventManageToken` and
+ *   `createEventPaymentToken` each return a URL that is ALSO handed back to API
+ *   callers as `next_step_url` / `fallback_payment_url`, which the website uses
+ *   to redirect a booker straight to the payment page. Shortening there would
+ *   put a redirect hop and a bogus click in front of every website booking.
+ *
+ * Doing it at the message-composition site means the email and the SMS for the
+ * same booking carry the same destination, and `createShortLinkInternal` dedupes
+ * on `destination_url`, so both channels resolve to ONE short code and one click
+ * count.
+ *
+ * SAFETY IS AN ALLOWLIST, not a denylist. A link can only be shortened if its
+ * kind is named in `GuestShortLinkKind` and its path matches that kind's shape.
+ * A denylist would have to anticipate every email the business will ever send;
+ * this way a link cannot be shortened unless somebody deliberately adds a kind
+ * for it, and `tsc` rejects anything else at the call site.
+ *
+ * FAILURE BEHAVIOUR: never throws, never blocks a send. On any failure the long
+ * URL is returned and the caller records the fallback somewhere durable. A
+ * shorter message is a nicety; a booking confirmation that never arrives is a
+ * lost booking.
+ */
+
+import { hashGuestToken } from '@/lib/guest/tokens'
+import { logger } from '@/lib/logger'
+import { isShortLinkHost } from '@/lib/short-links/routing'
+import { ShortLinkService } from '@/services/short-links'
+
+export type GuestShortLinkKind =
+  | 'guest_review'
+  | 'table_manage'
+  | 'table_payment'
+  | 'event_manage'
+  | 'event_payment'
+
+/**
+ * The only path shapes that may be shortened, one per kind. Verified against the
+ * minters: table-manage `src/lib/table-bookings/manage-booking.ts:286`,
+ * table-payment `src/lib/table-bookings/bookings.ts:663`, event-manage
+ * `src/lib/events/manage-booking.ts:652`, event-payment
+ * `src/lib/events/event-payments.ts:241`, review `src/app/r/[token]/route.ts`.
+ */
+const LINK_KIND_PATH: Record<GuestShortLinkKind, RegExp> = {
+  guest_review: /^\/r\/([^/]+)\/?$/,
+  table_manage: /^\/g\/([^/]+)\/table-manage\/?$/,
+  table_payment: /^\/g\/([^/]+)\/table-payment\/?$/,
+  event_manage: /^\/g\/([^/]+)\/manage-booking\/?$/,
+  event_payment: /^\/g\/([^/]+)\/event-payment\/?$/,
+}
+
+const LINK_KIND_ACTION_TYPE: Record<GuestShortLinkKind, string> = {
+  guest_review: 'review_redirect',
+  table_manage: 'manage',
+  table_payment: 'payment',
+  event_manage: 'manage',
+  event_payment: 'payment',
+}
+
+/**
+ * Kept per kind so the review links already live in production keep saying
+ * `guest_review_ask`. Relabelling them would split one kind of link across two
+ * sources in the same table.
+ */
+const LINK_KIND_SOURCE: Record<GuestShortLinkKind, string> = {
+  guest_review: 'guest_review_ask',
+  table_manage: 'guest_link_builder',
+  table_payment: 'guest_link_builder',
+  event_manage: 'guest_link_builder',
+  event_payment: 'guest_link_builder',
+}
+
+export interface GuestShortLinkInput {
+  /** The full long URL, exactly as the token minter returned it. */
+  longUrl: string
+  linkKind: GuestShortLinkKind
+  customerId: string
+  eventBookingId?: string | null
+  tableBookingId?: string | null
+}
+
+export interface GuestShortLinkResult {
+  /** The URL to put in front of the guest. Short when shortening worked. */
+  url: string
+  /** False when we fell back to the long URL. Record it, do not just log it. */
+  shortened: boolean
+}
+
+function refuse(
+  longUrl: string,
+  reasonCode: string,
+  input: GuestShortLinkInput,
+  error?: unknown
+): GuestShortLinkResult {
+  logger.warn('Sending the full-length guest link; it could not be shortened', {
+    ...(error ? { error: error instanceof Error ? error : new Error(String(error)) } : {}),
+    metadata: {
+      reason_code: reasonCode,
+      link_kind: input.linkKind,
+      customer_id: input.customerId,
+      event_booking_id: input.eventBookingId ?? null,
+      table_booking_id: input.tableBookingId ?? null,
+    },
+  })
+
+  return { url: longUrl, shortened: false }
+}
+
+export async function buildGuestShortLink(input: GuestShortLinkInput): Promise<GuestShortLinkResult> {
+  const longUrl = input.longUrl
+
+  let parsed: URL
+  try {
+    parsed = new URL(longUrl)
+  } catch {
+    return refuse(longUrl, 'unparseable_url', input)
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return refuse(longUrl, 'unsupported_protocol', input)
+  }
+
+  // Already short. Not a failure, and not worth a second row: return it as it is
+  // and report success so the caller does not count a fallback.
+  if (isShortLinkHost(parsed.hostname)) {
+    return { url: longUrl, shortened: true }
+  }
+
+  // A query string or fragment is refused outright. The redirector sets
+  // `short_code` on every destination, which re-serialises the whole query, and
+  // that mangles a placeholder such as Stripe's `{CHECKOUT_SESSION_ID}` into
+  // `%7BCHECKOUT_SESSION_ID%7D`, which Stripe substitutes by exact match.
+  if (parsed.search || parsed.hash) {
+    return refuse(longUrl, 'url_has_query_or_fragment', input)
+  }
+
+  const match = LINK_KIND_PATH[input.linkKind]?.exec(parsed.pathname)
+  if (!match) {
+    return refuse(longUrl, 'path_does_not_match_link_kind', input)
+  }
+
+  const rawToken = match[1]
+  if (!rawToken) {
+    return refuse(longUrl, 'no_token_in_path', input)
+  }
+
+  try {
+    const result = await ShortLinkService.createShortLinkInternal({
+      destination_url: longUrl,
+      // 'custom' is what all existing guest short links use and the CHECK
+      // constraint already allows it, so no migration. These rows stay out of the
+      // staff /short-links list because createShortLinkInternal leaves created_by
+      // NULL, which is exactly what getShortLinks filters on.
+      link_type: 'custom',
+      // No name: deriveShortLinkName already turns these paths into readable
+      // labels ('Table Manage', 'Event Payment', 'Review Link').
+      metadata: {
+        source: LINK_KIND_SOURCE[input.linkKind],
+        guest_link_kind: input.linkKind,
+        guest_action_type: LINK_KIND_ACTION_TYPE[input.linkKind],
+        // The hash, never the raw token: `authenticated` holds SELECT on
+        // short_links, and the raw token IS the credential.
+        guest_token_hash: hashGuestToken(rawToken),
+        customer_id: input.customerId,
+        event_booking_id: input.eventBookingId ?? null,
+        table_booking_id: input.tableBookingId ?? null,
+      },
+    })
+
+    if (!result?.full_url) {
+      return refuse(longUrl, 'short_link_returned_no_url', input)
+    }
+
+    return { url: result.full_url, shortened: true }
+  } catch (error) {
+    // Includes assertAllowedShortLinkDestination throwing on an off-allowlist
+    // host, which is a deliberate refusal rather than an outage.
+    return refuse(longUrl, 'short_link_creation_failed', input, error)
+  }
+}

--- a/src/lib/guest/review-short-link.ts
+++ b/src/lib/guest/review-short-link.ts
@@ -1,41 +1,24 @@
 /**
- * Builds the review-ask link a guest actually receives, shortened.
+ * The review-ask link a guest receives, shortened.
  *
- * The raw link is `${appBaseUrl}/r/${rawToken}` where the token is 32 random
- * bytes base64url, 43 characters on top of a 38-character origin. At 81
- * characters it is the longest thing in the message by a wide margin.
+ * This is a thin wrapper over `buildGuestShortLink` (src/lib/guest/guest-short-link.ts),
+ * which owns the shortening rules for every guest link kind. It stays as its own
+ * module because the review ask is the one caller that needs the `/r/` URL built
+ * for it from an app base and a raw token, rather than handed a URL a token
+ * minter already produced.
  *
- * Why this exists when `shortenUrlsInSmsBody` already shortens outbound SMS:
+ * Why the review ask is shortened at all, and why here rather than at send time:
+ * the table-booking review ask is email-first, and only `sendSMS` rewrites URLs
+ * (src/lib/twilio.ts). Before this, a guest with an email address got the full
+ * 81-character URL while a guest with only a mobile got a short one. Doing it
+ * once, up front, fixes the email and gives the email and the SMS fallback the
+ * same short code, so a click is counted once whichever channel the guest used.
  *
- * 1. **Email was never covered.** `sendSMS` rewrites URLs at send time
- *    (src/lib/twilio.ts), but `sendEmail` does not, and the table-booking
- *    review ask is email-first. So a guest with an email address received the
- *    full 81-character URL in the message body while a guest with only a mobile
- *    received a short one. Shortening here, at the point the link is built,
- *    fixes the email and covers both channels from one place.
- *
- * 2. **One link per guest, not one per channel.** Both the email and the SMS
- *    fallback now carry the same short code, so a click is one click no matter
- *    which channel the guest used.
- *
- * 3. **Metadata worth having.** The generic SMS shortener can only tag a link
- *    `source: 'sms_auto_shortener'`. Here we know the customer and the booking,
- *    so the row can say what it is and be traced back later.
- *
- * Double-shortening is not a risk: `shortenUrlsInSmsBody` skips any URL already
- * on a short-link host, so an SMS carrying the output of this module passes
- * through untouched.
- *
- * FAILURE BEHAVIOUR: never throws, and never blocks the send. If the short link
- * cannot be created the long URL is returned and the message still goes out
- * with a working link. A shorter message is a nicety; a review ask that never
- * arrives is a lost review. The failure is logged with the booking and customer
- * so it is visible in Vercel logs rather than silent.
+ * FAILURE BEHAVIOUR: never throws. On failure the long URL is returned and the
+ * caller counts the fallback into the cron's response.
  */
 
-import { hashGuestToken } from '@/lib/guest/tokens'
-import { logger } from '@/lib/logger'
-import { ShortLinkService } from '@/services/short-links'
+import { buildGuestShortLink } from '@/lib/guest/guest-short-link'
 
 export interface GuestReviewLinkInput {
   /** Origin of the management app, e.g. https://management.orangejelly.co.uk */
@@ -59,50 +42,11 @@ export function buildLongGuestReviewUrl(appBaseUrl: string, rawToken: string): s
 }
 
 export async function buildGuestReviewUrl(input: GuestReviewLinkInput): Promise<GuestReviewLinkResult> {
-  const longUrl = buildLongGuestReviewUrl(input.appBaseUrl, input.rawToken)
-
-  try {
-    const result = await ShortLinkService.createShortLinkInternal({
-      destination_url: longUrl,
-      // 'custom' is the only value in the short_links link_type CHECK constraint
-      // that fits a one-off guest link, so no migration is needed. The row is
-      // told apart from a staff-made link by metadata.guest_link_kind, and it
-      // stays out of the staff /short-links list because createShortLinkInternal
-      // leaves created_by NULL (see ShortLinkService.getShortLinks includeSystem).
-      link_type: 'custom',
-      // No explicit name: deriveShortLinkName already special-cases an `/r/` path
-      // and returns 'Review Link' (src/lib/short-links/names.ts). Review links
-      // shortened at SMS send time have carried that name for as long as the
-      // auto-shortener has existed, so naming these anything else would leave one
-      // kind of link with two names in the table.
-      metadata: {
-        source: 'guest_review_ask',
-        guest_link_kind: 'guest_review',
-        guest_action_type: 'review_redirect',
-        // The hash, never the raw token: this row is readable by every member of
-        // staff who can see short links, and the raw token IS the credential.
-        guest_token_hash: hashGuestToken(input.rawToken),
-        customer_id: input.customerId,
-        event_booking_id: input.eventBookingId ?? null,
-        table_booking_id: input.tableBookingId ?? null,
-      },
-    })
-
-    if (!result?.full_url) {
-      throw new Error('Short link service returned no URL')
-    }
-
-    return { url: result.full_url, shortened: true }
-  } catch (error) {
-    logger.warn('Failed to shorten guest review link; sending the full-length URL', {
-      error: error instanceof Error ? error : new Error(String(error)),
-      metadata: {
-        customerId: input.customerId,
-        eventBookingId: input.eventBookingId ?? null,
-        tableBookingId: input.tableBookingId ?? null,
-      },
-    })
-
-    return { url: longUrl, shortened: false }
-  }
+  return buildGuestShortLink({
+    longUrl: buildLongGuestReviewUrl(input.appBaseUrl, input.rawToken),
+    linkKind: 'guest_review',
+    customerId: input.customerId,
+    eventBookingId: input.eventBookingId ?? null,
+    tableBookingId: input.tableBookingId ?? null,
+  })
 }

--- a/src/lib/table-bookings/bookings.ts
+++ b/src/lib/table-bookings/bookings.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { fromZonedTime } from 'date-fns-tz'
 import { createGuestToken, hashGuestToken } from '@/lib/guest/tokens'
+import { buildGuestShortLink } from '@/lib/guest/guest-short-link'
 import { queueManagerReportEmail } from '@/lib/manager-report/queue'
 import { notifyCustomer } from '@/lib/notifications/notify'
 import { sendSMS } from '@/lib/twilio'
@@ -1000,6 +1001,10 @@ export async function sendTableBookingCreatedSmsIfAllowed(
   }).format(depositAmount)
   const supportPhone = process.env.NEXT_PUBLIC_CONTACT_PHONE_NUMBER || process.env.TWILIO_PHONE_NUMBER || undefined
   let manageLink: string | null = null
+  // True when a link went out at full length because shortening failed. Recorded on
+  // the audit row below rather than only logged, so a spell of silent failure is
+  // queryable instead of invisible.
+  let shortLinkFallback = false
 
   if (input.bookingResult.state === 'confirmed' && input.bookingResult.table_booking_id) {
     try {
@@ -1009,10 +1014,35 @@ export async function sendTableBookingCreatedSmsIfAllowed(
         bookingStartIso: input.bookingResult.start_datetime || null,
         appBaseUrl: process.env.NEXT_PUBLIC_APP_URL
       })
-      manageLink = token.url
+      // Shortened here rather than inside createTableManageToken: that URL is also
+      // handed back to API callers, so the caller's copy must stay long. Doing it
+      // once here covers both the email and the SMS below.
+      const shortened = await buildGuestShortLink({
+        longUrl: token.url,
+        linkKind: 'table_manage',
+        customerId: input.customerId,
+        tableBookingId: input.bookingResult.table_booking_id,
+      })
+      manageLink = shortened.url
+      if (!shortened.shortened) shortLinkFallback = true
     } catch {
       manageLink = null
     }
+  }
+
+  // input.nextStepUrl is the same string the API returns as next_step_url and
+  // fallback_payment_url, so only a local copy is shortened; the caller keeps the
+  // long one for its straight-to-payment redirect.
+  let paymentLink = input.nextStepUrl || null
+  if (paymentLink && input.bookingResult.table_booking_id) {
+    const shortenedPayment = await buildGuestShortLink({
+      longUrl: paymentLink,
+      linkKind: 'table_payment',
+      customerId: input.customerId,
+      tableBookingId: input.bookingResult.table_booking_id,
+    })
+    paymentLink = shortenedPayment.url
+    if (!shortenedPayment.shortened) shortLinkFallback = true
   }
 
   // Render the server-GRANTED chair count (never the requested value) and outside-safe wording.
@@ -1028,7 +1058,7 @@ export async function sendTableBookingCreatedSmsIfAllowed(
       : isOutside ? 'deposit' : 'table deposit'
     const secureNoun = isOutside ? 'outside booking' : 'table'
     const base = `The Anchor: Hi ${firstName}, please pay your ${depositKindLabel} of ${depositLabel} (${partySize} x GBP ${DEPOSIT_PER_PERSON_GBP}) to secure your ${secureNoun} for ${partySize} ${seatWord} on ${bookingMoment}.`
-    const cta = input.nextStepUrl ? `Pay now: ${input.nextStepUrl}` : 'We will text your payment link shortly.'
+    const cta = paymentLink ? `Pay now: ${paymentLink}` : 'We will text your payment link shortly.'
     smsBody = `${base}${highChairSuffix}${outsideSuffix} ${cta}`
   } else {
     const bookingNoun = isOutside ? 'outside booking' : 'table booking'
@@ -1066,7 +1096,7 @@ export async function sendTableBookingCreatedSmsIfAllowed(
     bookingReference: input.bookingResult.booking_reference || null,
     state: input.bookingResult.state,
     manageLink,
-    paymentLink: input.nextStepUrl || null,
+    paymentLink,
     depositLabel,
     christmasCourseSummary,
     highChairCount: grantedHighChairs,
@@ -1183,6 +1213,7 @@ export async function sendTableBookingCreatedSmsIfAllowed(
       selected_channels: notificationResult.selectedChannels,
       email_sent: emailDeliveredOrUnknown,
       sms_sent: smsDeliveredOrUnknown,
+      short_link_fallback: shortLinkFallback,
     },
   })
 
@@ -1680,6 +1711,7 @@ export async function sendTableBookingRescheduledNotificationIfAllowed(
     const bookingNoun = isOutside ? 'outside booking' : 'table booking'
 
     let manageLink: string | null = null
+    let shortLinkFallback = false
     try {
       const token = await createTableManageToken(supabase, {
         customerId: customer.id,
@@ -1687,7 +1719,14 @@ export async function sendTableBookingRescheduledNotificationIfAllowed(
         bookingStartIso: booking.start_datetime || null,
         appBaseUrl: process.env.NEXT_PUBLIC_APP_URL,
       })
-      manageLink = token.url
+      const shortened = await buildGuestShortLink({
+        longUrl: token.url,
+        linkKind: 'table_manage',
+        customerId: customer.id,
+        tableBookingId: booking.id,
+      })
+      manageLink = shortened.url
+      shortLinkFallback = !shortened.shortened
     } catch {
       manageLink = null
     }
@@ -1787,6 +1826,7 @@ export async function sendTableBookingRescheduledNotificationIfAllowed(
         booking_reference: booking.booking_reference,
         selected_channels: notificationResult.selectedChannels,
         sms_code: smsCode,
+        short_link_fallback: shortLinkFallback,
       },
     })
   } catch (error) {

--- a/tests/lib/eventPaymentConfirmationEmail.test.ts
+++ b/tests/lib/eventPaymentConfirmationEmail.test.ts
@@ -16,6 +16,18 @@ const { warn } = vi.hoisted(() => ({
   warn: vi.fn(),
 }))
 
+// Without this the guest manage link is shortened for real, createShortLinkInternal
+// throws on the test's Supabase stub, and the fail-open helper hands back the long
+// URL. Every assertion below would still pass while proving nothing about what the
+// guest receives.
+const createShortLinkInternalMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/short-links', () => ({
+  ShortLinkService: {
+    createShortLinkInternal: createShortLinkInternalMock,
+  },
+}))
+
 vi.mock('@/lib/logger', () => ({
   logger: {
     warn,
@@ -96,6 +108,11 @@ describe('event payment confirmation email', () => {
       success: true,
       messageId: 'email-1',
     })
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'mng123',
+      full_url: 'https://l.the-anchor.pub/mng123',
+      already_exists: false,
+    })
   })
 
   it('sends a customer confirmation email after payment', async () => {
@@ -130,6 +147,14 @@ describe('event payment confirmation email', () => {
     }))
     expect((sendEmail as unknown as vi.Mock).mock.calls[0][0].text).toContain('We have received your £10.00 payment')
     expect((sendEmail as unknown as vi.Mock).mock.calls[0][0].html).toContain('Manage booking')
+
+    // The guest gets the short link, and no trace of the long token URL.
+    const sent = (sendEmail as unknown as vi.Mock).mock.calls[0][0]
+    expect(sent.html).toContain('https://l.the-anchor.pub/mng123')
+    expect(sent.text).toContain('https://l.the-anchor.pub/mng123')
+    expect(sent.html).not.toContain('/g/manage-token/manage-booking')
+    expect(sent.text).not.toContain('/g/manage-token/manage-booking')
+    expect(sent.metadata.short_link_fallback).toBe(false)
   })
 
   it('skips when a successful confirmation email already exists', async () => {

--- a/tests/lib/guestReviewShortLink.test.ts
+++ b/tests/lib/guestReviewShortLink.test.ts
@@ -107,9 +107,11 @@ describe('buildGuestReviewUrl', () => {
     expect(result).toEqual({ url: LONG_URL, shortened: false })
     expect(loggerWarnMock).toHaveBeenCalledTimes(1)
     expect(loggerWarnMock.mock.calls[0][1].metadata).toEqual({
-      customerId: 'customer-1',
-      eventBookingId: null,
-      tableBookingId: 'table-booking-1',
+      reason_code: 'short_link_creation_failed',
+      link_kind: 'guest_review',
+      customer_id: 'customer-1',
+      event_booking_id: null,
+      table_booking_id: 'table-booking-1',
     })
   })
 

--- a/tests/lib/guestShortLink.test.ts
+++ b/tests/lib/guestShortLink.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { hashGuestToken } from '@/lib/guest/tokens'
+
+const createShortLinkInternalMock = vi.hoisted(() => vi.fn())
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/short-links', () => ({
+  ShortLinkService: {
+    createShortLinkInternal: createShortLinkInternalMock,
+  },
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    warn: loggerWarnMock,
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}))
+
+import { buildGuestShortLink } from '@/lib/guest/guest-short-link'
+
+const BASE = 'https://management.orangejelly.co.uk'
+const SHORT = 'https://l.the-anchor.pub/abc123'
+
+function ok() {
+  createShortLinkInternalMock.mockResolvedValue({
+    short_code: 'abc123',
+    full_url: SHORT,
+    already_exists: false,
+  })
+}
+
+describe('buildGuestShortLink: the kinds it accepts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ok()
+  })
+
+  const CASES = [
+    ['guest_review', `${BASE}/r/tok`],
+    ['table_manage', `${BASE}/g/tok/table-manage`],
+    ['table_payment', `${BASE}/g/tok/table-payment`],
+    ['event_manage', `${BASE}/g/tok/manage-booking`],
+    ['event_payment', `${BASE}/g/tok/event-payment`],
+  ] as const
+
+  it.each(CASES)('shortens a %s link', async (linkKind, longUrl) => {
+    const result = await buildGuestShortLink({ longUrl, linkKind, customerId: 'c1' })
+
+    expect(result).toEqual({ url: SHORT, shortened: true })
+    expect(createShortLinkInternalMock).toHaveBeenCalledTimes(1)
+    const [payload] = createShortLinkInternalMock.mock.calls[0]
+    expect(payload.metadata.guest_link_kind).toBe(linkKind)
+    expect(payload.metadata.guest_token_hash).toBe(hashGuestToken('tok'))
+    expect(JSON.stringify(payload.metadata)).not.toContain('"tok"')
+  })
+})
+
+/**
+ * The allowlist is the safety mechanism: a link can only be shortened if its kind
+ * is declared AND its path matches that kind's shape. These are the cases that
+ * must never reach the short-link service.
+ */
+describe('buildGuestShortLink: what it refuses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ok()
+  })
+
+  async function expectRefused(input: Parameters<typeof buildGuestShortLink>[0], reasonCode: string) {
+    const result = await buildGuestShortLink(input)
+    expect(result).toEqual({ url: input.longUrl, shortened: false })
+    expect(createShortLinkInternalMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock.mock.calls[0][1].metadata.reason_code).toBe(reasonCode)
+  }
+
+  // The redirector re-serialises the query on every hop, turning Stripe's
+  // {CHECKOUT_SESSION_ID} into %7BCHECKOUT_SESSION_ID%7D, which Stripe then fails
+  // to substitute because it matches by exact string.
+  it('refuses a URL carrying a query string, including the Stripe placeholder', async () => {
+    await expectRefused({
+      longUrl: `${BASE}/g/tok/table-payment?state=success&session_id={CHECKOUT_SESSION_ID}`,
+      linkKind: 'table_payment',
+      customerId: 'c1',
+    }, 'url_has_query_or_fragment')
+  })
+
+  it('refuses a URL carrying a fragment', async () => {
+    await expectRefused({
+      longUrl: `${BASE}/g/tok/table-manage#food`,
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'url_has_query_or_fragment')
+  })
+
+  // The case that matters most: an unsubscribe link must never end up behind a
+  // short code a manager could delete, and must never disagree with the
+  // List-Unsubscribe header.
+  it('refuses an unsubscribe URL smuggled in under a valid kind', async () => {
+    await expectRefused({
+      longUrl: `${BASE}/api/unsubscribe`,
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'path_does_not_match_link_kind')
+  })
+
+  it('refuses a staff route smuggled in under a valid kind', async () => {
+    await expectRefused({
+      longUrl: `${BASE}/table-bookings/tb-1`,
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'path_does_not_match_link_kind')
+  })
+
+  it('refuses a link whose path belongs to a different kind', async () => {
+    await expectRefused({
+      longUrl: `${BASE}/g/tok/table-payment`,
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'path_does_not_match_link_kind')
+  })
+
+  it('refuses a mailto link', async () => {
+    await expectRefused({
+      longUrl: 'mailto:manager@the-anchor.pub',
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'unsupported_protocol')
+  })
+
+  it('refuses an unparseable URL', async () => {
+    await expectRefused({
+      longUrl: 'not a url',
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    }, 'unparseable_url')
+  })
+})
+
+describe('buildGuestShortLink: already short, and failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ok()
+  })
+
+  // Guards against a second row per guest if a shortened URL is ever passed back
+  // through, e.g. by a caller that shortens and then hands the result on.
+  it('passes an already-short URL through without minting a second row', async () => {
+    const result = await buildGuestShortLink({
+      longUrl: SHORT,
+      linkKind: 'table_manage',
+      customerId: 'c1',
+    })
+
+    expect(result).toEqual({ url: SHORT, shortened: true })
+    expect(createShortLinkInternalMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the long URL when the short link service rejects', async () => {
+    createShortLinkInternalMock.mockRejectedValue(new Error('boom'))
+    const longUrl = `${BASE}/g/tok/table-manage`
+
+    const result = await buildGuestShortLink({ longUrl, linkKind: 'table_manage', customerId: 'c1' })
+
+    expect(result).toEqual({ url: longUrl, shortened: false })
+    expect(loggerWarnMock.mock.calls[0][1].metadata.reason_code).toBe('short_link_creation_failed')
+  })
+
+  // assertAllowedShortLinkDestination throws rather than returning, so an
+  // off-allowlist host must be caught, not propagated into a send path.
+  it('falls back when the destination host is not allowlisted', async () => {
+    createShortLinkInternalMock.mockImplementation(() => {
+      throw new Error('Short links can only point to approved Anchor or Orange Jelly domains')
+    })
+    const longUrl = 'https://evil.example.com/g/tok/table-manage'
+
+    const result = await buildGuestShortLink({ longUrl, linkKind: 'table_manage', customerId: 'c1' })
+
+    expect(result).toEqual({ url: longUrl, shortened: false })
+  })
+
+  it('falls back when the short link service returns no URL', async () => {
+    createShortLinkInternalMock.mockResolvedValue({ short_code: 'abc123', full_url: '' })
+    const longUrl = `${BASE}/g/tok/event-payment`
+
+    const result = await buildGuestShortLink({ longUrl, linkKind: 'event_payment', customerId: 'c1' })
+
+    expect(result).toEqual({ url: longUrl, shortened: false })
+    expect(loggerWarnMock.mock.calls[0][1].metadata.reason_code).toBe('short_link_returned_no_url')
+  })
+})

--- a/tests/lib/tableBookingConfirmationShortLink.test.ts
+++ b/tests/lib/tableBookingConfirmationShortLink.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+/**
+ * The booking confirmation is the highest-volume guest email the pub sends, and
+ * every stored one in the 90 days to 2026-09-07 carried a raw ~80-character
+ * `/g/<token>/table-manage` URL. The SMS on the same path was already short,
+ * because only `sendSMS` rewrites URLs at send time.
+ *
+ * These tests assert on what `notifyCustomer` is actually handed: the SMS body
+ * and both email parts must carry the short link and no token URL at all.
+ *
+ * NOTE the base URL below is management.orangejelly.co.uk, not example.test. The
+ * short-link destination allowlist rejects anything else by throwing, and the
+ * helper fails open, so an off-allowlist fixture would quietly exercise the
+ * fallback and assert nothing.
+ */
+
+const notifyCustomerMock = vi.fn()
+
+vi.mock('@/lib/notifications/notify', () => ({
+  notifyCustomer: (input: unknown) => notifyCustomerMock(input),
+}))
+
+vi.mock('@/lib/email/emailService', () => ({
+  sendEmail: vi.fn(async () => ({ success: true })),
+}))
+
+vi.mock('@/lib/twilio', () => ({
+  sendSMS: vi.fn(async () => ({ success: true, code: null, logFailure: false })),
+}))
+
+vi.mock('@/lib/table-bookings/manage-booking', () => ({
+  createTableManageToken: vi.fn(async () => ({
+    rawToken: 'raw-manage-token',
+    url: 'https://management.orangejelly.co.uk/g/raw-manage-token/table-manage',
+    expiresAt: '2026-07-10T00:00:00.000Z',
+  })),
+}))
+
+const logAuditEventMock = vi.hoisted(() => vi.fn(async () => undefined))
+
+vi.mock('@/services/audit', () => ({
+  AuditService: { logAuditEvent: logAuditEventMock },
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminClient: vi.fn(() => ({ from: vi.fn() })),
+}))
+
+const createShortLinkInternalMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/services/short-links', () => ({
+  ShortLinkService: {
+    createShortLinkInternal: createShortLinkInternalMock,
+  },
+}))
+
+import { sendTableBookingCreatedSmsIfAllowed, type TableBookingRpcResult } from '@/lib/table-bookings/bookings'
+
+const SHORT_URL = 'https://l.the-anchor.pub/tbm123'
+const LONG_MANAGE_URL = 'https://management.orangejelly.co.uk/g/raw-manage-token/table-manage'
+const LONG_PAYMENT_URL = 'https://management.orangejelly.co.uk/g/raw-pay-token/table-payment'
+
+function customerClient() {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(async () => ({
+            data: {
+              id: 'cust-1',
+              first_name: 'Sam',
+              last_name: 'Jones',
+              mobile_e164: '+447700900123',
+              mobile_number: '+447700900123',
+              email: 'sam@example.test',
+              sms_status: 'active',
+              sms_opt_in: true,
+              marketing_sms_opt_in: true,
+              email_status: 'active',
+              email_deactivated_at: null,
+              marketing_email_opt_in: true,
+            },
+            error: null,
+          })),
+        })),
+      })),
+    })),
+  }
+}
+
+function confirmedResult(partial: Partial<TableBookingRpcResult> = {}): TableBookingRpcResult {
+  return {
+    state: 'confirmed',
+    table_booking_id: 'tb-1',
+    booking_reference: 'TB-0001',
+    party_size: 4,
+    start_datetime: '2026-07-10T18:00:00.000Z',
+    high_chair_count: 0,
+    is_outside_seating: false,
+    ...partial,
+  } as TableBookingRpcResult
+}
+
+function captured() {
+  const arg = notifyCustomerMock.mock.calls[0]?.[0] as
+    | { sms?: { body?: string }; email?: { html?: string; text?: string } }
+    | undefined
+  return {
+    sms: arg?.sms?.body ?? '',
+    html: arg?.email?.html ?? '',
+    text: arg?.email?.text ?? '',
+  }
+}
+
+function auditInfo() {
+  return logAuditEventMock.mock.calls[0]?.[0]?.additional_info as Record<string, unknown> | undefined
+}
+
+describe('table booking confirmation: guest link shortening', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    notifyCustomerMock.mockResolvedValue({ selectedChannels: ['email'], attempts: [] })
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'tbm123',
+      full_url: SHORT_URL,
+      already_exists: false,
+    })
+  })
+
+  it('puts the shortened manage link in the email and the SMS, with no token URL left', async () => {
+    await sendTableBookingCreatedSmsIfAllowed(customerClient() as any, {
+      customerId: 'cust-1',
+      normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult(),
+    })
+
+    const out = captured()
+    expect(out.html).toContain(SHORT_URL)
+    expect(out.text).toContain(SHORT_URL)
+    expect(out.sms).toContain(SHORT_URL)
+
+    for (const part of [out.html, out.text, out.sms]) {
+      expect(part).not.toContain(LONG_MANAGE_URL)
+      expect(part).not.toContain('/g/raw-manage-token/')
+    }
+  })
+
+  it('shortens once and tags the row with the booking it belongs to', async () => {
+    await sendTableBookingCreatedSmsIfAllowed(customerClient() as any, {
+      customerId: 'cust-1',
+      normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult(),
+    })
+
+    expect(createShortLinkInternalMock).toHaveBeenCalledTimes(1)
+    const [payload] = createShortLinkInternalMock.mock.calls[0]
+    expect(payload.destination_url).toBe(LONG_MANAGE_URL)
+    expect(payload.link_type).toBe('custom')
+    expect(payload.metadata.guest_link_kind).toBe('table_manage')
+    expect(payload.metadata.table_booking_id).toBe('tb-1')
+    expect(payload.metadata.customer_id).toBe('cust-1')
+    // An expiry would send a late tapper to the pub homepage rather than a page
+    // that explains itself, so the row must not carry one.
+    expect(payload.expires_at).toBeUndefined()
+    // The raw token is the credential and staff can read short_links.
+    expect(JSON.stringify(payload.metadata)).not.toContain('raw-manage-token')
+  })
+
+  it('records short_link_fallback false on the audit row when shortening worked', async () => {
+    await sendTableBookingCreatedSmsIfAllowed(customerClient() as any, {
+      customerId: 'cust-1',
+      normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult(),
+    })
+
+    expect(auditInfo()?.short_link_fallback).toBe(false)
+  })
+
+  // A confirmation that never arrives is a lost booking. The character saving is
+  // worth far less than the message, so shortening must fail open.
+  it('still sends the confirmation with the long link when shortening fails', async () => {
+    createShortLinkInternalMock.mockRejectedValue(new Error('short link service down'))
+
+    await sendTableBookingCreatedSmsIfAllowed(customerClient() as any, {
+      customerId: 'cust-1',
+      normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult(),
+    })
+
+    const out = captured()
+    expect(out.html).toContain(LONG_MANAGE_URL)
+    expect(out.text).toContain(LONG_MANAGE_URL)
+    expect(out.sms).toContain(LONG_MANAGE_URL)
+    // and the failure is durably recorded, not just logged
+    expect(auditInfo()?.short_link_fallback).toBe(true)
+  })
+
+  it('shortens the deposit payment link on the pending_payment path', async () => {
+    createShortLinkInternalMock.mockResolvedValue({
+      short_code: 'pay123',
+      full_url: 'https://l.the-anchor.pub/pay123',
+      already_exists: false,
+    })
+
+    await sendTableBookingCreatedSmsIfAllowed(customerClient() as any, {
+      customerId: 'cust-1',
+      normalizedPhone: '+447700900123',
+      bookingResult: confirmedResult({ state: 'pending_payment' }),
+      nextStepUrl: LONG_PAYMENT_URL,
+    } as any)
+
+    const [payload] = createShortLinkInternalMock.mock.calls[0]
+    expect(payload.destination_url).toBe(LONG_PAYMENT_URL)
+    expect(payload.metadata.guest_link_kind).toBe('table_payment')
+
+    const out = captured()
+    expect(out.sms).toContain('https://l.the-anchor.pub/pay123')
+    expect(out.sms).not.toContain('/g/raw-pay-token/')
+    expect(out.html).not.toContain('/g/raw-pay-token/')
+  })
+})


### PR DESCRIPTION
Follow-on from #133, same defect and a wider surface.

## What

`sendSMS` rewrites every URL at send time (`src/lib/twilio.ts:451`). `sendEmail`
does not. So every guest email carrying a token link shipped the raw
~80-character URL. Production, last 90 days: **every stored
`table_booking_confirmed` email carried one**, plus
`event_payment_confirmation`, `table_booking_rescheduled` and
`event_payment_link`.

## How

Generalises the review helper from #133 into `src/lib/guest/guest-short-link.ts`,
with `review-short-link.ts` reduced to a thin wrapper, so there is one
implementation rather than two.

Shortening happens where the message is composed. Deliberately **not** in two
tempting places:

- **Not in `sendEmail`.** It would also rewrite unsubscribe links (leaving the
  body disagreeing with the `List-Unsubscribe` header), PayPal approve URLs (off
  the destination allowlist, which *throws*), marketing links that already carry
  per-recipient tracking, and the cron alert email that fires when the system is
  unhealthy. It would also need an HTML-aware parser, since the SMS shortener's
  bare-URL regex eats `"` and `>` out of an anchor tag.
- **Not in the token minters.** `createTableManageToken`,
  `createTablePaymentToken`, `createEventManageToken` and
  `createEventPaymentToken` each return a URL that is *also* handed back to API
  callers as `next_step_url` / `fallback_payment_url`, which the website uses to
  send a booker straight to payment. Shortening there would put a redirect hop
  and a bogus click in front of every website booking.

Composing-site shortening also means the email and the SMS for one booking carry
the same destination, and `createShortLinkInternal` dedupes on
`destination_url`, so both channels resolve to one short code and one click count.

## Safety: an allowlist, not a denylist

A link is shortened only if its kind is declared in `GuestShortLinkKind` **and**
its path matches that kind's shape. Anything else returns the long URL with a
`reason_code`. Query strings and fragments are refused outright, because the
redirector re-serialises the query on every hop and would turn Stripe's
`{CHECKOUT_SESSION_ID}` into `%7BCHECKOUT_SESSION_ID%7D`, which Stripe
substitutes by exact string match.

Pinned by 16 tests, including an unsubscribe URL and a staff route smuggled in
under a valid kind, and the Stripe placeholder.

## Fail open, but visibly

A confirmation that never arrives is a lost booking, so a shortening failure
returns the long URL. The fallback is recorded **durably**, not just logged:
`short_link_fallback` on the audit row for the table paths, on
`email_messages.metadata` for the event paths, and `shortLinkFallbacks` in the
cron response for the pre-order chase. One query covers the lot:

```sql
select comm_type,
       count(*) filter (where metadata->>'short_link_fallback' = 'true') as fallbacks,
       count(*) as total
from email_messages where created_at > now() - interval '7 days' group by 1;
```

## Assumptions, checked against production

- `link_type 'custom'`, `created_by` NULL and no expiry match the 1,435 guest
  short links already live, so **no migration**, and the rows stay hidden from
  the staff `/short-links` list.
- Volume: roughly 90 new rows a month against 2,727 existing. No expiry is
  deliberate, so a late tap still works.

## Two tests were passing while proving nothing

`tests/lib/eventPaymentConfirmationEmail.test.ts` and the highchair fixtures used
off-allowlist or unmocked short-link paths, so after this change they would have
gone green via the fail-open branch. Both now mock `ShortLinkService` and assert
the guest actually receives the short link.

## Verification

lint clean, `tsc --noEmit` clean, **763 files / 6865 tests** green in both
Europe/London and UTC, production build compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)