### PR TITLE
test(messages): fix the race behind the flaky role="log" assertion

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -210,3 +210,21 @@ wording distinction; verify it with the owner or an operational source first.
 ## 5 September 2026: dated event capacities
 
 Use the owner-confirmed dated capacities: 60 for the reviewed events, Halloween 150 and Tasting Night 25. Report-level genre examples are not live sellable-capacity instructions. Check the actual booking snapshot before reporting a configured limit.
+
+## 7 September 2026: a click that races an auto-selection effect looks like a slow CI runner
+
+**Mistake:** `MessagesClientResponsive.test.tsx` clicked a conversation row as soon
+as `findByRole('option')` resolved. On a loaded GitHub runner the click landed
+before React had flushed the pending passive effect that auto-selects the first
+unread row, so the synchronous router mock recorded `push(customer-2)` and then
+`replace(customer-1)`. Selection ended back on the customer whose response the test
+holds open, the `role="log"` pane never rendered, and the failure read as
+`Unable to find role="log"`, which looks like a timeout rather than a race.
+
+**Rule:** In these component tests, wait for the component's own auto-selection to
+land (for example `waitFor(() => expect(loader).toHaveBeenCalledWith(id, undefined))`)
+before firing a click that changes that selection. Getting there by raising a
+`waitFor` timeout hides the race and leaves the test asserting nothing. Anchor any
+assertion about an async pane with `findBy*`, never a bare `getBy*` after an await,
+and scope a "this control is absent" assertion inside the container that has to be
+open, or it passes because the container had not rendered yet.

--- a/tests/components/MessagesClientResponsive.test.tsx
+++ b/tests/components/MessagesClientResponsive.test.tsx
@@ -219,7 +219,12 @@ describe('MessagesClient, read state', () => {
     render(<MessagesClient />)
 
     fireEvent.click(await screen.findByRole('button', { name: 'Conversation actions' }))
-    expect(screen.queryByText(/Mark whole conversation unread/i)).not.toBeInTheDocument()
+    // Wait for the open menu first, and scope the absence to it. Asserting on
+    // the whole document before the menu has opened passes for the wrong
+    // reason, and would keep passing if the item came back.
+    const menu = await screen.findByRole('menu')
+    expect(within(menu).getByText('View full profile')).toBeInTheDocument()
+    expect(within(menu).queryByText(/Mark whole conversation unread/i)).not.toBeInTheDocument()
   })
 
   it('says that mark unread affects the whole conversation', async () => {
@@ -260,20 +265,30 @@ describe('MessagesClient, stale responses', () => {
     })
 
     render(<MessagesClient />)
+
+    // Let the auto-selection land before switching. Customer 1 is the first
+    // unread row, so the component selects it and opens the held-open request.
+    // Clicking sooner races that effect: it replaces the URL back to customer 1
+    // after the click has pushed customer 2, the thread pane never opens, and
+    // there is no stale response to discard either.
+    await waitFor(() =>
+      expect(getConversationMessages).toHaveBeenCalledWith('customer-1', undefined),
+    )
+
     fireEvent.click(await screen.findByRole('option', { name: /Sam Patel/i }))
 
-    await waitFor(() => {
-      expect(screen.getByRole('log').getAttribute('aria-label')).toContain('Sam Patel')
-    })
+    // The pane only exists once the newly selected conversation has loaded, so
+    // wait for it rather than querying for it straight away.
+    const thread = await screen.findByRole('log')
+    expect(thread.getAttribute('aria-label')).toContain('Sam Patel')
 
     // Now let customer 1's stale response land. It must be discarded.
     releaseSlow?.()
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    await waitFor(() => {
-      expect(screen.getByRole('log').getAttribute('aria-label')).toContain('Sam Patel')
-    })
-    expect(screen.getByRole('log').getAttribute('aria-label')).not.toContain('Jane')
+    const settled = await screen.findByRole('log')
+    expect(settled.getAttribute('aria-label')).toContain('Sam Patel')
+    expect(settled.getAttribute('aria-label')).not.toContain('Jane')
   })
 })
 


### PR DESCRIPTION
## Why

`build-and-lint` failed once on PR #134 with:

```
TestingLibraryElementError: Unable to find role="log"
  tests/components/MessagesClientResponsive.test.tsx > MessagesClient, stale responses
  > never renders one customer under another customer name
```

It passed on re-run with no code change, and the failure was unrelated to that
PR (`MessagesClient` imports none of its modules). Left alone it will keep
blocking unrelated merges.

## Root cause, not a timeout

The test clicked a conversation row as soon as `findByRole('option')` resolved.
On a loaded runner the click landed **before** React flushed the pending passive
effect that auto-selects the first unread row, so the router mock recorded
`push(customer-2)` then `replace(customer-1)`. Selection ended back on the
customer whose response the test deliberately holds open, the `role="log"` pane
never rendered, and the failure surfaced as a missing element rather than as the
race it was.

The fix waits for the component's own auto-selection to land before firing the
click that changes it. Raising a `waitFor` timeout would have hidden the race and
left the test asserting nothing.

## It strengthens the assertions, it does not soften them

- The stale-response test still asserts the thing that matters, that one
  customer's messages never render under another customer's name
  (`not.toContain('Jane')`). That assertion is preserved exactly.
- Bare `getByRole` after an await is replaced with `findByRole`, so an async pane
  is awaited rather than queried optimistically.
- A separate test in the same file was **passing for the wrong reason**: it
  asserted "Mark whole conversation unread" was absent from the whole document,
  which was true simply because the menu had not opened yet. It now waits for the
  menu, proves it is open (`View full profile` is present), and scopes the
  absence to it. That test would previously have kept passing if the item came
  back.

## Verification

Applied to a clean checkout of `main` and run independently of the authoring
session: the target file passes 5 consecutive runs under `TZ=UTC`, and the full
suite is green in **both** timezones (763 files / 6865 tests, `npm test` and
`npm run test:utc`).

The lesson is recorded in `tasks/lessons.md` per the repo convention.

Authored by a separate session spun off from the #134 review; pushed and raised
from here so it reaches CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)